### PR TITLE
added AddGroupButton to TOC

### DIFF
--- a/geonode_mapstore_client/client/js/plugins.js
+++ b/geonode_mapstore_client/client/js/plugins.js
@@ -10,6 +10,7 @@ const epics = require("./epics");
 
 module.exports = {
     plugins: {
+        AddGroupPlugin: require('../MapStore2/web/client/plugins/AddGroup').default,
         IdentifyPlugin: require('../MapStore2/web/client/plugins/Identify'),
         TOCPlugin: require('../MapStore2/web/client/plugins/TOC'),
         MapPlugin: require('../MapStore2/web/client/plugins/Map'),

--- a/geonode_mapstore_client/static/geonode/js/ms2/utils/ms2_composer_plugins.js
+++ b/geonode_mapstore_client/static/geonode/js/ms2/utils/ms2_composer_plugins.js
@@ -9,6 +9,8 @@ var MS2_EDIT_PLUGINS = {
 				"activateQueryTool": true,
 				"activateAddLayerButton": true,
 				"activateMetedataTool": false,
+				// ### Activate the Group Button in TOC
+				"activateAddGroupButton": true,
 				"spatialOperations": [{
 						"id": "INTERSECTS",
 						"name": "queryform.spatialfilter.operations.intersects"
@@ -51,6 +53,14 @@ var MS2_EDIT_PLUGINS = {
 		// ScaleBox, FeatureEditor, QueryPanel, MetadataExplorer, GoFull, FullScreen
 		// 	Widgets, WidgetsTray, SaveAs, Notifications TOCItemSettings, from map_viewer_plugins
 
+		//  // ###  Add the AddGroup Settings
+		"AddGroup",
+		{
+			"name": "Settings",
+			"cfg": {
+				"wrap": true
+			}
+		},
 		"WidgetsBuilder",
 		"Save"
 	]


### PR DESCRIPTION
need additional code in the MapStore2 repo to work.
`geonode-mapstore-client\geonode_mapstore_client\client\MapStore2\web\client\plugins\TOC.jsx` has to be changed according to this patch:
```
Index: web/client/plugins/TOC.jsx
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
--- web/client/plugins/TOC.jsx	(date 1573211951000)
+++ web/client/plugins/TOC.jsx	(date 1583155850000)
@@ -284,7 +284,7 @@
         onGetMetadataRecord: () => {},
         hideLayerMetadata: () => {},
         activateAddLayerButton: false,
-        activateAddGroupButton: false,
+        activateAddGroupButton: true,
         catalogActive: false,
         refreshLayerVersion: () => {},
         metadataTemplate: null
```