### PR TITLE
[Fixes #168] Responses do not include URLs for each resource in GeoNode v2 api for geostories

### DIFF
--- a/mapstore2_adapter/geoapps/geostories/api/serializers.py
+++ b/mapstore2_adapter/geoapps/geostories/api/serializers.py
@@ -67,6 +67,7 @@ class GeoStorySerializer(ResourceBaseSerializer):
     class Meta:
         model = GeoStory
         name = 'geostory'
+        view_name = 'geostories-list'
         fields = (
             'pk', 'uuid', 'app_type',
             'zoom', 'projection', 'center_x', 'center_y',

--- a/mapstore2_adapter/geoapps/geostories/api/urls.py
+++ b/mapstore2_adapter/geoapps/geostories/api/urls.py
@@ -23,7 +23,7 @@ from geonode.api.urls import router
 
 from mapstore2_adapter.geoapps.geostories.api import views
 
-router.register(r'geostories', views.GeoStoryViewSet)
+router.register(r'geostories', views.GeoStoryViewSet, 'geostories')
 
 urlpatterns = [
     url(r'^api/v2/', include(router.urls)),


### PR DESCRIPTION
References #168