### PR TITLE
[Backport 2.1.x][Fixes #135] Refactor how resource permissions are set inside the mapstore client context

### DIFF
--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -20,7 +20,7 @@
             {% endif %}
             isNewResource: {{ is_new_resource|default:'false'|safe }},
             isEmbed: {{ is_embed|default:'false'|safe }},
-            permissionsList: {{ perms_list|default:'[]' }},
+            perms: {{ perms_list|default:'[]' }},
             pluginsConfigKey: '{{ plugins_config_key|default:"" }}',
             userDetails: username && token && {
                 user: {


### PR DESCRIPTION
Changes `__GEONODE_CONFIG__.permissionsList` to `__GEONODE_CONFIG__.perms`