### PR TITLE
Implement client viewers architecture

### DIFF
--- a/geonode_mapstore_client/apps.py
+++ b/geonode_mapstore_client/apps.py
@@ -10,6 +10,7 @@
 #########################################################################
 import os
 from django.apps import AppConfig as BaseAppConfig
+from django.views.generic import TemplateView
 
 def run_setup_hooks(*args, **kwargs):
     from geonode.urls import urlpatterns
@@ -22,6 +23,7 @@ def run_setup_hooks(*args, **kwargs):
     urlpatterns += [
         url(r'^mapstore/', include('mapstore2_adapter.urls')),
         url(r'^', include('mapstore2_adapter.geoapps.geostories.api.urls')),
+        url(r'^viewer/', TemplateView.as_view(template_name='geonode-mapstore-client/viewer.html')),
     ]
 
 

--- a/geonode_mapstore_client/client/js/actions/gnviewer.js
+++ b/geonode_mapstore_client/client/js/actions/gnviewer.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const REQUEST_LAYER_CONFIG = 'GEONODE_VIEWER:REQUEST_LAYER_CONFIG';
+export const REQUEST_MAP_CONFIG = 'GEONODE_VIEWER:REQUEST_MAP_CONFIG';
+export const REQUEST_GEOSTORY_CONFIG = 'GEONODE_VIEWER:REQUEST_GEOSTORY_CONFIG';
+export const REQUEST_DOCUMENT_CONFIG = 'GEONODE_VIEWER:REQUEST_DOCUMENT_CONFIG';
+
+export function requestLayerConfig(pk) {
+    return {
+        type: REQUEST_LAYER_CONFIG,
+        pk
+    };
+}
+
+export function requestMapConfig(pk) {
+    return {
+        type: REQUEST_MAP_CONFIG,
+        pk
+    };
+}
+
+export function requestGeoStoryConfig(pk) {
+    return {
+        type: REQUEST_GEOSTORY_CONFIG,
+        pk
+    };
+}
+
+export function requestDocumentConfig(pk) {
+    return {
+        type: REQUEST_DOCUMENT_CONFIG,
+        pk
+    };
+}
+

--- a/geonode_mapstore_client/client/js/api/geonode/config/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/config/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import axios from '@mapstore/framework/libs/ajax';
+
+export const getBaseMapConfiguration = (baseMapUrl = '/static/mapstore/configs/map.json') => {
+    return axios.get(baseMapUrl)
+        .then(({ data }) => data);
+};
+
+export default {
+    getBaseMapConfiguration
+};

--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -231,6 +231,16 @@ export const getResourceByPk = (pk) => {
         .then(({ data }) => data.resource);
 };
 
+export const getLayerByPk = (pk) => {
+    return axios.get(parseDevHostname(`${endpoints[LAYERS]}/${pk}`))
+        .then(({ data }) => data.layer);
+};
+
+export const getDocumentByPk = (pk) => {
+    return axios.get(parseDevHostname(`${endpoints[DOCUMENTS]}/${pk}`))
+        .then(({ data }) => data.document);
+};
+
 export const createGeoApp = (body) => {
     return axios.post(parseDevHostname(`${endpoints[GEOAPPS]}`), body, {
         params: {
@@ -240,8 +250,26 @@ export const createGeoApp = (body) => {
         .then(({ data }) => data.resource);
 };
 
+export const getGeoAppByPk = (pk) => {
+    return axios.get(parseDevHostname(`${endpoints[GEOAPPS]}/${pk}`), {
+        params: {
+            full: true
+        }
+    })
+        .then(({ data }) => data.geoapp);
+};
+
 export const createGeoStory = (body) => {
     return axios.post(parseDevHostname(`${endpoints[GEOSTORIES]}`), body, {
+        params: {
+            include: ['data']
+        }
+    })
+        .then(({ data }) => data.geostory);
+};
+
+export const getGeoStoryByPk = (pk) => {
+    return axios.get(parseDevHostname(`${endpoints[GEOSTORIES]}/${pk}`), {
         params: {
             include: ['data']
         }
@@ -371,7 +399,9 @@ export default {
     getResources,
     getResourceByPk,
     createGeoApp,
+    getGeoAppByPk,
     createGeoStory,
+    getGeoStoryByPk,
     updateGeoStory,
     getMaps,
     getDocumentsByDocType,
@@ -379,5 +409,7 @@ export default {
     getAccountInfo,
     getConfiguration,
     getResourceTypes,
-    getResourcesTotalCount
+    getResourcesTotalCount,
+    getLayerByPk,
+    getDocumentByPk
 };

--- a/geonode_mapstore_client/client/js/apps/gn-viewer.js
+++ b/geonode_mapstore_client/client/js/apps/gn-viewer.js
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import main from '@mapstore/framework/components/app/main';
+import Router, { withRoutes } from '@js/components/app/Router';
+import MainLoader from '@js/components/app/MainLoader';
+import { connect } from 'react-redux';
+import { getConfigProp, setConfigProp } from '@mapstore/framework/utils/ConfigUtils';
+import { loadPrintCapabilities } from '@mapstore/framework/actions/print';
+import StandardApp from '@mapstore/framework/components/app/StandardApp';
+import geostory from '@mapstore/framework/reducers/geostory';
+import withExtensions from '@mapstore/framework/components/app/withExtensions';
+
+// the app needs this epics and reducers from mapstore to correctly initialize some functionalities
+import controls from '@mapstore/framework/reducers/controls';
+import maptype from '@mapstore/framework/reducers/maptype';
+import security from '@mapstore/framework/reducers/security';
+import print from '@mapstore/framework/reducers/print';
+import {
+    standardReducers,
+    standardEpics,
+    standardRootReducerFunc
+} from '@mapstore/framework/stores/defaultOptions';
+
+import timeline from '@mapstore/framework/reducers/timeline';
+import dimension from '@mapstore/framework/reducers/dimension';
+import playback from '@mapstore/framework/reducers/playback';
+import mapPopups from '@mapstore/framework/reducers/mapPopups';
+import catalog from '@mapstore/framework/reducers/catalog';
+import searchconfig from '@mapstore/framework/reducers/searchconfig';
+import widgets from '@mapstore/framework/reducers/widgets';
+// end
+
+import LayerViewerRoute from '@js/routes/LayerViewer';
+import MapViewerRoute from '@js/routes/MapViewer';
+import GeoStoryViewerRoute from '@js/routes/GeoStoryViewer';
+import DocumentViewerRoute from '@js/routes/DocumentViewer';
+
+import gnresource from '@js/reducers/gnresource';
+import gnsettings from '@js/reducers/gnsettings';
+
+import {
+    getConfiguration,
+    getEndpoints,
+    getAccountInfo
+} from '@js/api/geonode/v2';
+
+import {
+    setupConfiguration,
+    getVersion,
+    initializeApp,
+    getPluginsConfiguration
+} from '@js/utils/AppUtils';
+
+import { updateGeoNodeSettings } from '@js/actions/gnsettings';
+
+import {
+    updateMapLayoutEpic,
+    _setFeatureEditPermission,
+    _setStyleEditorPermission
+} from '@js/epics';
+import gnviewerEpics from '@js/epics/gnviewer';
+import maplayout from '@mapstore/framework/reducers/maplayout';
+import 'react-widgets/dist/css/react-widgets.css';
+import 'react-select/dist/react-select.css';
+
+import pluginsDefinition from '@js/plugins/index';
+import ReactSwipe from 'react-swipeable-views';
+import SwipeHeader from '@mapstore/framework/components/data/identify/SwipeHeader';
+const requires = {
+    ReactSwipe,
+    SwipeHeader
+};
+
+const DEFAULT_LOCALE = {};
+const ConnectedRouter = connect((state) => ({
+    locale: state?.locale || DEFAULT_LOCALE
+}))(Router);
+
+const routes = [
+    {
+        name: 'layer_viewer',
+        path: [
+            '/layer/:pk'
+        ],
+        component: LayerViewerRoute
+    },
+    {
+        name: 'layer_edit_data_viewer',
+        path: [
+            '/layer/:pk/edit/data'
+        ],
+        component: LayerViewerRoute
+    },
+    {
+        name: 'layer_edit_style_viewer',
+        path: [
+            '/layer/:pk/edit/style'
+        ],
+        component: LayerViewerRoute
+    },
+    {
+        name: 'map_viewer',
+        path: [
+            '/map/:pk'
+        ],
+        component: MapViewerRoute
+    },
+    {
+        name: 'geostory_viewer',
+        path: [
+            '/geostory/:pk'
+        ],
+        component: GeoStoryViewerRoute
+    },
+    {
+        name: 'document_viewer',
+        path: [
+            '/document/:pk'
+        ],
+        component: DocumentViewerRoute
+    }
+];
+
+initializeApp();
+
+Promise.all([
+    getConfiguration(),
+    getAccountInfo(),
+    getEndpoints()
+])
+    .then(([localConfig, user]) => {
+        const {
+            securityState,
+            geoNodeConfiguration,
+            pluginsConfigKey,
+            query,
+            configEpics,
+            mapType = 'openlayers',
+            onStoreInit,
+            targetId = 'ms-container',
+            settings
+        } = setupConfiguration({
+            localConfig,
+            user
+        });
+
+        // get the correct map layout
+        const mapLayout = getConfigProp('mapLayout') || {};
+        setConfigProp('mapLayout', mapLayout[query.theme] || mapLayout.viewer);
+
+        // register custom arcgis layer
+        import('@js/components/' + mapType + '/ArcGisMapServer')
+            .then(() => {
+                main({
+                    targetId,
+                    enableExtensions: true,
+                    appComponent: withRoutes(routes)(ConnectedRouter),
+                    loaderComponent: MainLoader,
+                    initialState: {
+                        defaultState: {
+                            ...securityState,
+                            maptype: {
+                                mapType
+                            }
+                        }
+                    },
+                    themeCfg: {
+                        path: '/static/mapstore/dist/themes',
+                        prefixContainer: '#' + targetId,
+                        version: getVersion(),
+                        prefix: 'msgapi',
+                        theme: query.theme
+                    },
+                    pluginsConfig: getPluginsConfiguration(localConfig.plugins, pluginsConfigKey),
+                    lazyPlugins: pluginsDefinition.lazyPlugins,
+                    pluginsDef: {
+                        plugins: {
+                            ...pluginsDefinition.plugins
+                        },
+                        requires: {
+                            ...requires,
+                            ...pluginsDefinition.requires
+                        }
+                    },
+                    printEnabled: true,
+                    rootReducerFunc: standardRootReducerFunc,
+                    onStoreInit,
+                    appReducers: {
+                        ...standardReducers,
+                        gnresource,
+                        gnsettings,
+                        security,
+                        maptype,
+                        print,
+                        maplayout,
+                        controls,
+                        timeline,
+                        dimension,
+                        playback,
+                        mapPopups,
+                        catalog,
+                        searchconfig,
+                        widgets,
+                        geostory,
+                        ...pluginsDefinition.reducers
+                    },
+                    appEpics: {
+                        ...standardEpics,
+                        ...configEpics,
+                        updateMapLayoutEpic,
+                        _setFeatureEditPermission,
+                        _setStyleEditorPermission,
+                        ...pluginsDefinition.epics,
+                        ...gnviewerEpics
+                    },
+                    geoNodeConfiguration,
+                    initialActions: [
+                        // add some settings in the global state to make them accessible in the monitor state
+                        // later we could use expression in localConfig
+                        updateGeoNodeSettings.bind(null, settings),
+                        loadPrintCapabilities.bind(null, getConfigProp('printUrl'))
+                    ]
+                },
+                withExtensions(StandardApp));
+            });
+    });

--- a/geonode_mapstore_client/client/js/components/home/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/home/DetailsPanel.jsx
@@ -96,11 +96,14 @@ function DetailsPanel({
 
     const types = getTypesInfo();
     const {
-        formatEmbedUrl = embedUrl => embedUrl,
+        formatEmbedUrl = res => res?.embed_url,
+        formatDetailUrl = res => res?.detail_url,
         icon,
         name
     } = resource && (types[resource.doc_type] || types[resource.resource_type]) || {};
-    const embedUrl = resource?.embed_url && formatEmbedUrl(resource.embed_url);
+    const embedUrl = resource?.embed_url && formatEmbedUrl(resource);
+    const detailUrl = resource?.pk && formatDetailUrl(resource);
+
     return (
         <div
             ref={detailsContainerNode}
@@ -177,7 +180,7 @@ function DetailsPanel({
                             {resource?.title}
                         </h1>
                         <div className="gn-details-panel-tools">
-                            {resource && <OverlayTrigger
+                            {detailUrl && <OverlayTrigger
                                 placement="top"
                                 overlay={(props) =>
                                     <Tooltip id="share-resource-tooltip" {...props}>
@@ -189,7 +192,7 @@ function DetailsPanel({
                                     </Tooltip>}
                             >
                                 <CopyToClipboard
-                                    text={formatResourceLinkUrl(resource.detail_url)}
+                                    text={formatResourceLinkUrl(detailUrl)}
                                 >
                                     <Button
                                         variant="default"
@@ -198,9 +201,11 @@ function DetailsPanel({
                                     </Button>
                                 </CopyToClipboard>
                             </OverlayTrigger>}
-                            {resource?.detail_url && <Button
+                            {detailUrl && <Button
                                 variant="default"
-                                href={resource.detail_url}>
+                                href={detailUrl}
+                                target="_blank"
+                                rel="noopener noreferrer">
                                 <Message msgId={`gnhome.view${name || ''}`}/>
                             </Button>}
                         </div>

--- a/geonode_mapstore_client/client/js/epics/gnviewer.js
+++ b/geonode_mapstore_client/client/js/epics/gnviewer.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Observable } from 'rxjs';
+import axios from '@mapstore/framework/libs/ajax';
+import turfBbox from '@turf/bbox';
+import {
+    REQUEST_LAYER_CONFIG,
+    REQUEST_MAP_CONFIG,
+    REQUEST_GEOSTORY_CONFIG,
+    REQUEST_DOCUMENT_CONFIG
+} from '@js/actions/gnviewer';
+import { getBaseMapConfiguration } from '@js/api/geonode/config';
+import {
+    getLayerByPk,
+    getGeoStoryByPk,
+    getDocumentByPk
+} from '@js/api/geonode/v2';
+import { getMapStoreMapById } from '@js/api/geonode/adapter';
+import { configureMap } from '@mapstore/framework/actions/config';
+import { zoomToExtent } from '@mapstore/framework/actions/map';
+import { getConfigProp } from '@mapstore/framework/utils/ConfigUtils';
+import {
+    // setResourcePermissions,
+    // setNewResource,
+    setResource
+} from '@js/actions/gnresource';
+import { setCurrentStory } from '@mapstore/framework/actions/geostory';
+
+export const gnViewerRequestLayerConfig = (action$) =>
+    action$.ofType(REQUEST_LAYER_CONFIG)
+        .switchMap(({ pk }) => {
+            return Observable.defer(() => axios.all([
+                getBaseMapConfiguration(),
+                getLayerByPk(pk)
+            ])).switchMap((response) => {
+                const [mapConfig, gnLayer] = response;
+                const geoserverUrl = getConfigProp('geoserverUrl') || '/geoserver/';
+                const geonodeUrl = getConfigProp('geonodeUrl') || '/';
+                const extent = turfBbox({
+                    type: 'Feature',
+                    properties: {},
+                    geometry: gnLayer.ll_bbox_polygon
+                });
+                const [minx, miny, maxx, maxy] = extent;
+                const bbox = {
+                    crs: 'EPSG:4326',
+                    bounds: { minx, miny, maxx, maxy }
+                };
+                return Observable.of(
+                    configureMap({
+                        ...mapConfig,
+                        map: {
+                            ...mapConfig.map,
+                            layers: [
+                                ...mapConfig.map.layers,
+                                {
+                                    id: `pk:${gnLayer.pk}`,
+                                    pk: gnLayer.pk,
+                                    type: 'wms',
+                                    name: `${gnLayer.workspace}:${gnLayer.name}`,
+                                    url: `${geoserverUrl}/ows`,
+                                    format: 'image/png',
+                                    ...(gnLayer.storeType === 'dataStore' && {
+                                        search: {
+                                            type: 'wfs',
+                                            url: `${geonodeUrl}/gs/ows`
+                                        }
+                                    }),
+                                    bbox,
+                                    ...(gnLayer.featureinfo_custom_template && {
+                                        featureInfo: {
+                                            format: 'TEMPLATE',
+                                            template: gnLayer.featureinfo_custom_template
+                                        }
+                                    }),
+                                    style: '',
+                                    title: gnLayer.title,
+                                    visibility: true
+                                }
+                            ]
+                        }
+                    }),
+                    zoomToExtent(extent, 'EPSG:4326'),
+                    setResource(gnLayer)
+                );
+            });
+        });
+
+export const gnViewerRequestMapConfig = (action$) =>
+    action$.ofType(REQUEST_MAP_CONFIG)
+        .switchMap(({ pk }) => {
+            return Observable.defer(() => axios.all([
+                getMapStoreMapById(pk)
+            ])).switchMap((response) => {
+                const [adapterMap] = response;
+                return Observable.of(
+                    configureMap(adapterMap.data)// ,
+                    // setResource(gnLayer)
+                );
+            });
+        });
+
+export const gnViewerRequestGeoStoryConfig = (action$) =>
+    action$.ofType(REQUEST_GEOSTORY_CONFIG)
+        .switchMap(({ pk }) => {
+            return Observable.defer(() => axios.all([
+                getGeoStoryByPk(pk)
+            ])).switchMap((response) => {
+                const [gnGeoStory] = response;
+                const { data, ...resource } = gnGeoStory;
+                return Observable.of(
+                    setCurrentStory(data),
+                    setResource(resource)
+                );
+            });
+        });
+
+export const gnViewerRequestDocumentConfig = (action$) =>
+    action$.ofType(REQUEST_DOCUMENT_CONFIG)
+        .switchMap(({ pk }) => {
+            return Observable.defer(() => axios.all([
+                getDocumentByPk(pk)
+            ])).switchMap((response) => {
+                const [gnDocument] = response;
+                return Observable.of(
+                    setResource(gnDocument)
+                );
+            });
+        });
+
+export default {
+    gnViewerRequestLayerConfig,
+    gnViewerRequestMapConfig,
+    gnViewerRequestGeoStoryConfig,
+    gnViewerRequestDocumentConfig
+};

--- a/geonode_mapstore_client/client/js/epics/gnviewer.js
+++ b/geonode_mapstore_client/client/js/epics/gnviewer.js
@@ -89,6 +89,9 @@ export const gnViewerRequestLayerConfig = (action$) =>
                     zoomToExtent(extent, 'EPSG:4326'),
                     setResource(gnLayer)
                 );
+            }).catch(() => {
+                // TODO: implement various error cases
+                return Observable.empty();
             });
         });
 
@@ -103,6 +106,9 @@ export const gnViewerRequestMapConfig = (action$) =>
                     configureMap(adapterMap.data)// ,
                     // setResource(gnLayer)
                 );
+            }).catch(() => {
+                // TODO: implement various error cases
+                return Observable.empty();
             });
         });
 
@@ -118,6 +124,9 @@ export const gnViewerRequestGeoStoryConfig = (action$) =>
                     setCurrentStory(data),
                     setResource(resource)
                 );
+            }).catch(() => {
+                // TODO: implement various error cases
+                return Observable.empty();
             });
         });
 
@@ -131,6 +140,9 @@ export const gnViewerRequestDocumentConfig = (action$) =>
                 return Observable.of(
                     setResource(gnDocument)
                 );
+            }).catch(() => {
+                // TODO: implement various error cases
+                return Observable.empty();
             });
         });
 

--- a/geonode_mapstore_client/client/js/hooks/usePluginItems.js
+++ b/geonode_mapstore_client/client/js/hooks/usePluginItems.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState, useMemo } from 'react';
+import React, { useRef, useMemo } from 'react';
 import join from 'lodash/join';
 import { getConfiguredPlugin } from '@mapstore/framework/utils/PluginsUtils';
 
@@ -23,7 +23,7 @@ const usePluginItems = ({
                 Component: getConfiguredPlugin(plg, props.loadedPlugins, props.loaderComponent || <div />)
             })) || [];
     }
-    const props = useState({});
+    const props = useRef({});
     props.current = {
         items,
         loadedPlugins,

--- a/geonode_mapstore_client/client/js/hooks/usePluginItems.js
+++ b/geonode_mapstore_client/client/js/hooks/usePluginItems.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState, useMemo } from 'react';
+import join from 'lodash/join';
+import { getConfiguredPlugin } from '@mapstore/framework/utils/PluginsUtils';
+
+const usePluginItems = ({
+    items,
+    loadedPlugins,
+    loaderComponent
+}) => {
+    function configurePluginItems(props) {
+        return [...props.items]
+            .sort((a, b) => a.position > b.position ? 1 : -1)
+            .map(plg => ({
+                ...plg,
+                Component: getConfiguredPlugin(plg, props.loadedPlugins, props.loaderComponent || <div />)
+            })) || [];
+    }
+    const props = useState({});
+    props.current = {
+        items,
+        loadedPlugins,
+        loaderComponent
+    };
+    const loadedPluginsKeys = join(Object.keys(loadedPlugins || {}), ',');
+    const configuredItems = useMemo(() => configurePluginItems(props.current), [loadedPluginsKeys]);
+    return configuredItems;
+};
+
+export default usePluginItems;

--- a/geonode_mapstore_client/client/js/plugins/ActionNavbar.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ActionNavbar.jsx
@@ -34,7 +34,7 @@ const ActionNavbarPlugin = connect(
 export default createPlugin('ActionNavbar', {
     component: ActionNavbarPlugin,
     containers: {
-        EditorLayout: {
+        ViewerLayout: {
             priority: 1,
             target: 'header'
         }

--- a/geonode_mapstore_client/client/js/plugins/ActionNavbar.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ActionNavbar.jsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { createPlugin } from '@mapstore/framework/utils/PluginsUtils';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+
+function ActionNavbar({}) {
+    // placeholder plugin component
+    return (
+        <div
+            style={{
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: 50,
+                backgroundColor: '#2c689c'
+            }}>
+        </div>
+    );
+}
+
+const ActionNavbarPlugin = connect(
+    createSelector([], () => ({})),
+    {}
+)(ActionNavbar);
+
+export default createPlugin('ActionNavbar', {
+    component: ActionNavbarPlugin,
+    containers: {
+        EditorLayout: {
+            priority: 1,
+            target: 'header'
+        }
+    },
+    epics: {},
+    reducers: {}
+});

--- a/geonode_mapstore_client/client/js/plugins/BrandNavbar.jsx
+++ b/geonode_mapstore_client/client/js/plugins/BrandNavbar.jsx
@@ -34,7 +34,7 @@ const BrandNavbarPlugin = connect(
 export default createPlugin('BrandNavbar', {
     component: BrandNavbarPlugin,
     containers: {
-        EditorLayout: {
+        ViewerLayout: {
             priority: 1,
             target: 'header'
         }

--- a/geonode_mapstore_client/client/js/plugins/BrandNavbar.jsx
+++ b/geonode_mapstore_client/client/js/plugins/BrandNavbar.jsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { createPlugin } from '@mapstore/framework/utils/PluginsUtils';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+
+function BrandNavbar({}) {
+    // placeholder plugin component
+    return (
+        <div
+            style={{
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: 60,
+                backgroundColor: '#f2f2f2'
+            }}>
+        </div>
+    );
+}
+
+const BrandNavbarPlugin = connect(
+    createSelector([], () => ({})),
+    {}
+)(BrandNavbar);
+
+export default createPlugin('BrandNavbar', {
+    component: BrandNavbarPlugin,
+    containers: {
+        EditorLayout: {
+            priority: 1,
+            target: 'header'
+        }
+    },
+    epics: {},
+    reducers: {}
+});

--- a/geonode_mapstore_client/client/js/plugins/EditorLayout.jsx
+++ b/geonode_mapstore_client/client/js/plugins/EditorLayout.jsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import isEqual from 'lodash/isEqual';
+import { createPlugin } from '@mapstore/framework/utils/PluginsUtils';
+import usePluginItems from '@js/hooks/usePluginItems';
+
+function EditorLayout({
+    items
+}, context) {
+    const { loadedPlugins } = context;
+    const configuredItems = usePluginItems({ items, loadedPlugins });
+    return (
+        <div
+            style={{
+                position: 'fixed',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column'
+            }}>
+            <header>
+                {configuredItems
+                    .filter(({ target }) => target === 'header')
+                    .map(({ Component, name }) => <Component key={name} />)}
+            </header>
+            <div
+                style={{
+                    flex: 1,
+                    position: 'relative'
+                }}
+            >
+                {configuredItems
+                    .filter(({ target }) => !target)
+                    .map(({ Component, name }) => <Component key={name} />)}
+            </div>
+            <footer>
+                {configuredItems
+                    .filter(({ target }) => target === 'footer')
+                    .map(({ Component, name }) => <Component key={name} />)}
+            </footer>
+        </div>
+    );
+}
+
+EditorLayout.contextTypes = {
+    loadedPlugins: PropTypes.object
+};
+
+function arePropsEqual(prevProps, nextProps) {
+    return isEqual(prevProps, nextProps);
+}
+
+const MemoizeEditorLayout = memo(EditorLayout, arePropsEqual);
+
+const EditorLayoutPlugin = connect(
+    createSelector([], () => ({})),
+    {}
+)(MemoizeEditorLayout);
+
+export default createPlugin('EditorLayout', {
+    component: EditorLayoutPlugin,
+    containers: {},
+    epics: {},
+    reducers: {}
+});

--- a/geonode_mapstore_client/client/js/plugins/ViewerLayout.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ViewerLayout.jsx
@@ -14,7 +14,7 @@ import isEqual from 'lodash/isEqual';
 import { createPlugin } from '@mapstore/framework/utils/PluginsUtils';
 import usePluginItems from '@js/hooks/usePluginItems';
 
-function EditorLayout({
+function ViewerLayout({
     items
 }, context) {
     const { loadedPlugins } = context;
@@ -54,7 +54,7 @@ function EditorLayout({
     );
 }
 
-EditorLayout.contextTypes = {
+ViewerLayout.contextTypes = {
     loadedPlugins: PropTypes.object
 };
 
@@ -62,15 +62,15 @@ function arePropsEqual(prevProps, nextProps) {
     return isEqual(prevProps, nextProps);
 }
 
-const MemoizeEditorLayout = memo(EditorLayout, arePropsEqual);
+const MemoizeViewerLayout = memo(ViewerLayout, arePropsEqual);
 
-const EditorLayoutPlugin = connect(
+const ViewerLayoutPlugin = connect(
     createSelector([], () => ({})),
     {}
-)(MemoizeEditorLayout);
+)(MemoizeViewerLayout);
 
-export default createPlugin('EditorLayout', {
-    component: EditorLayoutPlugin,
+export default createPlugin('ViewerLayout', {
+    component: ViewerLayoutPlugin,
     containers: {},
     epics: {},
     reducers: {}

--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -250,6 +250,18 @@ export const plugins = {
     DrawerMenuPlugin: toLazyPlugin(
         'DrawerMenu',
         import(/* webpackChunkName: 'plugins/drawer-menu-plugin' */ '@mapstore/framework/plugins/DrawerMenu')
+    ),
+    EditorLayoutPlugin: toLazyPlugin(
+        'EditorLayout',
+        import(/* webpackChunkName: 'plugins/editor-layout-plugin' */ '@js/plugins/EditorLayout')
+    ),
+    ActionNavbarPlugin: toLazyPlugin(
+        'ActionNavbar',
+        import(/* webpackChunkName: 'plugins/action-navbar-plugin' */ '@js/plugins/ActionNavbar')
+    ),
+    BrandNavbarPlugin: toLazyPlugin(
+        'BrandNavbar',
+        import(/* webpackChunkName: 'plugins/brand-navbar-plugin' */ '@js/plugins/BrandNavbar')
     )
 };
 

--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -251,9 +251,9 @@ export const plugins = {
         'DrawerMenu',
         import(/* webpackChunkName: 'plugins/drawer-menu-plugin' */ '@mapstore/framework/plugins/DrawerMenu')
     ),
-    EditorLayoutPlugin: toLazyPlugin(
-        'EditorLayout',
-        import(/* webpackChunkName: 'plugins/editor-layout-plugin' */ '@js/plugins/EditorLayout')
+    ViewerLayoutPlugin: toLazyPlugin(
+        'ViewerLayout',
+        import(/* webpackChunkName: 'plugins/editor-layout-plugin' */ '@js/plugins/ViewerLayout')
     ),
     ActionNavbarPlugin: toLazyPlugin(
         'ActionNavbar',

--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -253,7 +253,7 @@ export const plugins = {
     ),
     ViewerLayoutPlugin: toLazyPlugin(
         'ViewerLayout',
-        import(/* webpackChunkName: 'plugins/editor-layout-plugin' */ '@js/plugins/ViewerLayout')
+        import(/* webpackChunkName: 'plugins/viewer-layout-plugin' */ '@js/plugins/ViewerLayout')
     ),
     ActionNavbarPlugin: toLazyPlugin(
         'ActionNavbar',

--- a/geonode_mapstore_client/client/js/routes/DocumentViewer.jsx
+++ b/geonode_mapstore_client/client/js/routes/DocumentViewer.jsx
@@ -1,21 +1,22 @@
 /*
- * Copyright 2018, GeoSolutions Sas.
+ * Copyright 2021, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import url from 'url';
-import isArray from 'lodash/isArray';
+import { createSelector } from 'reselect';
 import BorderLayout from '@mapstore/framework/components/layout/BorderLayout';
 import { getMonitoredState } from '@mapstore/framework/utils/PluginsUtils';
 import { getConfigProp } from '@mapstore/framework/utils/ConfigUtils';
 import PluginsContainer from '@mapstore/framework/components/plugins/PluginsContainer';
-
 import useLazyPlugins from '@js/hooks/useLazyPlugins';
+import { requestDocumentConfig } from '@js/actions/gnviewer';
 
 const urlQuery = url.parse(window.location.href, true).query;
 
@@ -27,37 +28,38 @@ const ConnectedPluginsContainer = connect((state) => ({
     }
 }))(PluginsContainer);
 
-function MapViewerRoute({
+function DocumentViewerRoute({
     name,
     pluginsConfig: propPluginsConfig,
     params,
-    onMount,
+    onUpdate,
     loaderComponent,
     lazyPlugins,
-    plugins
+    plugins,
+    match
 }) {
 
-    const pluginsConfig = isArray(propPluginsConfig)
-        ? propPluginsConfig
-        : propPluginsConfig && propPluginsConfig[name] || [];
-
+    const { pk } = match.params || {};
+    const pluginsConfig = propPluginsConfig && propPluginsConfig[name] || [];
     const [loading, setLoading] = useState(true);
     const { plugins: loadedPlugins } = useLazyPlugins({
         pluginsEntries: lazyPlugins,
         pluginsConfig
     });
+
     useEffect(() => {
-        if (!loading && onMount) {
-            onMount(true);
+        if (!loading) {
+            onUpdate(pk);
         }
-    }, [ loading, onMount ]);
+    }, [loading, pk]);
     const Loader = loaderComponent;
+
     return (
         <>
             <ConnectedPluginsContainer
-                key="page-map-viewer"
-                id="page-map-viewer"
-                className="page page-map-viewer"
+                key="page-document-viewer"
+                id="page-document-viewer"
+                className="page page-document-viewer"
                 component={BorderLayout}
                 pluginsConfig={pluginsConfig}
                 plugins={{ ...loadedPlugins, ...plugins }}
@@ -69,17 +71,17 @@ function MapViewerRoute({
     );
 }
 
-MapViewerRoute.propTypes = {
-    onMount: PropTypes.func
+DocumentViewerRoute.propTypes = {
+    onUpdate: PropTypes.func
 };
 
-const ConnectedMapViewerRoute = connect(
-    () => ({}),
-    {}
-)(MapViewerRoute);
+const ConnectedDocumentViewerRoute = connect(
+    createSelector([], () => ({})),
+    {
+        onUpdate: requestDocumentConfig
+    }
+)(DocumentViewerRoute);
 
-ConnectedMapViewerRoute.displayName = 'ConnectedMapViewerRoute';
+ConnectedDocumentViewerRoute.displayName = 'ConnectedDocumentViewerRoute';
 
-export default ConnectedMapViewerRoute;
-
-
+export default ConnectedDocumentViewerRoute;

--- a/geonode_mapstore_client/client/js/routes/GeoStoryViewer.jsx
+++ b/geonode_mapstore_client/client/js/routes/GeoStoryViewer.jsx
@@ -1,21 +1,22 @@
 /*
- * Copyright 2018, GeoSolutions Sas.
+ * Copyright 2021, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import url from 'url';
-import isArray from 'lodash/isArray';
+import { createSelector } from 'reselect';
 import BorderLayout from '@mapstore/framework/components/layout/BorderLayout';
 import { getMonitoredState } from '@mapstore/framework/utils/PluginsUtils';
 import { getConfigProp } from '@mapstore/framework/utils/ConfigUtils';
 import PluginsContainer from '@mapstore/framework/components/plugins/PluginsContainer';
-
 import useLazyPlugins from '@js/hooks/useLazyPlugins';
+import { requestGeoStoryConfig } from '@js/actions/gnviewer';
 
 const urlQuery = url.parse(window.location.href, true).query;
 
@@ -27,19 +28,19 @@ const ConnectedPluginsContainer = connect((state) => ({
     }
 }))(PluginsContainer);
 
-function MapViewerRoute({
+function GeoStoryViewerRoute({
     name,
     pluginsConfig: propPluginsConfig,
     params,
-    onMount,
+    onUpdate,
     loaderComponent,
     lazyPlugins,
-    plugins
+    plugins,
+    match
 }) {
 
-    const pluginsConfig = isArray(propPluginsConfig)
-        ? propPluginsConfig
-        : propPluginsConfig && propPluginsConfig[name] || [];
+    const { pk } = match.params || {};
+    const pluginsConfig = propPluginsConfig && propPluginsConfig[name] || [];
 
     const [loading, setLoading] = useState(true);
     const { plugins: loadedPlugins } = useLazyPlugins({
@@ -47,17 +48,18 @@ function MapViewerRoute({
         pluginsConfig
     });
     useEffect(() => {
-        if (!loading && onMount) {
-            onMount(true);
+        if (!loading) {
+            onUpdate(pk);
         }
-    }, [ loading, onMount ]);
+    }, [loading, pk]);
     const Loader = loaderComponent;
+
     return (
         <>
             <ConnectedPluginsContainer
-                key="page-map-viewer"
-                id="page-map-viewer"
-                className="page page-map-viewer"
+                key="page-geostory-viewer"
+                id="page-geostory-viewer"
+                className="page page-geostory-viewer"
                 component={BorderLayout}
                 pluginsConfig={pluginsConfig}
                 plugins={{ ...loadedPlugins, ...plugins }}
@@ -69,17 +71,17 @@ function MapViewerRoute({
     );
 }
 
-MapViewerRoute.propTypes = {
-    onMount: PropTypes.func
+GeoStoryViewerRoute.propTypes = {
+    onUpdate: PropTypes.func
 };
 
-const ConnectedMapViewerRoute = connect(
-    () => ({}),
-    {}
-)(MapViewerRoute);
+const ConnectedGeoStoryViewerRoute = connect(
+    createSelector([], () => ({})),
+    {
+        onUpdate: requestGeoStoryConfig
+    }
+)(GeoStoryViewerRoute);
 
-ConnectedMapViewerRoute.displayName = 'ConnectedMapViewerRoute';
+ConnectedGeoStoryViewerRoute.displayName = 'ConnectedGeoStoryViewerRoute';
 
-export default ConnectedMapViewerRoute;
-
-
+export default ConnectedGeoStoryViewerRoute;

--- a/geonode_mapstore_client/client/js/routes/LayerViewer.jsx
+++ b/geonode_mapstore_client/client/js/routes/LayerViewer.jsx
@@ -1,21 +1,22 @@
 /*
- * Copyright 2018, GeoSolutions Sas.
+ * Copyright 2021, GeoSolutions Sas.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import url from 'url';
-import isArray from 'lodash/isArray';
+import { createSelector } from 'reselect';
 import BorderLayout from '@mapstore/framework/components/layout/BorderLayout';
 import { getMonitoredState } from '@mapstore/framework/utils/PluginsUtils';
 import { getConfigProp } from '@mapstore/framework/utils/ConfigUtils';
 import PluginsContainer from '@mapstore/framework/components/plugins/PluginsContainer';
-
 import useLazyPlugins from '@js/hooks/useLazyPlugins';
+import { requestLayerConfig } from '@js/actions/gnviewer';
 
 const urlQuery = url.parse(window.location.href, true).query;
 
@@ -27,37 +28,38 @@ const ConnectedPluginsContainer = connect((state) => ({
     }
 }))(PluginsContainer);
 
-function MapViewerRoute({
+function LayerViewerRoute({
     name,
     pluginsConfig: propPluginsConfig,
     params,
-    onMount,
+    onUpdate,
     loaderComponent,
     lazyPlugins,
-    plugins
+    plugins,
+    match
 }) {
 
-    const pluginsConfig = isArray(propPluginsConfig)
-        ? propPluginsConfig
-        : propPluginsConfig && propPluginsConfig[name] || [];
-
+    const { pk } = match.params || {};
+    const pluginsConfig = propPluginsConfig && propPluginsConfig[name] || [];
     const [loading, setLoading] = useState(true);
     const { plugins: loadedPlugins } = useLazyPlugins({
         pluginsEntries: lazyPlugins,
         pluginsConfig
     });
+
     useEffect(() => {
-        if (!loading && onMount) {
-            onMount(true);
+        if (!loading) {
+            onUpdate(pk);
         }
-    }, [ loading, onMount ]);
+    }, [loading, pk]);
     const Loader = loaderComponent;
+
     return (
         <>
             <ConnectedPluginsContainer
-                key="page-map-viewer"
-                id="page-map-viewer"
-                className="page page-map-viewer"
+                key="page-layer-viewer"
+                id="page-layer-viewer"
+                className="page page-layer-viewer"
                 component={BorderLayout}
                 pluginsConfig={pluginsConfig}
                 plugins={{ ...loadedPlugins, ...plugins }}
@@ -69,17 +71,17 @@ function MapViewerRoute({
     );
 }
 
-MapViewerRoute.propTypes = {
-    onMount: PropTypes.func
+LayerViewerRoute.propTypes = {
+    onUpdate: PropTypes.func
 };
 
-const ConnectedMapViewerRoute = connect(
-    () => ({}),
-    {}
-)(MapViewerRoute);
+const ConnectedLayerViewerRoute = connect(
+    createSelector([], () => ({})),
+    {
+        onUpdate: requestLayerConfig
+    }
+)(LayerViewerRoute);
 
-ConnectedMapViewerRoute.displayName = 'ConnectedMapViewerRoute';
+ConnectedLayerViewerRoute.displayName = 'ConnectedLayerViewerRoute';
 
-export default ConnectedMapViewerRoute;
-
-
+export default ConnectedLayerViewerRoute;

--- a/geonode_mapstore_client/client/js/utils/GNSearchUtils.js
+++ b/geonode_mapstore_client/client/js/utils/GNSearchUtils.js
@@ -76,38 +76,53 @@ function updateUrlQueryParameter(requestUrl, query) {
     });
 }
 
+// temporary wrapper to allow new path for detail in dev env
+// and keep legacy detail path for prod until the complete development of gn-viewer
+function devViewerDetailPath(resource, formattedDetailUrl) {
+    if (__DEVTOOLS__) {
+        return formattedDetailUrl;
+    }
+    return resource?.detail_url;
+}
+
 export const getResourceTypesInfo = () => ({
     'layer': {
         icon: 'layer-group',
-        formatEmbedUrl: (embedUrl) => updateUrlQueryParameter(embedUrl, {
+        formatEmbedUrl: (resource) => updateUrlQueryParameter(resource.embed_url, {
             config: 'layer_preview',
             theme: 'preview'
         }),
+        formatDetailUrl: (resource) => devViewerDetailPath(resource, `/viewer/#/layer/${resource.pk}`),
         name: 'Layer'
     },
     'map': {
         icon: 'map-marked',
-        formatEmbedUrl: (embedUrl) => updateUrlQueryParameter(embedUrl, {
+        formatEmbedUrl: (resource) => updateUrlQueryParameter(resource.embed_url, {
             config: 'map_preview',
             theme: 'preview'
         }),
+        formatDetailUrl: (resource) => devViewerDetailPath(resource, `/viewer/#/map/${resource.pk}`),
         name: 'Map'
     },
     'document': {
         icon: 'file',
-        name: 'Document'
+        name: 'Document',
+        formatDetailUrl: (resource) => devViewerDetailPath(resource, `/viewer/#/document/${resource.pk}`)
     },
     'geostory': {
         icon: 'book-open',
-        name: 'GeoStory'
+        name: 'GeoStory',
+        formatDetailUrl: (resource) => devViewerDetailPath(resource, `/viewer/#/geostory/${resource.pk}`)
     },
     'image': {
         icon: 'file-image',
-        name: 'Image'
+        name: 'Image',
+        formatDetailUrl: (resource) => devViewerDetailPath(resource, `/viewer/#/document/${resource.pk}`)
     },
     'video': {
         icon: 'file-video',
-        name: 'Video'
+        name: 'Video',
+        formatDetailUrl: (resource) => devViewerDetailPath(resource, `/viewer/#/document/${resource.pk}`)
     }
 });
 

--- a/geonode_mapstore_client/client/static/mapstore/configs/geostory.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/geostory.json
@@ -1,0 +1,42 @@
+{
+    "type": "cascade",
+    "resources": [],
+    "settings": {
+        "theme": {
+            "general": {
+                "color": "#333333",
+                "backgroundColor": "#ffffff",
+                "borderColor": "#e6e6e6"
+            },
+            "overlay": {
+                "backgroundColor": "rgba(255, 255, 255, 0.75)",
+                "borderColor": "#dddddd",
+                "boxShadow": "0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22)",
+                "color": "#333333"
+            }
+        }
+    },
+    "sections": [
+        {
+            "type": "title",
+            "id": "section_id",
+            "title": "Abstract",
+            "cover": true,
+            "contents": [
+                {
+                    "id": "content_id",
+                    "type": "text",
+                    "size": "large",
+                    "align": "center",
+                    "theme": "",
+                    "html": "",
+                    "background": {
+                        "fit": "cover",
+                        "size": "full",
+                        "align": "center"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -2431,7 +2431,7 @@
         ],
         "layer_viewer": [
             {
-                "name": "EditorLayout"
+                "name": "ViewerLayout"
             },
             {
                 "name": "ActionNavbar"
@@ -2462,7 +2462,7 @@
                     }
                 },
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2470,7 +2470,7 @@
             {
                 "name": "BackgroundSelector",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2497,7 +2497,7 @@
                     "layout": "horizontal"
                 },
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2513,7 +2513,7 @@
             {
                 "name": "OmniBar",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2527,7 +2527,7 @@
             {
                 "name": "MapFooter",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1,
                         "target": "footer"
                     }
@@ -2570,7 +2570,7 @@
             {
                 "name": "Timeline",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2632,7 +2632,7 @@
                     ]
                 },
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2682,7 +2682,7 @@
         ],
         "layer_edit_data_viewer": [
             {
-                "name": "EditorLayout"
+                "name": "ViewerLayout"
             },
             {
                 "name": "ActionNavbar"
@@ -2713,7 +2713,7 @@
                     }
                 },
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2721,7 +2721,7 @@
         ],
         "layer_edit_style_viewer": [
             {
-                "name": "EditorLayout"
+                "name": "ViewerLayout"
             },
             {
                 "name": "ActionNavbar"
@@ -2752,14 +2752,14 @@
                     }
                 },
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
             }
         ],
         "map_viewer": [
-            { "name": "EditorLayout" },
+            { "name": "ViewerLayout" },
             { "name": "ActionNavbar" },
             { "name": "BrandNavbar" },
             {
@@ -2783,7 +2783,7 @@
                     }
                 },
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2791,7 +2791,7 @@
             {
                 "name": "BackgroundSelector",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2824,7 +2824,7 @@
                     "layout": "horizontal"
                 },
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2840,7 +2840,7 @@
             {
                 "name": "DrawerMenu",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2848,7 +2848,7 @@
             {
                 "name": "OmniBar",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2859,7 +2859,7 @@
             {
                 "name": "BurgerMenu",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2867,7 +2867,7 @@
             {
                 "name": "MapFooter",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1,
                         "target": "footer"
                     }
@@ -2910,7 +2910,7 @@
             {
                 "name": "Timeline",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2933,7 +2933,7 @@
             {
                 "name": "FeatureEditor",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -2980,7 +2980,7 @@
                     ]
                 },
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -3028,7 +3028,7 @@
                     "showFeatureInfoTab": false
                 },
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -3036,7 +3036,7 @@
             {
                 "name": "Widgets",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -3044,7 +3044,7 @@
             {
                 "name": "WidgetsTray",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -3110,7 +3110,7 @@
             }
         ],
         "geostory_viewer": [
-            { "name": "EditorLayout" },
+            { "name": "ViewerLayout" },
             { "name": "ActionNavbar" },
             { "name": "BrandNavbar" },
             {
@@ -3121,7 +3121,7 @@
                     "className": "navbar shadow navbar-home"
                 },
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -3129,7 +3129,7 @@
             {
                 "name": "BurgerMenu",
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -3188,7 +3188,7 @@
                     }
                 },
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -3203,7 +3203,7 @@
                     "containerPosition": "columns"
                 },
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -3214,7 +3214,7 @@
                     "containerPosition": "header"
                 },
                 "override": {
-                    "EditorLayout": {
+                    "ViewerLayout": {
                         "priority": 1
                     }
                 }
@@ -3233,7 +3233,7 @@
             }
         ],
         "document_viewer": [
-            { "name": "EditorLayout" },
+            { "name": "ViewerLayout" },
             { "name": "ActionNavbar" },
             { "name": "BrandNavbar" }
         ]

--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -215,40 +215,40 @@
                         "type": "select",
                         "suggestionsRequestKey": "owners"
                     }
-
                 ],
-                "links": [{
-                    "myresources" :[
-                        {
-                            "labelId": "gnhome.myresources",
-                            "type": "link",
-                            "href": "#",
-                            "authenticated": false
-                        },
-                        {
-                            "labelId": "gnhome.signIn",
-                            "type": "link",
-                            "href": "#",
-                            "authenticated": false
-                        }
-                    ]
-                },
-                {
-                    "mylink" :[
-                        {
-                            "labelId": "gnhome.myresources",
-                            "type": "link",
-                            "href": "account/signup/?next=/",
-                            "authenticated": false
-                        },
-                        {
-                            "labelId": "gnhome.signIn",
-                            "type": "link",
-                            "href": "account/login/?next=/",
-                            "authenticated": false
-                        }
-                    ]
-                }
+                "links": [
+                    {
+                        "myresources": [
+                            {
+                                "labelId": "gnhome.myresources",
+                                "type": "link",
+                                "href": "#",
+                                "authenticated": false
+                            },
+                            {
+                                "labelId": "gnhome.signIn",
+                                "type": "link",
+                                "href": "#",
+                                "authenticated": false
+                            }
+                        ]
+                    },
+                    {
+                        "mylink": [
+                            {
+                                "labelId": "gnhome.myresources",
+                                "type": "link",
+                                "href": "account/signup/?next=/",
+                                "authenticated": false
+                            },
+                            {
+                                "labelId": "gnhome.signIn",
+                                "type": "link",
+                                "href": "account/login/?next=/",
+                                "authenticated": false
+                            }
+                        ]
+                    }
                 ]
             },
             "order": {
@@ -2428,6 +2428,814 @@
             {
                 "name": "Notifications"
             }
+        ],
+        "layer_viewer": [
+            {
+                "name": "EditorLayout"
+            },
+            {
+                "name": "ActionNavbar"
+            },
+            {
+                "name": "BrandNavbar"
+            },
+            {
+                "name": "Map",
+                "cfg": {
+                    "shouldLoadFont": false,
+                    "fonts": [],
+                    "tools": [
+                        "measurement",
+                        "draw",
+                        "box"
+                    ],
+                    "mapOptions": {
+                        "openlayers": {
+                            "attribution": {
+                                "container": "#footer-attribution-container"
+                            },
+                            "interactions": {
+                                "pinchRotate": false,
+                                "altShiftDragRotate": false
+                            }
+                        }
+                    }
+                },
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "BackgroundSelector",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "Identify",
+                "cfg": {
+                    "viewerOptions": {
+                        "container": "{context.ReactSwipe}"
+                    }
+                },
+                "override": {
+                    "Toolbar": {
+                        "position": 11,
+                        "alwaysVisible": false
+                    }
+                }
+            },
+            {
+                "name": "Toolbar",
+                "id": "NavigationBar",
+                "cfg": {
+                    "id": "navigationBar",
+                    "layout": "horizontal"
+                },
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "MapLoading",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "OmniBar",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "Expander"
+            },
+            {
+                "name": "BurgerMenu"
+            },
+            {
+                "name": "MapFooter",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1,
+                        "target": "footer"
+                    }
+                }
+            },
+            {
+                "name": "Measure"
+            },
+            {
+                "name": "Print",
+                "cfg": {
+                    "useFixedScales": true,
+                    "mapWidth": 256
+                }
+            },
+            {
+                "name": "ZoomAll",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": false
+                    }
+                }
+            },
+            {
+                "name": "ZoomIn",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "ZoomOut",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "Timeline",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "Playback"
+            },
+            {
+                "name": "LayerDownload"
+            },
+            {
+                "name": "AddLayer"
+            },
+            {
+                "name": "FilterLayer"
+            },
+            {
+                "name": "ScaleBox"
+            },
+            {
+                "name": "QueryPanel",
+                "cfg": {
+                    "activateQueryTool": true,
+                    "spatialOperations": [
+                        {
+                            "id": "INTERSECTS",
+                            "name": "queryform.spatialfilter.operations.intersects"
+                        },
+                        {
+                            "id": "BBOX",
+                            "name": "queryform.spatialfilter.operations.bbox"
+                        },
+                        {
+                            "id": "CONTAINS",
+                            "name": "queryform.spatialfilter.operations.contains"
+                        },
+                        {
+                            "id": "WITHIN",
+                            "name": "queryform.spatialfilter.operations.within"
+                        }
+                    ],
+                    "spatialMethodOptions": [
+                        {
+                            "id": "Viewport",
+                            "name": "queryform.spatialfilter.methods.viewport"
+                        },
+                        {
+                            "id": "BBOX",
+                            "name": "queryform.spatialfilter.methods.box"
+                        },
+                        {
+                            "id": "Circle",
+                            "name": "queryform.spatialfilter.methods.circle"
+                        },
+                        {
+                            "id": "Polygon",
+                            "name": "queryform.spatialfilter.methods.poly"
+                        }
+                    ]
+                },
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "MousePosition",
+                "cfg": {
+                    "editCRS": true,
+                    "showLabels": true,
+                    "showToggle": true,
+                    "filterAllowedCRS": [
+                        "EPSG:4326",
+                        "EPSG:3857"
+                    ],
+                    "additionalCRS": {}
+                }
+            },
+            {
+                "name": "Search",
+                "cfg": {
+                    "withToggle": [
+                        "max-width: 768px",
+                        "min-width: 768px"
+                    ]
+                }
+            },
+            {
+                "name": "FullScreen",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": false
+                    }
+                }
+            },
+            {
+                "name": "Notifications"
+            },
+            {
+                "name": "Share",
+                "cfg": {
+                    "pathTemplate": "/maps/{id}/embed"
+                }
+            },
+            {
+                "name": "Locate"
+            }
+        ],
+        "layer_edit_data_viewer": [
+            {
+                "name": "EditorLayout"
+            },
+            {
+                "name": "ActionNavbar"
+            },
+            {
+                "name": "BrandNavbar"
+            },
+            {
+                "name": "Map",
+                "cfg": {
+                    "shouldLoadFont": false,
+                    "fonts": [],
+                    "tools": [
+                        "measurement",
+                        "draw",
+                        "box"
+                    ],
+                    "mapOptions": {
+                        "openlayers": {
+                            "attribution": {
+                                "container": "#footer-attribution-container"
+                            },
+                            "interactions": {
+                                "pinchRotate": false,
+                                "altShiftDragRotate": false
+                            }
+                        }
+                    }
+                },
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            }
+        ],
+        "layer_edit_style_viewer": [
+            {
+                "name": "EditorLayout"
+            },
+            {
+                "name": "ActionNavbar"
+            },
+            {
+                "name": "BrandNavbar"
+            },
+            {
+                "name": "Map",
+                "cfg": {
+                    "shouldLoadFont": false,
+                    "fonts": [],
+                    "tools": [
+                        "measurement",
+                        "draw",
+                        "box"
+                    ],
+                    "mapOptions": {
+                        "openlayers": {
+                            "attribution": {
+                                "container": "#footer-attribution-container"
+                            },
+                            "interactions": {
+                                "pinchRotate": false,
+                                "altShiftDragRotate": false
+                            }
+                        }
+                    }
+                },
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            }
+        ],
+        "map_viewer": [
+            { "name": "EditorLayout" },
+            { "name": "ActionNavbar" },
+            { "name": "BrandNavbar" },
+            {
+                "name": "Map",
+                "cfg": {
+                    "tools": [
+                        "measurement",
+                        "draw",
+                        "box"
+                    ],
+                    "mapOptions": {
+                        "openlayers": {
+                            "attribution": {
+                                "container": "#footer-attribution-container"
+                            },
+                            "interactions": {
+                                "pinchRotate": false,
+                                "altShiftDragRotate": false
+                            }
+                        }
+                    }
+                },
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "BackgroundSelector",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "Identify",
+                "cfg": {
+                    "viewerOptions": {
+                        "container": "{context.ReactSwipe}"
+                    }
+                },
+                "override": {
+                    "Toolbar": {
+                        "position": 11,
+                        "alwaysVisible": false
+                    }
+                }
+            },
+            {
+                "name": "TOC",
+                "cfg": {
+                    "activateMetedataTool": false
+                }
+            },
+            {
+                "name": "Toolbar",
+                "id": "NavigationBar",
+                "cfg": {
+                    "id": "navigationBar",
+                    "layout": "horizontal"
+                },
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "MapLoading",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "DrawerMenu",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "OmniBar",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "Expander"
+            },
+            {
+                "name": "BurgerMenu",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "MapFooter",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1,
+                        "target": "footer"
+                    }
+                }
+            },
+            {
+                "name": "Measure"
+            },
+            {
+                "name": "Print",
+                "cfg": {
+                    "useFixedScales": true,
+                    "mapWidth": 256
+                }
+            },
+            {
+                "name": "ZoomAll",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": false
+                    }
+                }
+            },
+            {
+                "name": "ZoomIn",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "ZoomOut",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "Timeline",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "Playback"
+            },
+            {
+                "name": "LayerDownload"
+            },
+            {
+                "name": "AddLayer"
+            },
+            {
+                "name": "FilterLayer"
+            },
+            {
+                "name": "ScaleBox"
+            },
+            {
+                "name": "FeatureEditor",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "QueryPanel",
+                "cfg": {
+                    "activateQueryTool": true,
+                    "spatialOperations": [
+                        {
+                            "id": "INTERSECTS",
+                            "name": "queryform.spatialfilter.operations.intersects"
+                        },
+                        {
+                            "id": "BBOX",
+                            "name": "queryform.spatialfilter.operations.bbox"
+                        },
+                        {
+                            "id": "CONTAINS",
+                            "name": "queryform.spatialfilter.operations.contains"
+                        },
+                        {
+                            "id": "WITHIN",
+                            "name": "queryform.spatialfilter.operations.within"
+                        }
+                    ],
+                    "spatialMethodOptions": [
+                        {
+                            "id": "Viewport",
+                            "name": "queryform.spatialfilter.methods.viewport"
+                        },
+                        {
+                            "id": "BBOX",
+                            "name": "queryform.spatialfilter.methods.box"
+                        },
+                        {
+                            "id": "Circle",
+                            "name": "queryform.spatialfilter.methods.circle"
+                        },
+                        {
+                            "id": "Polygon",
+                            "name": "queryform.spatialfilter.methods.poly"
+                        }
+                    ]
+                },
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "MetadataExplorer",
+                "cfg": {
+                    "wrap": true
+                }
+            },
+            {
+                "name": "MousePosition",
+                "cfg": {
+                    "editCRS": true,
+                    "showLabels": true,
+                    "showToggle": true,
+                    "filterAllowedCRS": [
+                        "EPSG:4326",
+                        "EPSG:3857"
+                    ],
+                    "additionalCRS": {}
+                }
+            },
+            {
+                "name": "Search",
+                "cfg": {
+                    "withToggle": [
+                        "max-width: 768px",
+                        "min-width: 768px"
+                    ]
+                }
+            },
+            {
+                "name": "FullScreen",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": false
+                    }
+                }
+            },
+            {
+                "name": "TOCItemsSettings",
+                "cfg": {
+                    "hideTitleTranslations": true,
+                    "showFeatureInfoTab": false
+                },
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "Widgets",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "WidgetsTray",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "SaveAs",
+                "cfg": {
+                    "disablePermission": true
+                }
+            },
+            {
+                "name": "Notifications"
+            },
+            {
+                "name": "Share",
+                "cfg": {
+                    "pathTemplate": "/maps/{id}/embed"
+                }
+            },
+            {
+                "name": "Swipe"
+            },
+            {
+                "name": "Locate"
+            },
+            {
+                "name": "WidgetsBuilder"
+            },
+            {
+                "name": "Save",
+                "cfg": {
+                    "disablePermission": true
+                }
+            },
+            {
+                "name": "AddGroup"
+            },
+            {
+                "name": "StyleEditor",
+                "cfg": {
+                    "styleService": {
+                        "baseUrl": "{state('settings') && state('settings').geonodeUrl && state('settings').geonodeUrl + 'gs/' || '/gs/'}",
+                        "formats": [
+                            "css",
+                            "sld"
+                        ],
+                        "availableUrls": [
+                            "{state('settings') && state('settings').geoserverUrl || '/geoserver/'}",
+                            "{state('settings') && state('settings').geonodeUrl && state('settings').geonodeUrl + 'gs/' || '/gs/'}"
+                        ],
+                        "fonts": [
+                            "Arial",
+                            "Courier New",
+                            "Monospaced",
+                            "SansSerif",
+                            "Serif",
+                            "Times New Roman"
+                        ]
+                    },
+                    "editingAllowedRoles": null,
+                    "enableSetDefaultStyle": true
+                }
+            }
+        ],
+        "geostory_viewer": [
+            { "name": "EditorLayout" },
+            { "name": "ActionNavbar" },
+            { "name": "BrandNavbar" },
+            {
+                "name": "OmniBar",
+                "cfg": {
+                    "disablePluginIf": "{!!(state('browser') && state('browser').mobile)}",
+                    "containerPosition": "header",
+                    "className": "navbar shadow navbar-home"
+                },
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "BurgerMenu",
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "GeoStory",
+                "cfg": {
+                    "mediaEditorSettings": {
+                        "sourceId": "geostory",
+                        "mediaTypes": {
+                            "image": {
+                                "defaultSource": "geostory",
+                                "sources": [
+                                    "geostory",
+                                    "geonode"
+                                ]
+                            },
+                            "video": {
+                                "defaultSource": "geostory",
+                                "sources": [
+                                    "geostory",
+                                    "geonode"
+                                ]
+                            },
+                            "map": {
+                                "defaultSource": "geostory",
+                                "sources": [
+                                    "geostory",
+                                    "geonode"
+                                ]
+                            }
+                        },
+                        "sources": {
+                            "geostory": {
+                                "name": "geostory.storyResources",
+                                "type": "geostory",
+                                "addMediaEnabled": {
+                                    "image": true,
+                                    "video": true
+                                },
+                                "editMediaEnabled": {
+                                    "image": true,
+                                    "video": true
+                                },
+                                "removeMediaEnabled": {
+                                    "image": true,
+                                    "video": true,
+                                    "map": true
+                                }
+                            },
+                            "geonode": {
+                                "name": "geostory.geoNode",
+                                "type": "geonode"
+                            }
+                        }
+                    }
+                },
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "MediaEditor"
+            },
+            {
+                "name": "GeoStoryEditor",
+                "cfg": {
+                    "disablePluginIf": "{!!(state('browser') && state('browser').mobile)}",
+                    "containerPosition": "columns"
+                },
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "GeoStoryNavigation",
+                "cfg": {
+                    "containerPosition": "header"
+                },
+                "override": {
+                    "EditorLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "Notifications"
+            },
+            {
+                "name": "Save"
+            },
+            {
+                "name": "SaveAs"
+            },
+            {
+                "name": "Share"
+            }
+        ],
+        "document_viewer": [
+            { "name": "EditorLayout" },
+            { "name": "ActionNavbar" },
+            { "name": "BrandNavbar" }
         ]
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/configs/map.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/map.json
@@ -1,0 +1,83 @@
+{
+    "version": 2,
+    "map": {
+        "projection": "EPSG:900913",
+        "units": "m",
+        "center": {
+            "x": 1250000.000000,
+            "y": 5370000.000000,
+            "crs": "EPSG:900913"
+        },
+        "zoom": 5,
+        "maxExtent": [
+            -20037508.34,
+            -20037508.34,
+            20037508.34,
+            20037508.34
+        ],
+        "layers": [
+            {
+                "type": "osm",
+                "title": "Open Street Map",
+                "name": "mapnik",
+                "source": "osm",
+                "group": "background",
+                "visibility": true
+            },
+            {
+                "type": "tileprovider",
+                "title": "NASAGIBS Night 2012",
+                "provider": "NASAGIBS.ViirsEarthAtNight2012",
+                "name": "Night2012",
+                "source": "nasagibs",
+                "group": "background",
+                "visibility": false
+            },
+            {
+                "type": "tileprovider",
+                "title": "OpenTopoMap",
+                "provider": "OpenTopoMap",
+                "name": "OpenTopoMap",
+                "source": "OpenTopoMap",
+                "group": "background",
+                "visibility": false
+            },
+            {
+                "format": "image/jpeg",
+                "group": "background",
+                "name": "s2cloudless:s2cloudless",
+                "opacity": 1,
+                "title": "Sentinel 2 Cloudless",
+                "type": "wms",
+                "url": [
+                    "https://maps1.geosolutionsgroup.com/geoserver/wms",
+                    "https://maps2.geosolutionsgroup.com/geoserver/wms",
+                    "https://maps3.geosolutionsgroup.com/geoserver/wms",
+                    "https://maps4.geosolutionsgroup.com/geoserver/wms",
+                    "https://maps5.geosolutionsgroup.com/geoserver/wms",
+                    "https://maps6.geosolutionsgroup.com/geoserver/wms"
+                ],
+                "source": "s2cloudless",
+                "visibility": false,
+                "singleTile": false,
+                "credits": {
+                    "title": "<a class=\"a-light\" xmlns:dct=\"http://purl.org/dc/terms/\" href=\"https://s2maps.eu\" property=\"dct:title\">Sentinel-2 cloudless 2016</a> by <a class=\"a-light\" xmlns:cc=\"http://creativecommons.org/ns#\" href=\"https://eox.at\" property=\"cc:attributionName\" rel=\"cc:attributionURL\">EOX IT Services GmbH</a>"
+                }
+            },
+            {
+                "source": "ol",
+                "group": "background",
+                "title": "Empty Background",
+                "fixed": true,
+                "type": "empty",
+                "visibility": false,
+                "args": [
+                    "Empty Background",
+                    {
+                        "visibility": false
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/geonode_mapstore_client/client/themes/default/less/geonode.less
+++ b/geonode_mapstore_client/client/themes/default/less/geonode.less
@@ -130,3 +130,8 @@
 .page-map-viewer {
     transform: translate(0, 0);
 }
+
+#drawer-menu-button,
+#mapstore-navbar-container {
+    z-index: 1;
+}

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/viewer.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/viewer.html
@@ -1,11 +1,13 @@
 {% load static from staticfiles %}
+{% load client_lib_tags %}
 <!DOCTYPE html>
 <html>
     <head>
         <meta charset="UTF-8">
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap" rel="stylesheet">
+        <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Lato&display=swap" rel="stylesheet">
         <title>{{ SITE_NAME }}</title>
         <link rel="shortcut icon" href="{% static 'geonode/img/favicon.ico' %}" />
         <style>
@@ -65,10 +67,22 @@
                 }
             }
         </style>
+
+        <style>
+            #ms-container {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                z-index: 99999;
+                background-color: #fff;
+            }
+        </style>
     </head>
     <body>
-        {% include './geonode-mapstore-client/_geonode_config.html' %}
-        <div id="container">
+        {% include './_geonode_config.html' %}
+        <div id="ms-container" class="ms2">
             <div class="gn-main-loader-container">
                 <div class="gn-main-loader-content">
                     <div class="gn-main-loader"></div>
@@ -76,6 +90,6 @@
                 </div>
             </div>
         </div>
-        <script id="gn-script" src="{% static 'mapstore/dist/gn-home.js' %}"></script>
+        <script id="gn-script" src="{% static 'mapstore/dist/gn-viewer.js' %}"></script>
     </body>
 </html>


### PR DESCRIPTION
This PR introduces the basic wireframe structure for the viewers using an SPA and the GeoNode API V2.
The new paths are:

- `/viewer/#/document/:pk` viewer or editor with general functionalities for document resource
- `/viewer/#/layer/:pk` viewer or editor with general functionalities for layer resource
- `/viewer/#/layer/:pk/edit/data/` specific editor for layer attributes
- `/viewer/#/layer/:pk/edit/style/` specific editor for layer styles
- `/viewer/#/map/:pk` viewer or editor with general functionalities for map resource
- `/viewer/#/geostory/:pk` viewer or editor with general functionalities for geostory app resource

This viewers are working with a new bundle called gn-viewer.
Currently the paths are connected to the homepage through the detail panel only in development environment.
