### PR TITLE
Remove the geocoding configuration from Mapstore client 

### DIFF
--- a/geonode_mapstore_client/static/geonode/js/ms2/utils/ms2_map_viewer_plugins.js
+++ b/geonode_mapstore_client/static/geonode/js/ms2/utils/ms2_map_viewer_plugins.js
@@ -169,7 +169,6 @@ var MS2_MAP_PLUGINS = {
 		"Notifications",
 		"Timeline",
 		"Playback",
-		"SearchServicesConfig",
 		{
 			"name": "Share",
 			"cfg": {

--- a/geonode_mapstore_client/static/geonode/js/ms2/utils/ms2_viewer_plugins.js
+++ b/geonode_mapstore_client/static/geonode/js/ms2/utils/ms2_viewer_plugins.js
@@ -98,7 +98,6 @@ var MS2_PLUGINS = {
 		"Redo",
 		"BurgerMenu",
 		"MapFooter",
-		"SearchServicesConfig",
 		{
 			"name": "Print",
 			"cfg": {


### PR DESCRIPTION
The current SearchServicesConfig plugin is a bit confusing in the GeoNode context.
This PR removes this from the configuration but keeps the plugin available in the js bundle.