### PR TITLE
Fix text overflow for resources cards in grid layout 

### DIFF
--- a/geonode_mapstore_client/client/js/components/home/ResourceCard.jsx
+++ b/geonode_mapstore_client/client/js/components/home/ResourceCard.jsx
@@ -32,7 +32,7 @@ const ResourceCard = forwardRef(({
     return (
         <Card
             ref={ref}
-            className={`gn-resource-card${active ? ' active' : ''} ${layoutCardsStyle === 'list' ? 'rounded-0' : ''}`}
+            className={`gn-resource-card${active ? ' active' : ''} gn-card-type-${layoutCardsStyle} ${layoutCardsStyle === 'list' ? 'rounded-0' : ''}`}
         >
             <a
                 className="gn-resource-card-link"

--- a/geonode_mapstore_client/client/themes/geonode/scss/_resource-card.scss
+++ b/geonode_mapstore_client/client/themes/geonode/scss/_resource-card.scss
@@ -46,6 +46,8 @@
         position: relative;
         pointer-events: none;
         z-index: 2;
+    }
+    &.gn-card-type-list .card-body {
         width: 20vw;
     }
     .card-img-top {


### PR DESCRIPTION
There was a regression on text overflow on resource cards when they were in grid layout and this PR fixes it