### PR TITLE
Enable add group plugin in the map editor

### DIFF
--- a/geonode_mapstore_client/static/geonode/js/ms2/utils/ms2_composer_plugins.js
+++ b/geonode_mapstore_client/static/geonode/js/ms2/utils/ms2_composer_plugins.js
@@ -57,6 +57,7 @@ var MS2_EDIT_PLUGINS = {
 			"cfg": {
 				"disablePermission": true
 			}
-		}
+		},
+		{ "name": "AddGroup" }
 	]
 }


### PR DESCRIPTION
This PR enable the add group plugin in the Map editor:

![image](https://user-images.githubusercontent.com/19175505/102230009-a9fbfd80-3eec-11eb-9801-7ea9bb834977.png)
