### PR TITLE
Introduce the support for local development with remote host

### DIFF
--- a/geonode_mapstore_client/client/package.json
+++ b/geonode_mapstore_client/client/package.json
@@ -260,12 +260,12 @@
     "ag-grid-community": "20.2.0",
     "connected-react-router": "6.3.2",
     "istanbul-instrumenter-loader": "3.0.1",
-    "react-checkbox-tree": "^1.5.1",
+    "react-checkbox-tree": "1.5.1",
     "react-contenteditable": "3.3.2",
     "react-dnd-test-backend": "2.6.0",
     "react-error-boundary": "1.2.5",
     "react-grid-layout": "0.16.6",
-    "react-horizontal-scrolling-menu": "^0.7.3",
+    "react-horizontal-scrolling-menu": "0.7.3",
     "react-resize-detector": "4.2.1"
   }
 }


### PR DESCRIPTION
This PR changes the local environment to develop without a local instance of GeoNode but instead to take advantage of an external dev instance using the webpack devServer proxy.

Here some other suggestions to improve the dev environment (these probably need further investigation):
- if possible avoid absolute urls in the `defaultConfig`
```js
// eg:
// current
proxy: "http://my-geonode.org/proxy/?url="
// expected
proxy: "/proxy/?url="
```
- centralize all the injected variable of the template in a single object (currently they are injected in different part of the `initMapStore2API` script)
```js
// eg
window.geonode_config = {
  geoserver: "{{ OGC_SERVER.default.PUBLIC_LOCATION|default:"" }}",
  token: "{{ ACCESS_TOKEN }}",
  locale: "{{ LANGUAGE_CODE }}"
  ...
};
```
- externalize all `initMapStore2API` scripts in js files so we will be easier to override the script request from the local environment  (similar to plugins config)
```html
<!-- expected in template -->
<script src="/static/path-to-init-files/ms2-init.js"></script>

```

```js
// /static/path-to-init-files/ms2-init.js

document.addEventListener('DOMContentLoaded', function () {
  const userDetails = {
    "User":  window.geonode_config.user,
    "access_token": window.geonode_config.accessToken
  };
  window.initMapstore2Api('edit', function(MapStore2, options) {
    const MS2_BASE_PLUGINS = window.MS2_BASE_PLUGINS;
    const MS2_MAP_PLUGINS = window.MS2_MAP_PLUGINS ;
    const MS2_EDIT_PLUGINS = window.MS2_EDIT_PLUGINS;

    const MS2_PLUGINS = window.squashMS2PlugCfg(
      MS2_BASE_PLUGINS,
      MS2_MAP_PLUGINS,
      MS2_EDIT_PLUGINS);
      if (options && options.setLocale) {
        options.setLocale(window.geonode_config.locale);
      }
      ...
```
- verify if possible to centralize script for configuration and init (maybe the geonode_config provide a key to recognize the current page: 'map', 'map-edit', 'layer', ...)


