### PR TITLE
[Backport 2.1.x] [Fixes #189]: A hash is needed for gn-xxx.js links otherwise browsers load stale code

### DIFF
--- a/geonode_mapstore_client/templates/geonode-mapstore-client/app/geostory.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/app/geostory.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load client_version %}
 
 {% include '../_geonode_config.html' with is_embed=is_embed is_app=True plugins_config_key=plugins_config_key|default:'geostory' is_new_resource=is_new|default:'true' %}
-<script id="ms2-api" src="{% static 'mapstore/dist/gn-geostory.js' %}"></script>
+<script id="ms2-api" src="{% static 'mapstore/dist/gn-geostory.js' %}?{% client_version %}"></script>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_embed.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_embed.html
@@ -1,5 +1,6 @@
 {% load static from staticfiles %}
 {% load client_lib_tags %}
+{% load client_version %}
 <!DOCTYPE html>
 <html>
     <head>
@@ -96,6 +97,6 @@
                 </div>
             </div>
         </div>
-        <script id="gn-script" src="/static/mapstore/dist/gn-map.js"></script>
+        <script id="gn-script" src="{% static 'mapstore/dist/gn-map.js' %}?{% client_version %}"></script>
     </body>
 </html>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/map_edit.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/map_edit.html
@@ -1,4 +1,5 @@
-
+{% load static %}
+{% load client_version %}
 <style>
     .gn-main-loader-container {
         position: absolute;
@@ -85,5 +86,5 @@
         </div>
     </div>
 </div>
-<script id="gn-script" src="/static/mapstore/dist/gn-map.js"></script>
+<script id="gn-script" src="{% static 'mapstore/dist/gn-map.js' %}?{% client_version %}"></script>
 {% endblock %}

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/map_embed.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/map_embed.html
@@ -1,5 +1,6 @@
 {% load static from staticfiles %}
 {% load client_lib_tags %}
+{% load client_version %}
 <!DOCTYPE html>
 <html>
     <head>
@@ -90,6 +91,6 @@
                 </div>
             </div>
         </div>
-        <script id="gn-script" src="/static/mapstore/dist/gn-map.js"></script>
+        <script id="gn-script" src="{% static 'mapstore/dist/gn-map.js' %}?{% client_version %}"></script>
     </body>
 </html>

--- a/geonode_mapstore_client/templatetags/client_version.py
+++ b/geonode_mapstore_client/templatetags/client_version.py
@@ -1,0 +1,23 @@
+import os
+import logging
+
+from django import template
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+register = template.Library()
+
+
+@register.simple_tag
+def client_version():
+    try:
+        file_path = os.path.join(
+            settings.STATIC_ROOT,
+            'mapstore/version.txt'
+        )
+        with open(file_path, 'r') as f:
+            version = f.read()
+        return version
+    except Exception as e:
+        logger.error(e)
+        return ''


### PR DESCRIPTION
References  #189]