### PR TITLE
Fix positioning of MapStore Print dialog inside map/layer preview

### DIFF
--- a/geonode_mapstore_client/client/themes/default/less/geonode.less
+++ b/geonode_mapstore_client/client/themes/default/less/geonode.less
@@ -52,3 +52,22 @@
     width: 100%;
     height: ~"calc(100% - 52px)";
 }
+.print-map-preview #print_preview {
+    margin: auto;
+}
+
+@media (max-width: 991px) {
+    #mapstore-print-panel.modal-dialog,
+    #measure-dialog,
+    #mapstore-about {
+        width: 700px;
+    }
+}
+
+@media (max-width: 767px) {
+    #mapstore-print-panel.modal-dialog,
+    #measure-dialog,
+    #mapstore-about {
+        width: 98%;
+    }
+}

--- a/geonode_mapstore_client/client/themes/default/less/geonode.less
+++ b/geonode_mapstore_client/client/themes/default/less/geonode.less
@@ -38,3 +38,17 @@
 .timeline-plugin {
     position: fixed !important;
 }
+#mapstore-print-panel.modal-dialog,
+#measure-dialog,
+#mapstore-about {
+    height: 400px;
+    width: 800px;
+    position: absolute;
+}
+#mapstore-print-panel .modal-body {
+    max-height: ~"calc(100vh - 190px)";
+    overflow-y: auto;
+    position: relative;
+    width: 100%;
+    height: ~"calc(100% - 52px)";
+}

--- a/geonode_mapstore_client/client/themes/preview/less/geonode.less
+++ b/geonode_mapstore_client/client/themes/preview/less/geonode.less
@@ -62,7 +62,7 @@
     max-height: 190px;
 }
 @geo-bottom-tools-position: absolute;
-
+/* override the inline values of print dialog */
 #mapstore-print-panel.modal-dialog {
     left: 0 !important;
     top: 0 !important;

--- a/geonode_mapstore_client/client/themes/preview/less/geonode.less
+++ b/geonode_mapstore_client/client/themes/preview/less/geonode.less
@@ -62,3 +62,9 @@
     max-height: 190px;
 }
 @geo-bottom-tools-position: absolute;
+
+#mapstore-print-panel.modal-dialog {
+    left: 0 !important;
+    top: 0 !important;
+    transform: none !important;
+}

--- a/geonode_mapstore_client/client/themes/preview/less/geonode.less
+++ b/geonode_mapstore_client/client/themes/preview/less/geonode.less
@@ -67,4 +67,6 @@
     left: 0 !important;
     top: 0 !important;
     transform: none !important;
+    height: 400px;
+    width: 100%;
 }

--- a/geonode_mapstore_client/static/geonode/js/ms2/utils/ms2_base_plugins.js
+++ b/geonode_mapstore_client/static/geonode/js/ms2/utils/ms2_base_plugins.js
@@ -97,7 +97,8 @@ var MS2_BASE_PLUGINS = {
 		{
 			"name": "Print",
 			"cfg": {
-				"useFixedScales": true
+				"useFixedScales": true,
+				"mapWidth": 256
 			}
 		},
 		{

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/base_ms.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/base_ms.html
@@ -106,18 +106,6 @@
         70% {opacity: .75}
         100%{opacity: 0}
     }
-    .msgapi #mapstore-print-panel.modal-dialog, #measure-dialog, #mapstore-about {
-        height: 400px;
-        width: 800px;
-        position: absolute;
-    }
-    .msgapi #mapstore-print-panel .modal-body {
-        max-height: calc(100vh - 190px);
-        overflow-y: auto;
-        position: relative;
-        width: 100%;
-        height: calc(100% - 52px);
-    }
 </style>
 {% block style %}{% endblock %}
 


### PR DESCRIPTION
This PR fixes the position of print dialog in the map and layer preview pages