### PR TITLE
Check how to extend the supported languages beyond MapStore's default ones #217

### DIFF
--- a/geonode_mapstore_client/client/copyUnsupportedLocales.js
+++ b/geonode_mapstore_client/client/copyUnsupportedLocales.js
@@ -1,0 +1,18 @@
+// copyfile.js
+const fs = require('fs');
+
+// destination will be created or overwritten by default.
+
+const unsupportedTranslationsPath = "./static/mapstore/unsupported_translations/";
+const mapStoreTranslationPath = "./node_modules/mapstore/web/client/translations/";
+const files = fs.readdirSync(unsupportedTranslationsPath);
+
+
+files.forEach((file) => {
+    fs.copyFile(`${unsupportedTranslationsPath}${file}`, `${mapStoreTranslationPath}${file}`, (err) => {
+        if (err) throw err;
+        console.log(`File ${file} from ${unsupportedTranslationsPath} was copied to destination ${mapStoreTranslationPath}`);
+    });
+});
+
+

--- a/geonode_mapstore_client/client/js/utils/AppUtils.js
+++ b/geonode_mapstore_client/client/js/utils/AppUtils.js
@@ -24,6 +24,7 @@ import { mapSelector } from '@mapstore/framework/selectors/map';
 import isArray from 'lodash/isArray';
 import isObject from 'lodash/isObject';
 import isString from 'lodash/isString';
+import { addLocaleData } from 'react-intl';
 
 import url from 'url';
 import axios from '@mapstore/framework/libs/ajax';
@@ -36,6 +37,19 @@ export function getVersion() {
     }
     return 'dev';
 }
+
+export const loadLanguage = (code) => { addLocaleData(require(`react-intl/locale-data/${code}`));};
+
+export const supportedLocalesKeys = {"en": "en", "es": "es", "fr": "fr", "it": "it", "de": "de"};
+
+export const checkAndLoadUnSupportedLocales = (languageConfig = {}) => {
+    const languageKeys = Object.keys(languageConfig);
+    languageKeys.forEach((key) => {
+        if (!supportedLocalesKeys[key]) {
+            loadLanguage(key);
+        }
+    });
+};
 
 export function initializeApp() {
 
@@ -109,6 +123,7 @@ export function setupConfiguration({
     );
     const supportedLocales = defaultSupportedLocales || getSupportedLocales();
     setSupportedLocales(supportedLocales);
+    checkAndLoadUnSupportedLocales(supportedLocales);
     const locale = supportedLocales[geoNodePageConfig.languageCode]?.code;
     setConfigProp('locale', locale);
     const geoNodeResourcesInfo = getConfigProp('geoNodeResourcesInfo') || {};

--- a/geonode_mapstore_client/client/package.json
+++ b/geonode_mapstore_client/client/package.json
@@ -22,7 +22,8 @@
     "test": "mapstore-project test geonode",
     "test:watch": "mapstore-project test:watch geonode",
     "update-project": "mapstore-project update geonode",
-    "lint": "eslint js --ext .jsx,.js"
+    "lint": "eslint js --ext .jsx,.js",
+    "compileLocales": "node copyUnsupportedLocales.js"
   },
   "author": "GeoSolutions",
   "license": "BSD-2-Clause",

--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -183,6 +183,10 @@
         "es": {
             "code": "es-ES",
             "description": "Español"
+        },
+        "ar": {
+            "code": "ar",
+            "description": "Arabic"
         }
     },
     "geoNodeConfiguration": {

--- a/geonode_mapstore_client/client/static/mapstore/unsupported_translations/data.ar.json
+++ b/geonode_mapstore_client/client/static/mapstore/unsupported_translations/data.ar.json
@@ -1,0 +1,3338 @@
+{
+    "locale": "ar",
+    "messages": {
+        "Language": "Sprache",
+        "msgId0": "{name} machte {numPhotos, plural, =0 {keine Fotos} =1 {ein Foto} other {# Fotos}} am {takenDate, date, long}.",
+        "htmlTest": "{name} {surname}",
+        "about_title": "Über",
+        "aboutLbl": "Über",
+        "about_p0-0": "MapStore ist ein Framework zur Erstellung von webbasierten Karten-Anwendungen mit Standard-Karten-Bibliotheken wie",
+        "about_p0-1": "und",
+        "about_p1": "Für MapStore gibt es verschiedene Beispiel Anwendungen:",
+        "about_ul0_li0": "MapViewer ist ein einfache Anwendung zur Ansicht von vorkonfigurierten Karten (die optional in einer Datenbank mittels GeoStore gespeichert werden können)",
+        "about_ul0_li1": "MapPublisher wurde entwickelt, um auf einfache und intuitive Weise Karten und Mashups zu erstellen, zu speichern und zu teilen, die auf Inhalten von bekannten Quellen wie Google Maps und OpenStreetMap oder von Diensten die auf offenen Protokollen wie OGC WMS, WFS, WMTS or TMS und so weiter basieren. Für mehr Informationen siehe die",
+        "about_h20": "Lizenz",
+        "about_p3": "MapStore ist kostenlos und Open Source, basierend auf OpenLayers, Leaflet und ReactJS und ist unter der vereinfachten BSD Lizenz lizenziert.",
+        "about_p5-0": "Für mehr Informationen siehe",
+        "about_a0": "diese",
+        "about_p5-1": "Seite.",
+        "about_h21": "Quellen",
+        "about_p6": "MapStore wird entwickelt von:",
+        "enable": "Aktiviere",
+        "layers": "Ebenen",
+        "warning": "Warnung",
+        "errorTitleDefault": "Fehler",
+        "errorDefault": "Ein Fehler ist aufgetreten",
+        "pageInfoShowMore": "Ergebnisse {count} von {total}",
+        "showMore": "Zeig mehr...",
+        "collapse": "Zuklappen",
+        "Links": "Links",
+        "Forbidden": "Verboten",
+        "layerNameChangeError": {
+            "title": "Namensänderungsfehler",
+            "message": "Die Ebene konnte nicht mit einem geänderten Namen neu geladen werden"
+        },
+        "expand": "Ausklappen",
+        "version": {
+            "label": "Version"
+        },
+        "errorPage": {
+            "title":"Ups, etwas ist schief gelaufen",
+            "subtitle":"Klicken Sie auf das Symbol unten, um MapStore neu zu laden",
+            "description":"Wenn Sie diesen Fehler melden möchten, können Sie eine E-Mail an unsere Mailingliste senden",
+            "descriptionAdmin":"Bitte wenden Sie sich an den Administrator"
+        },
+        "autorefresh": {
+            "of": "of",
+            "updating": "Updating...",
+            "layers": "layers"
+        },
+        "localeErrors": {
+            "404": "Übersetzungsdatei nicht gefunden"
+        },
+        "details": {
+            "title": "Infos zu dieser Karte"
+        },
+        "showEmptyMessageGFI": "Nachricht mit leeren Ergebnissen anzeigen",
+        "remove": "Löschen",
+        "removeThumbnail": "Miniaturbild entfernen",
+        "layerProperties": {
+            "windowTitle": "Ebenen Eigenschaften",
+            "title": "Titel",
+            "name": "Name",
+            "group": "Gruppe",
+            "description": "Beschreibung",
+            "general": "Generell",
+            "display": "Darstellung",
+            "style": "Stil",
+            "transparent": "Transparent",
+            "singleTile": "Single Tile",
+            "cached": "Verwenden Sie Cache-Optionen",
+            "styleCustom": "Stil \"{value}\" nutzen",
+            "styleListLoadError": "Es gab einen Fehler beim Laden der Liste von Stilen",
+            "stylesRefreshList": "Aktualisiere die Liste von Stilen",
+            "delete": "Löschen",
+            "deleteLayer":"Ebene löschen",
+            "deleteLayerMessage": "Möchten Sie diese Ebene wirklich löschen?",
+            "deleteLayerGroup":"Gruppe löschen",
+            "deleteLayerGroupMessage": "Möchten Sie diese Gruppe und alle ihre Ebenen wirklich löschen?",
+            "confirmDelete": "Sind Sie sicher?",
+            "featureTypeError": "Layerattribute können nicht geladen werden",
+            "featureTypeErrorInvalidJSON": "Layerattribute können nicht geladen werden. Antwort ist nicht gültig",
+            "elevation": "Höhe",
+            "titleTranslations": "Titel Übersetzungen",
+            "groupProperties": "Gruppeneigenschaften",
+            "featureInfo": "Feature Info",
+            "featureInfoFormatLbl": "Antwortformat festlegen",
+            "legenderror": "Legende ist nicht verfügbar",
+            "editCustomFormat": "Bearbeiten Sie das benutzerdefinierte Format",
+            "exampleOfResponse": "Beispiel",
+            "changedSettings": "Geänderte Einstellungen",
+            "changedSettingsAlert": "Sie schließen das Einstellungsfenster, ohne Ihre Änderungen zu speichern",
+            "textFormatTitle": "TEXT",
+            "textFormatDescription": "Zeigt Feature-Info-Ergebnisse als Nur-Text an",
+            "htmlFormatTitle": "HTML",
+            "htmlFormatDescription": "Zeigt Feature-Info-Ergebnisse als HTML an",
+            "propertiesFormatTitle": "EIGENSCHAFTEN",
+            "propertiesFormatDescription": "Zeigt Feature-Info-Ergebnisse als Eigenschaftsliste an",
+            "templateFormatTitle": "TEMPLATE",
+            "templateFormatDescription": "Passen Sie das Ergebnis der Feature-Informationen an",
+            "hideFormatTitle": "IDENTIFIZIERUNG DEAKTIVIEREN",
+            "hideFormatDescription": "Deaktivieren Sie die Funktionsinformationen für diese Ebene",
+            "styleWarning": "Ebenenstil-Editor für Geometrietyp '{geometryType}' wird nicht unterstützt.",
+            "templateFormatInfoAlert1": "Klicken Sie auf Bearbeiten, um eine neue Vorlage hinzuzufügen.",
+            "templateFormatInfoAlert2": "Verwenden Sie ${ attribute }, um Attribut-Werte anzuzeigen",
+            "templateFormatInfoAlertExample": "Die ID des Features lautet ${ properties }",
+            "templatePreview": "Vorschau template",
+            "visibilityLimits": {
+                "title": "Sichtbarkeitsgrenzen",
+                "serverValuesUpdateUndefined": "Der Server hat keine Skalierungssichtbarkeitsbeschränkungen für diese Ebene angegeben",
+                "serverValuesUpdate": "Der Server hat für diese Ebene minimale und maximale Sichtbarkeitsgrenzen für die Skalierung angegeben",
+                "serverValuesUpdateMinScale": "Der Server hat für diese Ebene nur eine minimale Sichtbarkeitsgrenze für die Skalierung angegeben",
+                "serverValuesUpdateMaxScale": "Der Server hat nur die maximale Sichtbarkeitsgrenze für diese Ebene angegeben",
+                "rangeError": "Der Minimalwert ist größer als der Maximalwert. Bitte geben Sie einen Bereich an, in dem der Maximalwert größer als der Minimalwert ist",
+                "serverValuesError": "Es ist nicht möglich, minimale und maximale Sichtbarkeitsbeschränkungen für den Server anzufordern. Wahrscheinlich aufgrund eines Fehlers in der Netzwerkverbindung oder eines fehlenden Funktionsendpunkts",
+                "updateWMSCapabilities": "Minimale und maximale Sichtbarkeitsbeschränkungen für den Server anfordern",
+                "maxValue": "Maximaler Wert (ausgeschlossen)",
+                "maxValuePlaceholder": "Maximalwert auswählen",
+                "valueNoResultsText": "Keine Optionen stimmen mit dem Eingabewert überein",
+                "createOption": "Neuen Wert hinzufügen {label}",
+                "minValue": "Mindestwert (enthalten)",
+                "minValuePlaceholder": "Mindestwert auswählen",
+                "type": "Limits Typ",
+                "scale": "Maßstab",
+                "resolution": "Auflösung"
+            },
+            "tooltip": {
+                "label": "QuickInfo",
+                "title": "Titel",
+                "description": "Beschreibung",
+                "both": "Titel und Beschreibung",
+                "none": "Kein Tooltip",
+                "labelPlacement": "Platzierung",
+                "right": "Recht",
+                "left": "Links",
+                "bottom": "Bottom",
+                "top": "Oben",
+                "editLayerName": "Layernamen bearbeiten",
+                "confirmLayerName": "Bestätigen Sie die Änderung des Ebenennamens"
+            },
+            "legendOptions": {
+              "title": "Legende",
+              "legendWidth": "Breite",
+              "legendHeight": "Höhe",
+              "legendPreview": "Vorschau"
+            },
+            "enableLocalizedLayerStyles": {
+                "label": "Lokalisierten Stil aktivieren",
+                "tooltip": "Hinweis: Diese Einstellung benötigt spezifische Konfigurationen im GeoServer"
+            },
+            "format": {
+                "title": "Format",
+                "refresh": "Unterstütztes Format abrufen",
+                "loading": "Wird geladen...",
+                "noOption": "Keine Option",
+                "error": {
+                    "title": "Error",
+                    "message": "Format konnte nicht abgerufen werden"
+                }
+            }
+        },
+        "longitude": "Lon",
+        "latitude": "Lat",
+        "notification": {
+            "update": "Aktualisierung",
+            "warning": "Warnung",
+            "success": "Erfolg",
+            "backgroundLayerNotSupported": "Der zuvor gewählte Hintergrund wird nicht für diese Art von Karte unterstützt. Der erste verfügbare wird alternativ verwendet.",
+            "noBackgroundLayerSupported": "Es gibt keine unterstützten Hintergrundebenen für diese Art von Karte.",
+            "updateOldMap": "Dies ist eine alte Karte, daher können nicht alle Funktionen aktiviert werden. Klicken Sie auf die Schaltfläche Aktualisieren, um die Karte zu aktualisieren, oder schließen Sie diese Benachrichtigung einfach, wenn Sie sie nicht aktualisieren möchten.",
+            "warningSaveUpdatedMap": "Einige Ebenen wurden nicht korrekt aktualisiert",
+            "saveUpdatedMap": "Alle Ebenen wurden erfolgreich aktualisiert",
+            "incompatibleBackgroundAndProjection":"Die von Ihnen ausgewählte Projektion ist nicht mit der Hintergrundkarte kompatibel. Wechseln Sie zu einer kompatiblen oder leeren Hintergrundkarte und wählen Sie danach diese Projektion aus!",
+            "incompatibleDataAndProjection":"Die aktuellen Ebenen und die Kartenprojektion sind nicht vollständig kompatibel. Teile oder alle Daten werden möglicherweise nicht auf der Karte angezeigt"
+        },
+        "dock": {
+            "row": "{rowsSelected}. Zeile ausgewählt",
+            "rows": "{rowsSelected} Zeilen ausgewählt"
+        },
+        "globeswitcher": {
+            "tooltipDeactivate": "Beenden Sie den 3D-Modus",
+            "tooltipActivate": "Starten Sie den 3D-Modus"
+        },
+        "cookie":{
+            "info": "Diese Webseite verwendet Cookies damit Sie diese einwandfrei nutzen können. Wir gehen davon aus, dass sie damit einverstanden sind, andernfalls können Sie die Webseite verlassen.",
+            "moreDetailsButton": "Mehr Details",
+            "leave": "Verlassen",
+            "accept": "Annehmen"
+        },
+        "background": "Hintergrund",
+        "language": "Sprache",
+        "mousePositionCoordinates": "Koordinatenanzeige",
+        "mouseCoordinates": "Koordinaten:",
+        "mousePositionCRS": "KBS:",
+        "mousePositionElevation": "Höhe:",
+        "mousePositionNoElevation": "N/v",
+        "elevationLoading": "Wird geladen...",
+        "elevationLoadingError": "Fehler",
+        "elevationNotAvailable": "N/v",
+        "mapScale": "Maßstab:",
+        "showMousePositionCoordinates": "Koordinaten anzeigen/ausblenden",
+        "showCrsSelector": "Wähle Projektion",
+        "crsSelectorFilterPlaceholder": "Projektionen filtern",
+        "crsSelectorSelectedCRS": "Ausgewählt:",
+        "menu": "Menü",
+        "options": "Optionen",
+        "settings": "Einstellungen",
+        "help": "Hilfe",
+        "docs": "Dokumentation",
+        "gohome": "Zurück zur Startseite",
+        "back": "Zurück zum Import",
+        "printbutton": "Drucken",
+        "annotationsbutton": "Notizen / Zeichnen",
+        "noresultfound": "Keine Ergebnisse gefunden",
+        "save": "Speichern",
+        "saveAs": "Speichern als...",
+        "opacity": "Deckkraft",
+        "elevation": "Höhe",
+        "close": "Schliessen",
+        "cancel": "Abbrechen",
+        "no": "Nein",
+        "yes": "Ja",
+        "confirm": "Bestätigen",
+        "confirmTitle": "Können Sie das bestätigen?",
+        "pageInfo": "{total, plural, =0 {Keine Artikel} =1 {{total} Artikel von {total}} other {Artikel {start}-{end} von {total}}}",
+        "loading": "Wird geladen...",
+        "group": "Gruppe",
+        "groups": "Gruppen",
+        "permission": "Genehmigung",
+        "permissions": "Genehmigungen",
+        "global": {
+            "colors": {
+                "red": "{number, plural, =0 {Rot} =1 {Rot} other {Rottöne}}",
+                "blue": "{number, plural, =0 {Blau} =1 {Blau} other {Blau}}",
+                "green": "{number, plural, =0 {Grün} =1 {Grün} other {Grüns}}",
+                "gray": "{number, plural, =0 {Grau} =1 {Grau} other {Grau}}",
+                "jet": "{number, plural, =0 {Jet} =1 {Jet} other {Jet}}",
+                "brown": "{number, plural, =0 {Braun} =1 {Braun} other {Braun}}",
+                "purple": "{number, plural, =0 {Lila} =1 {Lila} other {Purpur}}",
+                "random": "{number, plural, =0 {Zufällig} =1 {Zufällig} other {Zufällig}}",
+                "orrd":"OrRd",
+                "pubu":"PuBu",
+                "bupu":"BuPu",
+                "oranges":"Oranges",
+                "bugn":"BuGn",
+                "ylorbr":"YlOrBr",
+                "ylgn":"YlGn",
+                "reds":"Reds",
+                "rdpu":"RdPu",
+                "greens":"Greens",
+                "ylgnbu":"YlGnBu",
+                "purples":"Purples",
+                "gnbu":"GnBu",
+                "greys":"Greys",
+                "ylorrd":"YlOrRd",
+                "purd":"PuRd",
+                "blues":"Blues",
+                "pubugn":"PuBuGn",
+                "viridis":"Viridis",
+                "spectral":"Spectral",
+                "rdylgn":"RdYlGn",
+                "rdbu":"RdBu",
+                "piyg":"PiYg",
+                "prgn":"PrGn",
+                "rdylbu":"RdYlBu",
+                "brbg":"BrBg",
+                "rdgy":"RdGy",
+                "puor":"PuOr",
+                "set2":"Set 2",
+                "accent":"Accent",
+                "set1":"Set 1",
+                "set3":"Set 3",
+                "dark2":"Dark 2",
+                "paired":"Paired",
+                "pastel2":"Pastel 2",
+                "pastel1":"Pastel 1",
+                "custom": "Custom"
+            }
+        },
+        "home":{
+            "open": "Öffnen",
+            "shortDescription": "Modern webmapping mit OpenLayers, Leaflet und React<br/><small>besuchen sie die <a href=\"https://mapstore.readthedocs.io/en/latest/\">dokumentationsseite</a></small>",
+            "forkMeOnGitHub": "Fork me on GitHub",
+            "description": "MapStore wurde entwickelt, um auf einfache und intuitive Weise Karten und Mashups zu erstellen, zu speichern und zu teilen die auf Inhalten von bekannten Quellen wie Google Maps und OpenStreetMap oder von Diensten die auf offenen Protokollen wie OGC WMS, WFS, WMTS or TMS und so weiter basieren.<br/>Besuche die <a href=\"https://mapstore.readthedocs.io/en/latest/\">Homepage</a> für mehr Details.",
+            "Applications": "Anwendungen",
+            "Examples": "Beispiele",
+            "LinkedinGroup": "Mapstore Linkedin Gruppe",
+            "scrollTop": "An den Anfang der Seite scrollen",
+            "footerDescription": "<strong>GeoSolutions</strong> <a href=\"mailto:info@geosolutionsgroup.com\">info@geosolutionsgroup.com</a> <strong>US</strong> +1 (301) 337-7055 -  <strong>Italy</strong>: +39 0584 962313",
+            "ml": {
+                "title": "Bleibe in Verbindung und auf dem Laufenden mit der Mailing Liste",
+                "subscribe_users": "Abonniere die Benutzer Mailing Liste",
+                "subscribe_devel": "Abonniere die Entwickler Mailing Liste",
+                "visit_group": "Besuche diese Gruppe",
+                "subscribe": "Abonnieren",
+                "email": "Email:"
+            },
+            "examples":{
+                "viewer":{
+                    "html":"<h3>Viewer</h3><p>Einfacher Viewer</p>"
+                },
+                "3dviewer":{
+                    "html":"<h3>3D Viewer</h3><p>Einfacher CesiumJS basierter 3D Viewer</p>"
+                },
+                "manager":{
+                    "html":"<h3>Manager</h3><p>MapStore Karten durchsuchen</p>"
+                },
+                "mouseposition":{
+                    "html":"<h3>Maus Position</h3><p>Kundenspezifische Beispiele</p>"
+                },
+                "scalebar":{
+                    "html":"<h3>Scale Control</h3><p>Kundenspezifische Beispiele</p>"
+                },
+                "layertree":{
+                    "html":"<h3>Erweiterter Ebenen-Baum</h3><p>Kundenspezifische Beispiele</p>"
+                },
+                "queryform":{
+                    "html":"<h3>Query Builder</h3><p>Kundenspezifische Beispiele</p>"
+                },
+                "featuregrid":{
+                    "html":"<h3>Feature Editor</h3><p>Kundenspezifische Beispiele</p>"
+                },
+                "print":{
+                    "html":"<h3>Drucken</h3><p>Kundenspezifische Beispiele</p>"
+                },
+                "plugins":{
+                    "html":"<h3>Plugins</h3><p>Erstelle deine eigene Anwendung</p>"
+                },
+                "api":{
+                    "html":"<h3>API</h3><p>Verwenden Sie APIs, um eine MapStore-Karte in Ihre Anwendung aufzunehmen</p>"
+                },
+                "rasterstyler":{
+                    "html":"<h3>Raster Styler</h3><p>Style deine Rasterebene</p>"
+                }
+            }
+        },
+        "cookiesPolicyNotification": {
+            "title": "Diese Webseite verwendet Cookies",
+            "message": "Wenn Sie unsere Website weiterhin nutzen, akzeptieren Sie die Verwendung von Cookies.",
+            "confirm": "Ich stimme zu"
+        },
+        "manager": {
+            "openInANewTab":"Karte öffnen",
+            "deleteMap":"Karte löschen",
+            "deleteMapMessage": "Möchten Sie diese Karte wirklich löschen?",
+            "editMapMetadata":"Bearbeite die Eigenschaften der Karte",
+            "mapTypes_combo": "Wähle einen Karten-Viewer: ",
+            "theme_combo": "Thema wählen:",
+            "maps_title": "Karten",
+            "locales_combo": "Sprache:",
+            "featuredMaps": "Empfohlene Karten"
+        },
+        "newMap": "Neue Karte",
+        "newMapEmpty": "Leere Karte",
+        "newMapContext": "Bestehender Kontext",
+        "maps": {
+            "title": "Karten",
+            "addToFeaturedMaps": "Zu den vorgestellten Karten hinzufügen",
+            "removeFromFeaturedMaps": "Entfernen Sie von den vorgestellten Karten",
+            "feedback": {
+                "noDetailsAvailable": "Kartendetails nicht verfügbar",
+                "successSavedMap": "Die Karte wurde korrekt erstellt",
+                "errorDeletingMap": "Fehler beim Löschen dieser Map",
+                "errorDeletingThumbnailOfMap": "Fehler beim Löschen der Miniaturansicht für diese Karte",
+                "errorDeletingDetailsOfMap": "Fehler beim Löschen von Details für diese Map",
+                "allResDeleted": "Alle dieser Karte zugeordneten Ressourcen wurden erfolgreich gelöscht",
+                "errorFetchingDetailsOfMap": "Fehler beim Abrufen von Details für diese Karte",
+                "details": {
+                    "deletedSuccesfully": "Die Details wurden korrekt entfernt",
+                    "savedSuccesfully": "Die Details wurden korrekt entfernt",
+                    "updatedSuccesfully": "Die Details wurden korrekt aktualisiert"
+                },
+                "thumbnail": {
+                    "deletedSuccesfully": "Das Vorschaubild wurde korrekt entfernt",
+                    "savedSuccesfully": "Das Vorschaubild wurde korrekt entfernt",
+                    "updatedSuccesfully": "Das Thumbnail wurde korrekt aktualisiert"
+                },
+                "errorWhenSaving": "Beim Speichern ist ein Fehler aufgetreten",
+                "errorWhenUpdating": "Während des Aktualisierungsprozesses ist ein Fehler aufgetreten",
+                "errorWhenDeleting": "Beim Löschen ist ein Fehler aufgetreten",
+                "errorSizeExceeded": "Bitte verkleinern Sie die Größe der Details oder die Qualität der Bilder",
+                "errorLoadingContexts": "Beim Laden der Kontexte ist ein Fehler aufgetreten"
+            },
+            "search": "Suche..."
+        },
+        "resources": {
+            "successSaved": "Diese Ressource wurde korrekt gespeichert",
+            "savingError": "Beim Speichern der Ressource ist ein Fehler aufgetreten",
+            "deleteConfirmTitle": "Sind Sie sicher",
+            "deleteConfirmMessage": "Möchten Sie diese Ressource wirklich löschen?",
+            "deleteConfirmButtonText": "Löschen",
+            "deleteCancelButtonText": "Schließen",
+            "resource": {
+                "deleteResource": "Löschen",
+                "editResource": "Eigenschaften bearbeiten",
+                "editResourceData": "Ressourcendaten bearbeiten",
+                "addToFeatured": "Zu Beworbenen hinzufügen",
+                "removeFromFeatured": "Von Beworbenen entfernen",
+                "showDetails": "Details anzeigen"
+            },
+            "contents": {
+                "title": "Inhalt"
+            },
+            "dashboards": {
+                "newDashboard": "Neues Dashboard",
+                "title": "Dashboards ({count})",
+                "titleNoCount": "Dashboards",
+                "create": "Dashboard erstellen",
+                "noDashboardAvailable": "Kein Dashboard verfügbar",
+                "createANewOne": "Erstelle ein neues",
+                "deleteError": "Beim Löschen der Ressource ist ein Fehler aufgetreten",
+                "errorLoadingDashboards": "Beim Laden von Dashboards ist ein Fehler aufgetreten"
+            },
+            "maps": {
+                "title": "Karten ({count})",
+                "noMapAvailable": "Keine Karte verfügbar",
+                "createNewOne": "Erstelle ein neues",
+                "unsavedMapConfirmTitle": "Nicht gespeicherte Änderungen",
+                "unsavedMapConfirmMessage": "Möchten Sie nicht gespeicherte Änderungen wirklich verwerfen?",
+                "unsavedMapConfirmButtonText": "Verwerfen",
+                "unsavedMapCancelButtonText": "Schließen"
+            },
+            "geostories": {
+                "newGeostory": "Neue GeoStory",
+                "title": "GeoStories ({count})",
+                "titleNoCount": "GeoStories",
+                "create": "GeoStory erstellen",
+                "noGeostoryAvailable": "Kein GeoStory verfügbar",
+                "createANewOne": "Erstelle eine neue",
+                "deleteError": "Beim Löschen der GeoStory ist ein Fehler aufgetreten",
+                "errorLoadingGeostories": "Beim Laden von GeoStories ist ein Fehler aufgetreten"
+            }
+        },
+        "map": {
+            "errorLoadingFont": "Die Schriftfamilie {family} ist nicht korrekt geladen. Einige Elemente (wie Symbole in Markern) können zu Darstellungsproblemen führen",
+            "loading": "Wird geladen...",
+            "loadingSpinner": "Karte wird geladen",
+            "loadingerror": "Fehler während des Ladens",
+            "name": "Name",
+            "description": "Beschreibung",
+            "namePlaceholder": "Karten Name",
+            "descriptionPlaceholder": "Karten Beschreibung",
+            "saveTitle": "Karte speichern",
+            "saveText": "Aktuelle Karte speichern?",
+            "thumbnail": "Thumbnail",
+            "message": "Ein Bild klicken oder hierherbewegen",
+            "suggestion": "(möglichst 300px X 180px, max 500kb)",
+            "errorFormat": "Unterstützte Formate: png/jpg",
+            "errorSize": "Maximal zulässige Größe: 500kb",
+            "errorCustomSize": "Maximal zulässige Größe: {maxFileSize}",
+            "error": "Das bereitgestellte Bild ist ungültig",
+            "savedMapTitle": "Gespeicherte Karte",
+            "savedMapMessage": "Karte wurde korrekt gespeichert",
+            "thumbnailError": {
+                "error403": "Sie haben keine Berechtigung um Thumbnails hochzuladen",
+                "error404": "Es gab einen Fehler während der Erstellung des Thumbnails",
+                "error409": "Ein Thumbnail mit diesem Namen existiert bereits",
+                "errorDefault": "Netzwerk Fehler"
+            },
+            "mapError": {
+                "errorTitle": "Aktuelle Karte kann nicht gespeichert werden",
+                "error403": "Sie haben keine Berechtigung die Karte zu aktualisieren",
+                "error404": "Es gab einen Fehler während der Erstellung der Karte",
+                "error409": "Eine Ressource mit diesem Namen ist bereits vorhanden",
+                "error500": "Interner Serverfehler. Überprüfen Sie, ob die Größe der Kartenkonfigurationsdatei den festgelegten Grenzwert überschreitet",
+                "errorDefault": "Netzwerk Fehler"
+            },
+            "permissions": {
+                "noRules": "Keine Regeln",
+                "addRule": "Füge eine Regel hinzu...",
+                "selectGroup": "Wähle eine Gruppe...",
+                "canView": "kann ansehen",
+                "canWrite": "kann bearbeiten",
+                "noResult": "Keine Ergebnisse gefunden",
+                "title": "Gruppen Berechtigungen"
+            },
+            "details": {
+                "back": "Zurück",
+                "save": "Sparen",
+                "show": "Details anzeigen",
+                "add": "Neue Details hinzufügen",
+                "edit": "Details bearbeiten",
+                "rowTitle": "Detailblatt",
+                "title": "Detailblatt - {name}",
+                "undo": "Rückgängig entfernen",
+                "showPreview": "Vorschau zeigen",
+                "hidePreview": "Vorschau ausblenden",
+                "delete": "Löschen Sie das Detailblatt",
+                "titleUnsavedChanges": "Sind Sie sicher, dass Sie schließen wollen, ohne Ihre Änderungen zu speichern?",
+                "sureToClose": "Sind Sie sicher, dass Sie schließen wollen, ohne Ihre Änderungen zu speichern?",
+                "fieldsChanged": "Einige Felder wurden geändert",
+                "showAtStartup": "Beim Start anzeigen",
+                "showAsModal": "Als modal anzeigen"
+            },
+            "errors": {
+                "loading": {
+                    "title": "Fehler beim Laden der Karte",
+                    "notFound": "Karte nicht gefunden",
+                    "notAccessible": "Karte nicht zugänglich",
+                    "unknownError": "<p> <small> Einer der folgenden Gründe könnte die Ursache sein: </small> <ul><li> Sie haben keine Zugriffsberechtigung </li> <li> Sie versuchen, auf eine nicht vorhandene Map zuzugreifen </li> <li> Die Karte wurde entfernt </li> <li>Die Projektion der Karte ist nicht konfiguriert</li></ul> <p>",
+                    "projectionError": "Die Projektion {projection} der Karte ist nicht konfiguriert",
+                    "title" : "Karte kann nicht angezeigt werden"
+                }
+            }
+        },
+        "floatinglegend": {
+            "showTOC": "Ebenen anzeigen",
+            "showLegend": "Legende anzeigen",
+            "hideLegend": "Legende ausblenden"
+        },
+        "addgroup": {
+            "addbtn": "Hinzufügen",
+            "groupName": "Gruppenname"
+        },
+        "toc": {
+            "toggleLayerVisibility": "Ebenensichtbarkeit umschalten",
+            "toggleGroupVisibility": "Gruppensichtbarkeit umschalten",
+            "displayLegendAndTools": "Legende und Werkzeuge einblenden",
+            "zoomToLayerExtent": "Zoome auf Ausdehung der Ebene",
+            "addLayer": "Ebene hinzufügen",
+            "addLayerToGroup": "Ebene zur ausgewählten Gruppe hinzufügen",
+            "addGroup": "Gruppe hinzufügen",
+            "addSubGroup": "Untergruppe zur ausgewählten Gruppe hinzufügen",
+            "toolZoomToLayerTooltip": "Zoom auf die ausgewählte Ebene",
+            "toolZoomToLayersTooltip": "Zoom auf die ausgewählten Ebenen",
+            "toolLayerSettingsTooltip": "Einstellungen für ausgewählte Ebene",
+            "toolGroupSettingsTooltip": "Einstellungen für ausgewählte Gruppe",
+            "toolTrashLayerTooltip": "Ausgewählte Ebene entfernen",
+            "toolTrashLayersTooltip": "Ausgewählte Ebenen entfernen",
+            "toolTrashGroupTooltip": "Ausgewählte Gruppe entfernen",
+            "toolFeaturesGridTooltip": "Attributtabelle öffnen",
+            "layerFilterTooltip": "Ausgewählte Ebene filtern",
+            "toolDownloadTooltip": "Daten zur ausgewählten Ebene exportieren",
+            "noFilteredResults": "Keine Ergebnisse",
+            "filterPlaceholder": "Ebenen filtern",
+            "clearFilter": "Filter löschen",
+            "toolReloadLayerTooltip": "Erneutes Laden der ausgewählten Ebene erzwingen",
+            "toolReloadLayersTooltip": "Erneutes Laden der ausgewählten Ebenen erzwingen",
+            "statusIconOpen": "Gruppe schließen",
+            "statusIconClose": "Gruppe öffnen",
+            "grabLayerIcon": "Ebene greifen und sortieren",
+            "grabGroupIcon": "Gruppe greifen und sortieren",
+            "toggleLayerVisibilityWarning": "Layer-Sichtbarkeit ändern, Warnung: Layer wurde nicht richtig geladen",
+            "createWidget": "Widget für die ausgewählte Ebene erstellen",
+            "editLayerProperties": "Eigenschaften der Ebene ändern",
+            "browseData": "Attributtabelle der ausgewählten Ebene öffnen",
+            "removeLayer": "Ebene entfernen",
+            "loadingerror": "Diese Ebene wurde nicht korrekt geladen oder ist nicht verfügbar",
+            "measure": "Messen",
+            "backgroundSwitcher": "Hintergrund",
+            "layers": "Ebenen",
+            "drawerButton": "Ebenen",
+            "refreshTitle": "Ebenen aktualisieren",
+            "refreshConfirm": "Aktualisieren",
+            "refreshMessage": "WMS-Layer-Konfiguration vom Server laden",
+            "refreshError": "Fehler beim Aktualisieren der Ebenen: ",
+            "epsgNotSupported": "KBS {epsg} wird für das Zoomen auf den Layer nicht unterstützt",
+            "compareTool": "Tool vergleichen",
+            "configureTool": "Konfigurieren",
+            "spyconfiguration": "Spyglass Konfiguration",
+            "swipeconfiguration": "Swipe-Konfiguration",
+            "swipe": "Wischen Sie",
+            "spyGlass": "Spion Glas",
+            "direction": "Wischerichtung",
+            "radius": "Radius",
+            "filterIconEnabled": "Ebenenfilter deaktivieren",
+            "filterIconDisabled": "Ebenenfilter aktivieren",
+            "notVisibleZoomIn": "Die Ebene ist nicht sichtbar, da sie außerhalb der Auflösungsgrenzen liegt. Zoomen Sie hinein, um die Ebene anzuzeigen",
+            "notVisibleZoomOut": "Die Ebene ist nicht sichtbar, da sie außerhalb der Auflösungsgrenzen liegt. Verkleinern Sie die Ansicht, um die Ebene anzuzeigen",
+            "refreshOptions": {
+                "bbox": "BBOX aktualisieren",
+                "search": "Suchoptionen aktualisieren",
+                "title": "Titel aktualisieren",
+                "dimensions": "Dimensionen aktualisieren"
+            },
+            "layerInfoTooltip": "Ebenentitel und Beschreibung aktualisieren",
+            "layerMetadata": {
+                "identifier": "Kennung",
+                "title": "Titel",
+                "abstract": "Zusammenfassung",
+                "purpose": "Zweck",
+                "source": "Quelle",
+                "createdDate": "Erstellungsdatum",
+                "lastRevisionDate": "Datum der letzten Überarbeitung",
+                "pointsOfContact": "Ansprechpartner",
+                "individualName": "Individueller Name",
+                "organisationName": "Name der Organisation",
+                "contactInfo": "Kontaktinformationen",
+                "phone": "Telefonnummer",
+                "deliveryPoints": "Lieferpunkte",
+                "city": "Stadt",
+                "postalCode": "Postleitzahl",
+                "country": "Land",
+                "URL": "URL",
+                "metadataUrl": "Metadaten-URL",
+                "role": "Rolle",
+                "hoursOfService": "Öffnungszeiten",
+                "electronicMailAddress": "E-Mail-Addresse",
+                "subject": "Betreff",
+                "type": "Typ",
+                "creator": "Ersteller",
+                "defaultPropName": "Eigentum=\"{propName}\"",
+                "toolLayerMetadataTooltip": "Metadaten der ausgewählten Ebene",
+                "layerMetadataPanelTitle": "Ebenenmetadaten",
+                "notification": {
+                    "warnigGetMetadataRecordById": "Fehler bei der Metadatensuche"
+                },
+                "itemTitles": {
+                    "pointsOfContact": "Kontakt",
+                    "default": "Artikel"
+                },
+                "emptyMetadata": "Keine Metadaten verfügbar"
+            },
+            "thematic": {
+                "classification_field": "Klassifizierungsfeld:",
+                "classification_method": "Klassifizierungsmethode:",
+                "classification_aggregate": "Aggregatfunktion:",
+                "classification_colors": "Farbrampe:",
+                "classification_intervals": "Intervalle:",
+                "preview": "Vorschau",
+                "remove_thematic": "Zurück zum einfachen Stil",
+                "values": {
+                    "equalInterval": "Gleiche Intervalle",
+                    "quantile": "Quantil",
+                    "jenks": "Natürliche Unterbrechungen",
+                    "sum": "Summe",
+                    "avg": "Durchschnittlich",
+                    "count": "Anzahl",
+                    "min": "Mindest",
+                    "max": "Max"
+                },
+                "configuration": "Aufbau",
+                "apply": "Klassifizierung anwenden",
+                "restore": "Anpassungen zurücksetzen",
+                "go_to_cfg": "Konfigurieren...",
+                "go_to_thema": "Verwenden Sie diese Konfiguration",
+                "cfgError": "Fehler in der Konfigurations-JSON",
+                "classify": "Klassifizieren",
+                "remove": "Klassifizierung entfernen",
+                "data_panel": "Daten",
+                "classification_stroke": "Strich",
+                "classification_error": "Fehler beim Aufruf des Klassifizierungsdienstes: {message}",
+                "fields_error": "Fehler beim Laden der Felderliste: {message}",
+                "interval_limit": "Intervalle sollten eine Zahl zwischen {min} und {max} sein",
+                "invalid_object": "Ungültige Serviceantwort",
+                "invalid_geometry": "Der Geometrietyp ist nicht gültig, kein Punkt, Linie oder Polygon",
+                "invalid_attribute": "Ungültiger Attributtyp bei Auswahl. Bitte wählen Sie ein gültiges Attribut aus der Liste für die Klassifizierungsmethode aus",
+                "invalid_classes": "Max muss in jeder Klasse größer als min sein"
+            },
+            "error": {
+                "defaultGroupOnTop": "Die Gruppe {groupTitle} ist als Standardzielgruppe festgelegt und muss daher oben bleiben"
+            }
+        },
+        "print":{
+            "paneltitle": "Drucken",
+            "layout": "Layout",
+            "sheetsize": "Blattgröße:",
+            "legendoptions": "Legenden Optionen",
+            "submit": "Drucken",
+            "title": "Titel",
+            "titleplaceholder": "Gib einen Titel ein...",
+            "description": "Beschreibung",
+            "descriptionplaceholder": "Gib eine Beschreibung ein...",
+            "resolution": "Auflösung:",
+            "defaultBackground": "Nutze OSM als Hintergrund",
+            "printtooltip": "Drucken",
+            "alternatives": {
+                "legend": "Legende einschließen",
+                "2pages": "Legende auf einer separaten Seite",
+                "landscape": "Querformat",
+                "portrait": "Hochformat"
+            },
+            "legend": {
+                "font": "Label Einstellungen:",
+                "forceLabels": "Labels erzwingen:",
+                "antiAliasing": "Anti Aliasing Schrift:",
+                "iconsSize": "Symbolgröße:",
+                "dpi": "dpi:"
+            },
+            "layoutWarning": "Layout nicht erlaubt"
+        },
+        "backgroundSwither":{
+            "tooltip": "Wähle Hintergrund"
+        },
+        "info":{
+            "tooltip": "Objekte auf der Karte abfragen"
+        },
+        "expandtoolbar": {
+            "tooltip": "Aus- / Einklappen"
+        },
+        "getFeatureInfoTitle": "Feature Info",
+        "identifyTitle": "Feature Info",
+        "identifyNoQueryableLayers": "Keine aktive abrufbare Ebene",
+        "identifyRevGeocodeHeader": "Koordinaten",
+        "identifyShowCoordinateEditor": "Koordinateneditor anzeigen",
+        "identifyHideCoordinateEditor": "Koordinateneditor ausblenden",
+        "identifyCoordinateApplyChanges": "Änderungen übernehmen",
+        "identifyChangeCoordinateFormat": "Koordinatenformat ändern",
+        "identifyZoomToFeature": "Auf Objekt zoomen",
+        "identifyStopHighlightingFeatures": "Objekte in Karte nicht mehr hervorheben",
+        "identifyHighlightFeatures": "Objekte in Karte hervorheben",
+        "identifyRevGeocodeModalTitle": "Addresse",
+        "identifyRevGeocodeSubmitText": "Mehr Informationen",
+        "identifyRevGeocodeCloseText": "Schliessen",
+        "identifyRevGeocodeError": "Konnte nicht geocodiert werden",
+        "identifyEdit": "Bearbeiten",
+        "identifyLayerSelectNoResult": "Keine Ebenen gefunden",
+        "getFeatureInfoError": {
+            "title": "Ooops! Etwas ist schiefgelaufen.",
+            "text": "Ein Fehler ist während dieser <b>GetFeatureInfo</b> Anfrage aufgetreten"
+        },
+        "noFeatureInfo": "Zu diesem Punkt sind keine Informationen verfügbar",
+        "noInfoForLayers": "Für die folgenden Ebenen gibt es keine Objekte: ",
+        "history":{
+            "barLabel": "Kartenverlauf",
+            "undoBtnTooltip": "Gehe zurück",
+            "redoBtnTooltip": "Gehe vorwärts"
+        },
+        "infoFormatLbl": "Antwortformat festlegen",
+        "infoTriggerLabel": "Auslöseereignis für Info-Box",
+        "click": "Click",
+        "hover": "Hover",
+        "measureSupport": {
+            "continueLine": "Klicken Sie auf die Karte, um mit dem Zeichnen der Linie fortzufahren",
+            "continuePolygon": "Klicken Sie auf die Karte, um mit dem Zeichnen des Polygons fortzufahren",
+            "startDrawing": "Klicken Sie auf die Karte, um mit dem Zeichnen zu beginnen"
+        },
+        "measureComponent": {
+            "Measure": "Messen",
+            "MeasureLength": "Distanz messen",
+            "MeasureArea": "Fläche messen",
+            "MeasureBearing": "Richtung messen",
+            "MeasureTrueBearing": "Richtung (True Bearing) messen",
+            "tooltip": "Distanz, Fläche und Richtung messen",
+            "title": "Messen",
+            "lengthButtonText": "Linie",
+            "areaButtonText": "Fläche",
+            "resetButtonText": "Zurücksetzen",
+            "lengthLabel": "Länge",
+            "areaLabel": "Fläche",
+            "bearingLabel": "Richtung",
+            "trueBearingLabel": "Richtung (True Bearing)",
+            "formula": "Formel zur Distanzberechnung",
+            "showLabel": "Zeige Messwert",
+            "addAsAnnotation": "Als Notiz hinzufügen",
+            "newMeasure": "Neue Messung",
+            "selectTool": "Wählen Sie ein Messwerkzeug aus",
+            "exportToGeoJSON": "Export als GeoJSON",
+            "saveMeasure": "Speichern Sie die Messungen in Notizen / Zeichnungen",
+            "resetTooltip": "Messung entfernen",
+            "addAsLayer": "Als Ebene hinzufügen"
+        },
+        "search":{
+            "layerMustBeVisible": "Die Zielebene ist inaktiv",
+            "decimal": "Dezimal",
+            "aeronautical": "Luftfahrt",
+            "changeSearchInputField": "Suchwerkzeug ändern",
+            "addressSearch": "Suche nach Standortname",
+            "coordinatesSearch": "Suche nach Koordinaten",
+            "searchservicesbutton": "Suchdienste konfigurieren",
+            "configpaneltitle": "Einen Suchdienst anlegen / bearbeiten",
+            "serviceslistlabel": "Verfügbare Suchdienste",
+            "overriedservice": "Standardservice überschreiben",
+            "addbtn": "Hinzufügen",
+            "nextbtn": "Weiter",
+            "prevbtn": "Zurück",
+            "savebtn": "Aktualisieren",
+            "cancelbtn": "Abbrechen",
+            "confirmremove": "Löschen?",
+            "cancelconfirm": "Sind Sie sicher?",
+            "searchByBookmark": "Suche nach Lesezeichen",
+            "bookmarksettings": "Lesezeicheneinstellungen",
+            "zoomToBookmark": "Auf ausgewähltes Lesezeichen zoomen",
+            "bookmarkFilter": "Lesezeichen filtern",
+            "editBookmark": "Lesezeichen bearbeiten",
+            "deleteBookmark": "Lesezeichen löschen",
+            "b_listpaneltitle": "Lesezeichen anzeigen",
+            "b_newpaneltitle": "Neues Lesezeichen hinzufügen",
+            "latitude": "Lat",
+            "longitude": "Lon",
+            "b_title": "Titel",
+            "b_layer_tooltip": "Deaktivieren Sie das Neuladen der Ebenensichtbarkeit",
+            "b_bbox": "Begrenzungsrahmen",
+            "b_bbox_tooltip": "Verwenden Sie die aktuelle Ansicht als Begrenzungsrahmen",
+            "b_bbox_south": "Süden",
+            "b_bbox_south_placeholder": "Südliche Begrenzung eingeben",
+            "b_bbox_west": "Westen",
+            "b_bbox_west_placeholder": "Westliche Begrenzung eingeben",
+            "b_bbox_east": "Osten",
+            "b_bbox_east_placeholder": "Östliche  Begrenzung eingeben",
+            "b_bbox_north": "Norden",
+            "b_bbox_north_placeholder": "Nördliche Begrenzung eingeben",
+            "bookmarkslistempty": "Kein Lesezeichen definiert",
+            "b_placeholder": "Lesezeichen auswählen ...",
+            "b_clearvalue": "Lesezeichen löschen",
+            "b_noresult": "Keine Lesezeichen gefunden",
+            "s_name": "Name",
+            "s_title": "Titel",
+            "s_description": "Beschreibung",
+            "s_priority": "Priorität",
+            "s_url": "Service url",
+            "s_layer": "Ebenen",
+            "s_attributes": "Attribute",
+            "s_sort": "Sortiere nach",
+            "s_max_features": "Max. Objekte",
+            "s_max_zoom": "Max. Zoomstufe",
+            "s_wfs_props_label" : "WFS-Service-Eigenschaften",
+            "s_wfs_opt_props_label" : "Optionale Eigenschaften",
+            "s_result_props_label": "Ergebnisanzeigeeigenschaften",
+            "s_priority_info": "Wird verwendet, um Suchergebnisse zu sortieren, niedrigere Werte zuerst. Nominatim Ergebnisse haben Priorität = 5",
+            "serviceslistempty": "Keine benutzerdefinierten Services definiert",
+            "service_missing": "{serviceType} dienst ist nicht konfiguriert",
+            "generic_error": "Bei der Suche ist ein Fehler aufgetreten. Fehlerdetails: {message}",
+            "showGFI": "GFI anzeigen",
+            "errors": {
+                "nonQueriableLayers": "Der in der URL angegebene Layer ist nicht abfragbar oder in der Karte nicht sichtbar.",
+                "serverError": "Der Server hat beim Ausführen der GetFeatureInfo-Anforderung einen Fehler zurückgegeben. Überprüfen Sie, ob die Parameter korrekt sind"
+            },
+            "s_launch_info_panel": {
+                "label": "Starten Sie das Infofenster",
+                "no_info": "Keine Infos",
+                "all_layers": "Alle Ebenen",
+                "single_layer": "Einzelne Ebene",
+                "no_info_description": "Das Identifizierungsfeld wird bei der Suche nicht angezeigt",
+                "all_layers_description": "Das Fenster Identifizieren zeigt Informationen zu allen in der Karte sichtbaren Layern an",
+                "single_layer_description": "Im Bereich Identifizieren werden nur Informationen für diese Ebene angezeigt",
+                "openFeatureInfoButtonCheckbox": "Verwenden Sie die Schaltfläche, um Funktionsinformationen zu öffnen",
+                "forceSearchLayerVisibility": "Sichtbarkeit der Suchebene erzwingen"
+            },
+            "advancedSearchPanel": {
+                "title": "Erweiterte Suchfilter",
+                "context": {
+                    "title": "Kontext"
+                },
+                "showTooltip": "Erweiterte Filter anzeigen",
+                "showTooltipActive": "Erweiterte Filter anzeigen (aktiv)",
+                "hideTooltip": "Erweiterte Filter ausblenden",
+                "hideTooltipActive": "Erweiterte Filter ausblenden (aktiv)"
+            }
+        },
+        "draw": {
+            "fill": "Füllung",
+            "text": "Text",
+            "fontTitle": "Font",
+            "color": "Farbe",
+            "lineDash": "Linienart",
+            "stroke": "Linie",
+            "opacity": "Deckkraft",
+            "width": "Linienbreite",
+            "textRotation": "Drehung",
+            "font": {
+                "textColor": "Farbe",
+                "family": "Schriftart",
+                "size": "Größe",
+                "style": "Stil",
+                "weight": "Breite",
+                "textAlign": "Ausrichtung des Textes"
+            },
+            "marker": {
+                "layout": "Layout",
+                "shape": "Form",
+                "size": "Größe",
+                "type": "Typ",
+                "icon": "Symbol"
+            }
+        },
+        "drawLocal": {
+            "draw": {
+                "toolbar": {
+                    "actions": {
+                        "title": "Zeichnung abbrechen",
+                        "text": "Abbrechen"
+                    },
+                    "undo": {
+                        "title": "Letzten gezeichneten Punkt löschen",
+                        "text": "Letzten Punkt löschen"
+                    },
+                    "buttons": {
+                        "polyline": "Zeichne eine Multilinie",
+                        "polygon": "Zeichne ein Polygon",
+                        "rectangle": "Zeichne ein Rechteck",
+                        "circle": "Zeichne einen Kreis",
+                        "marker": "Zeichne einen Punkt"
+                    }
+                },
+                "handlers": {
+                    "circle": {
+                        "tooltip": {
+                            "start": "Klicke und ziehe um einen Kreis zu zeichnen."
+                        }
+                    },
+                    "marker": {
+                        "tooltip": {
+                            "start": "Klicke in die Karte um einen Punkt zu setzen."
+                        }
+                    },
+                    "polygon": {
+                        "tooltip": {
+                            "start": "Klicke um mit dem Zeichnen einer Form zu beginnen.",
+                            "cont": "Klicke um das Zeichnen der Form fortzusetzen.",
+                            "end": "Klicke den ersten Punkt der Form um sie zu schließen."
+                        }
+                    },
+                    "polyline": {
+                        "error": "Fehler: Die Kanten der Form dürfen sich nicht überschneiden!",
+                        "tooltip": {
+                            "start": "Klicke um mit dem Zeichnen einer Linie zu beginnen.",
+                            "cont": "Klicke um das Zeichnen der Linie fortzusetzen.",
+                            "end": "Klicke den letzten Punkt um die Linie abzuschließen."
+                        }
+                    },
+                    "rectangle": {
+                        "tooltip": {
+                            "start": "Klicke und ziehe um ein Rechteck zu zeichnen."
+                        }
+                    },
+                    "simpleshape": {
+                        "tooltip": {
+                            "end": "Lass die Maustaste los um das Zeichnen zu beenden."
+                        }
+                    }
+                }
+            },
+            "edit": {
+                "toolbar": {
+                    "actions": {
+                        "save": {
+                            "title": "Änderungen speichern.",
+                            "text": "Speichern"
+                        },
+                        "cancel": {
+                            "title": "Bearbeitung abbrechen, alle Änderungen werden verworfen.",
+                            "text": "Abbrechen"
+                        }
+                    },
+                    "buttons": {
+                        "edit": "Ebenen bearbeiten.",
+                        "editDisabled": "Keine bearbeitbaren Ebenen vorhanden.",
+                        "remove": "Ebenen löschen.",
+                        "removeDisabled": "Keine löschbaren Ebenen vorhanden."
+                    }
+                },
+                "handlers": {
+                    "edit": {
+                        "tooltip": {
+                            "text": "Klicke und Ziehe um das Feature zu bearbeiten.",
+                            "subtext": "Klicke Abbrechen um Änderungen zu verwerfen."
+                        }
+                    },
+                    "remove": {
+                        "tooltip": {
+                            "text": "Klicke ein zu entfernendes Feature"
+                        }
+                    }
+                }
+            }
+        },
+        "locate": {
+            "tooltip": "Zeige meine Position",
+            "tooltipDeactivate": "Hör auf, meine Position zu zeigen",
+            "metersUnit": "Meter",
+            "feetUnit": "Fuß",
+            "popup": "Sie sind weniger als {distance} {unit} von diesem Punkt entfernt",
+            "outsideMapBoundsMsg": "Sie scheinen sich außerhalb der Grenzen dieser Karte zu befinden"
+        },
+        "zoombuttons": {
+            "zoomInTooltip": "Zoom vergrößern",
+            "zoomOutTooltip": "Zoom verringern",
+            "zoomAllTooltip": "Zoom auf maximale Ausdehnung"
+        },
+        "fullscreen": {
+            "tooltipActivate": "Umschalten auf Vollbild",
+            "tooltipDeactivate": "Vollbild verlassen",
+            "viewLargerMap": "Größere Karte ansehen"
+        },
+        "helptexts": {
+            "scaleBox": "Das ist die Hilfe für die ScaleBox",
+            "zoomToMaxExtentButton": "Das ist die Hilfe für den ZoomToMaxExtentButton",
+            "zoomIn": "Das ist die Hilfe für ZoomIn",
+            "zoomOut": "Das ist die Hilfe für ZoomOut",
+            "searchBar": "Geben Sie eine Adresse eines Ortes ein bspw. 'Brandenburger Tor, Berlin'. Sie können auch Koordinaten im folgenden Format eingeben: 43.87, 10.20",
+            "metadataexplorer": "Das ist die Hilfe für den MetadataExplorer",
+            "settingsPanel": "Das ist die Hilfe für das SettingsPanel",
+            "gohome": "Das ist die Hilfe für Home",
+            "measureComponent": "Das ist die Hilfe für MeasureComponent",
+            "layerSwitcher": "Das ist die Hilfe für den LayerSwitcher",
+            "infoButton": "Das ist die Hilfe für den InfoButton",
+            "locateBtn": "Das ist die Hilfe für den LocateBtn",
+            "snapshot": "Das ist die Hilfe für Snapshot",
+            "print": "Das ist die Hilfe für Print",
+            "shapefile": "Das ist die Hilfe für Shapefile",
+            "rasterstyler": "Definiere Minimum, Maximum, Anzahl von Klassen und ColorRamp und generiere eine neue klassifizierte Raster Ebene",
+            "expandToolbar": "Das ist die Hilfe für Expand / Collapse",
+            "historyundo": "Nutze diesen Button um zur vorherigen Kartenansicht zu gehen",
+            "historyredo": "Nutze diesen Button um zur nächsten Kartenansicht zu gehen",
+            "vectorstyler": "Erstelle den Stil für die gewählte Vektor Ebene",
+            "styler": "Erstelle den Stil für die gewählte Ebene"
+        },
+        "queryform": {
+            "title": "Erweiterte Suche",
+            "query": "Suche",
+            "apply": "Anwenden",
+            "reset": "Zurücksetzen",
+            "save": "Sparen",
+            "discard": "Rückgängig machen",
+            "query_request_exception": "Abfrage Fehler",
+            "config": {
+                "load_config_exception": "Fehler beim Laden der Konfiguration"
+            },
+            "comboField": {
+                "default_placeholder": "Wählen...",
+                 "drop_down": "Öffnen Sie das Dropdown-Menü"
+            },
+            "form": {
+                "header": "Finde im Datensatz",
+                "dataset_header": "Datensatz"
+            },
+            "emptyfilter": "Kein Filtersatz. Die Suche kann abgebrochen werden, wenn der Server keine 'pagination' unterstützt.",
+            "attributefilter":{
+                "add_condition": "Bedingung hinzufügen",
+                "delete": " Löschen",
+                "deleteGroup": " Gruppe löschen",
+                "add_group": "Gruppe hinzufügen",
+                "group_label_a": "Übereinstimmung",
+                "group_label_b": "der folgenden Bedingungen:",
+                "combo_placeholder": "Attribut",
+                "text_placeholder": "Gib den zu filternden Text ein",
+                "attribute_filter_header": "Attributfilter",
+                "tooltipTextField": "Verwenden <b>*</b> für ein beliebiges Zeichen</br>Verwenden <b>.</b> für ein einzelnes Zeichen</br>Verwenden <b>!</b> für Sonderzeichen (* und .)</br>",
+                "groupField": {
+                    "any": "einer",
+                    "all": "aller",
+                    "none": "keiner"
+                },
+                "numberfield": {
+                    "isRequired": "Eingabe nötig",
+                    "wrong_range": "Die untere Grenze muss kleiner als die obere Grenze sein"
+                },
+                "datefield": {
+                    "wrong_date_range": "Das Datum des Beginns muss früher als das des Endes sein"
+                },
+                "autocomplete": {
+                    "emptyList": "Keine Ergebnisse",
+                    "emptyFilter": "Der Filter hat keine Ergebnisse zurückgegeben",
+                    "open": "Menü öffnen"
+                }
+            },
+            "spatialfilter": {
+                "filterType": "Filtertyp",
+                "geometric_operation": "Geometrische Operation",
+                "spatial_filter_header": "Interessensgebiet",
+                "remove": "Löschen",
+                "combo_placeholder": "Wählen...",
+                "draw_start_label": "Zeichnen Sie das Interessensgebiet auf der Karte ein",
+                "dwithin_label": "Meter",
+                "details": {
+                    "detail_button_label": "Details",
+                    "details_header": "Details der Auswahl",
+                    "details_bbox_label": "Bearbeiten Sie die Koordinaten um den gwählten Bereich zu ändern",
+                    "details_circle_label": "Bearbeiten Sie die numerischen Felder um den Radius und das Zentrum des Kreises zu ändern",
+                    "reset_bbox": "Zurücksetzen",
+                    "save_bbox": "BBOX Änderungen speichern",
+                    "save_radius": "Radius/Kreiszentrum Änderungen speichern",
+                    "radius": "Radius({unit})"
+                },
+                "methods": {
+                    "zone": "Zone",
+                    "viewport": "Sichtbereich",
+                    "regions": "Regionen",
+                    "box": "Rechteck",
+                    "buffer": "Puffer",
+                    "circle": "Kreis",
+                    "poly": "Polygon",
+                    "cql":   "CQL"
+                },
+                "operations": {
+                    "intersects": "Schneidet",
+                    "bbox": "Rechteck",
+                    "contains": "Enthalten in",
+                    "dwithin": "Entfernung von",
+                    "within": "Enthält"
+                }
+            },
+            "crossLayerFilter": {
+                "title": "Ebenenfilter",
+                "targetLayer": "Zielebene",
+                "clear": "Filter löschen",
+                "operation": "Geometrische Operation",
+                "placeholder": "Wählen Sie eine Ebene aus",
+                "errors": {
+                    "noCrossLayerAvailable": "Ebenenfilter ist für die ausgewählte Ebene nicht verfügbar",
+                    "layersExcluded": "Für diesen Ebenenfilter können nur Ebenen ausgewählt werden, die von derselben Quelle stammen"
+                }
+            },
+            "changedFilter": "Filter geändert",
+            "changedFilterAlert": "Es gibt ungespeicherte Änderungen. Möchten Sie diese speichern?",
+            "resetFilter": "Filter entfernen",
+            "confirmReset": "Bestätigen",
+            "loadingError": "Der aktuelle Filter verursachte ein Rendering-Problem für den Layer auf der Karte. Bitte überprüfen Sie die Layerkonfiguration auf dem Server oder korrigieren Sie den Filter",
+            "changedFilterWithErrorAlert": "Der Filter verursacht einen Layer-Rendering-Fehler. Möchten Sie ihn trotzdem speichern?"
+        },
+        "annotations": {
+            "errorLoadingSymbols": "Beim Laden der Symbolliste ist ein Fehler aufgetreten. Bitte wenden Sie sich an den Administrator, um die Konfigurationsoptionen zu überprüfen",
+            "edit": "Bearbeiten",
+            "remove": "Löschen",
+            "save": "Speichern",
+            "saveGeometry": "Geometrie speichern",
+            "cancel": "Abbrechen",
+            "back": "Zurück",
+            "applyStyle": "Stil anwenden",
+            "addGeometry": "Neue Geometrie hinzufügen",
+            "styleGeometry": "Stil ändern",
+            "deleteGeometry": "Alle Geometrien der Notiz /Zeichnung entfernen",
+            "geometries": "Geometrien",
+            "removeannotation": "Möchten Sie die Notiz / Zeichnung mit dem Titel {title} entfernen?",
+            "removegeometry": "Möchten Sie diese Geometrie entfernen?",
+            "confirm": "Bestätigen",
+            "title": "Notizen / Zeichnungen",
+            "mandatory": "Pflichtfeld",
+            "add": "Neue Notiz / Zeichnung",
+            "emptygeometry": "Fügen Sie mindestens eine gültige Geometrie hinzu",
+            "empty": "Noch keine Notizen / Zeichnungen, klicken Sie auf [+], um welche hinzuzufügen",
+            "enableEdit": "Bearbeiten aktivieren",
+            "editMeasurement": "Messung bearbeiten",
+            "zoomTo": "Zur Notiz / Zeichnung zoomen",
+            "zoomToGeometry": "Auf Geometrie zoomen",
+            "removeGeometry": "Entfernen",
+            "hide": "Notiz / Zeichnung ausblenden",
+            "show": "Notiz / Zeichnung anzeigen",
+            "tabCoordinates": "Koordinaten",
+            "warning": "Warnung!",
+            "measureWarningText": "Wenn Sie zum Bearbeiten des Messfelds navigieren, werden alle angewendeten Stile entfernt",
+            "notShowAgain": "Diese Nachricht nicht mehr anzeigen",
+            "tabStyle": "Stil",
+            "filter": "Notizen / Zeichnungen filtern...",
+            "undo": "Sind Sie sicher, dass Sie die Bearbeitung der Notizen / Zeichnungen beenden möchten?",
+            "titleUndoGeom": "Die Geometrie hat sich geändert",
+            "undoGeom": "Sind Sie sicher, ohne zu speichern zu beenden? (Sie werden alle Änderungen verlieren)",
+            "confirmGeom": "Bestätigen",
+            "cancelModalGeom": "Abbrechen",
+            "deleteFeature": "Objekt löschen",
+            "undoDeleteFeature": "Möchten Sie dieses Objekt wirklich löschen?",
+            "insertText": "Bitte fügen Sie eine Textanmerkung ein",
+            "downloadtooltip": "Alle Notizen / Zeichnungen herunterladen",
+            "downloadcurrenttooltip": "Aktuelle Notiz / Zeichnung herunterladen",
+            "downloadError": "Fehler beim Exportieren",
+            "loadtooltip": "Notizen / Zeichnungen importieren",
+            "loadtitle": "Notizen / Zeichnungen importieren",
+            "selectfiletext": "Legen Sie die Datei hier ab oder klicken Sie, um die zu importierende Notiz / Zeichnung auszuwählen. (unterstützte Dateien: JSON)",
+            "loadoverride": "Notizen / Zeichnungen ersetzen",
+            "loaderror": "Wählen Sie eine oder mehrere Notizen / Zeichnungen aus. (unterstützte Dateien: JSON)",
+            "defaulttitle": "Standardtitel bearbeiten",
+            "field": {
+                "title": "Titel",
+                "description": "Beschreibung"
+            },
+            "titles": {
+                "marker": " Punkt",
+                "line": " Linie",
+                "polygon": " Polygon",
+                "text": " Text",
+                "circle": " Kreis"
+            },
+            "editor": {
+                "decimal": "Dezimal",
+                "aeronautical": "Luftfahrt",
+                "title": {
+                    "Polygon": "Polygon-Editor",
+                    "LineString": "Linien-Editor",
+                    "Bearing": "Richtungs-Editor",
+                    "Circle": "Kreis-Editor",
+                    "Point": "Punkt-Editor",
+                    "MultiPoint": "Multipoint-Editor",
+                    "Text": "Text-Editor"
+                },
+                "center": "Mittelpunkt",
+                "add": "Fügen Sie eine neue Koordinate hinzu",
+                "addByClick": "Fügen Sie neue Koordinaten hinzu, indem Sie auf die Plus-Schaltfläche oder auf die Karte klicken",
+                "valid": "Geometrie ist gültig",
+                "radius": "Radius",
+                "text": "Text",
+                "lat": "Breite",
+                "lon": "Längengrad",
+                "notValidMarker": "Fügen Sie eine gültige Koordinate ein (+|- 90° lat, +|-180° lon)",
+                "notValidPolyline": "Alle Koordinaten müssen gültig sein (+|- 90° lat, +|-180° lon)",
+                "notValidText": "Fügen Sie einen Textwert und eine gültige Koordinate ein (+|- 90° lat, +|-180° lon)",
+                "notValidCircle": "Geben Sie einen Radius und eine gültige Koordinate ein (+|- 90° lat, +|-180° lon)",
+                "newFeature": "Neu"
+            }
+        },
+        "user":{
+            "login": "Login",
+            "logout": "Logout",
+            "info": " Account Info",
+            "details": " Nutzer Details",
+            "noAttributesMessage": "Es gibt keine Information bezüglich deines Accounts",
+            "changePwd": "Passwort ändern",
+            "newPwd": "Neues Passwort",
+            "retypePwd": "Passwort wiederholen",
+            "passwordMinlenght": "Dein Passwort muss aus mindestens {data} Zeichen bestehen",
+            "passwordCheckFail": "Passwörter sind nicht identisch!",
+            "passwordInvalid": "Ungültiges Passwort",
+            "username": "Benutzername",
+            "password": "Passwort",
+            "passwordMessage": "Das Passwort muss aus mindestens 6 Zeichen bestehen. Gültige Werte für Kennwörter sind Ziffern, Klein- oder Großbuchstaben und die folgenden Sonderzeichen: !,@,#,$,%,&,*,_",
+            "passwordInvalidChar": "Das Passwort darf diese Zeichen nicht enthalten: {data}",
+            "passwordChanged": "Passwort geändert",
+            "passwordError": "Fehler beim Ändern des Passworts",
+            "signIn":"Anmelden",
+            "loginFail":"Anmeldung gescheitert",
+            "loginFailedStatusMessages": {
+                "usernamePwdInsert": "Bitte gib Benutzernamen und Password ein",
+                "usernamePwdIncorrect":"Benutzername oder Passwort inkorrekt"
+            },
+            "detailsName": "Name",
+            "detailsRole": "Rolle",
+            "detailsGroups": "Gruppen",
+            "detailsEmail": "E-mail",
+            "detailsCompany": "Unternehmen",
+            "detailsNotes": "Anmerkungen"
+        },
+        "users": {
+            "title": "Accounts verwalten",
+            "users": "Benutzer",
+            "manageUsers": "Benutzer verwalten",
+            "searchUsers": "Suche nach Benutzern...",
+            "newUser": "Neuer Benutzer",
+            "editUser": "Benutzer ändern",
+            "deleteUser": "Benutzer löschen",
+            "statusTitle": "Status",
+            "enabled": "Berechtigt",
+            "groupTitle": "Gruppen:",
+            "roleTitle": "Rolle",
+            "saveUser": "Speichern",
+            "savingUser": "Speichern...",
+            "userSaved": "Gespeichert!",
+            "createUser": "Erstellen",
+            "creatingUser": "Erstellen...",
+            "userCreated": "Erstellt!",
+            "deleting": "Löschen...",
+            "delete": "Löschen",
+            "confirmDeleteUser": "Sind Sie sicher, das Sie diesen Benutzer löschen möchten?",
+            "errorDelete": "Es gab einen Fehler beim Löschen von Benutzer:",
+            "errorSaving": "Es gab einen Fehler beim Speichern von Benutzer:",
+            "selectedGroups": "Ausgewählte Gruppen",
+            "requiredFiedsMessage": "Felder, welche mit einem Sternchen (*) markiert sind, sind Pflichtfelder"
+        },
+        "usergroups": {
+          "searchGroups": "Suche Gruppen...",
+          "groups": "Gruppen",
+          "nameLimit": "Der Name ist auf 255 Zeichen limitiert.",
+          "descLimit": "Die Beschreibung ist auf 255 Zeichen limitiert.",
+          "editGroup": "Gruppe bearbeiten",
+          "deleteGroup": "Gruppe löschen",
+          "removeUser": "Benutzer löschen",
+          "newGroup": "Neue Gruppe",
+          "manageGroups": "Gruppen verwalten",
+          "description": "Beschreibung:",
+          "noDescriptionAvailable": "(Keine beschreibung)",
+          "groupName": "Gruppenname",
+          "groupDescription": "Beschreibung",
+          "saveGroup": "Speichern",
+          "createGroup": "Erstellen",
+          "creatingGroup": "Erstellen...",
+          "groupMembers": "Mitglied:",
+          "addMember": "Mitglied hinzufügen",
+          "selectMemberPlaceholder": "Mitglied auswählen ...",
+          "noUsers": "Keine Benutzer für diese Gruppe gefunden",
+          "errorSaving": "Es gab einen Fehler beim Speichern dieser Gruppe",
+          "errorDelete": "Es gab einen Fehler beim Löschen dieser Gruppe",
+          "confirmDeleteGroup": "Sind Sie sicher, das Sie diese Gruppe löschen möchten?"
+        },
+        "share":{
+            "title": "Teilen",
+            "titlePanel": "Teile die Karte",
+            "socialIntro": "In deinem bevorzugten sozialen Netzwerk",
+            "directLinkTitle": "Über einen direkten Link",
+            "social": "Social",
+            "direct": "Link",
+            "code": "Embed",
+            "embeddedLinkTitle": "Über einen eingebetteten Code",
+            "forceDrawer": "Inhaltsverzeichnis anzeigen",
+            "apiLinkTitle": "API verwenden",
+            "QRCodeLinkTitle": "QR code",
+            "msgCopiedUrl": "Kopiert",
+            "msgToCopyUrl": "Klicke um zu kopieren",
+            "sharedTitle": "Schau dir meine neue Karte an: ",
+            "advancedOptions": "Erweiterte Optionen",
+            "addBboxParam": "Bbox (Bounding Box / Ausdehnung) zum Link hinzufügen",
+            "wrongBboxParamTitle": "Ungültiger Bbox-Parameter",
+            "wrongBboxParamMessage": "Bbox-Parameter müssen in EPSG:4326 sein und angegeben werden als: bbox=minx,miny,maxx,maxy",
+            "wrongCenterAndZoomParamTitle": "Ungültiger Mittelpunkt und Zoomparameter",
+            "wrongCenterAndZoomParamMessage": "Mittelpunkt und Zoom Parameter müssen angegeben werden als: center=lon,lat&zoom=value und (+|- 90° lat, +|-180° lon, <=+35 zoom)",
+            "wrongMarkerAndZoomParamTitle": "Ungültiger Marker und Zoomparameter",
+            "wrongMarkerAndZoomParamMessage": "Marker und Zoomparameter müssen angegeben werden als: marker=lon,lat&zoom=value und (+|- 90° lat, +|-180° lon, <=+35 zoom)",
+            "showHomeButton": "Link zur MapStore-Startseite",
+            "addCenterAndZoomParam": "Mittelpunkt und Zoomlevel zum Link hinzufügen",
+            "addMarkerAndZoomParam": "Marker und Zoomlevel zum Link hinzufügen",
+            "zoom": "Zoomen",
+            "marker": "Marker auf geteilter Karte anzeigen",
+            "coordinate": "Koordinate",
+            "coordTooltip": "Klicken Sie auf die Karte, um die Koordinaten zu ändern / festzulegen",
+            "zoomToolTip": "Min: 1 und Max: 35",
+            "showSectionId": "Bildlaufposition einschließen",
+            "showConnections": "Verbindungen anzeigen",
+            "sizeOptions": {
+                "width": "Breite",
+                "height": "Höhe"
+            }
+        },
+        "snapshot": {
+            "title": "Snapshot Vorschau",
+            "save": "Speichern",
+            "tooltip": "Speichere einen Snapshot der Karte.",
+            "googleBingError": "Google und Bing Ebenen sind aufgrund urheberrechtlicher Einschränkungen für den Snapshot nicht verfügbar.",
+            "downloadingSnapshots": "Snapshot Erstellung...",
+            "date": "Datum",
+            "layers": "Ebenen",
+            "size": "Größe",
+            "notsupported": "Snapshot nicht unterstützt",
+            "taintedMessage": "Die Snapshot Speichern Funktionalität ist aufgrund von Browser Sicherheits Beschränkungen eingeschränkt. Für ein besseres Ergebnis klicke mit der rechten Maustaste auf die Vorschau und wähle 'Bild speichern unter'(unterstützt von Firefox und Chrome)"
+        },
+        "shapefile": {
+            "title": "Vektor-Dateien hochladen",
+            "tooltip": "Füge der Karte ein Vektor-Dateien hinzu.",
+            "placeholder": "Ziehe deine Dateien hierher oder klicke Vektor-Dateien die importiert werden sollen.(Shapefiles müssen in Zip-Archiven enthalten sein, KML/KMZ e GPX)",
+            "defaultStyle": "Standardstil",
+            "zoom": "Zoome auf Shapefiles",
+            "error": {
+                "select": "Wählen Sie die richtige Datei aus",
+                "shapeFileParsingError": "Das Shapefile kann nicht geladen werden. Die Datei könnte beschädigt oder nicht gut geformt sein",
+                "genericLoadError": "Das Shapefile kann nicht auf der Karte geladen werden",
+                "missingPrj": "Fehlende Projektionsinformation (.prj), Koordinatensystem soll EPSG: 4326 sein"
+            },
+            "add": "Hinzufügen",
+            "cancel": "Abbrechen",
+            "merge": "Mit der vorhandenen Annotationsebene zusammenführen",
+            "replace": "Ersetzen Sie die vorhandene Anmerkungsebene",
+            "success": " erfolgreich importiert",
+            "next": "Nächster",
+            "skip": "springen",
+            "finish": "Fertig",
+            "layerOf": "Ebene {count} von {total}:",
+            "styleCustomizationDisabled":"Diese Ebene hat bereits einen Stil definiert und kann nicht angepasst werden."
+        },
+        "mapImport": {
+                "title": "Importieren",
+                "tooltip": "Importieren Sie eine Kartendatei oder Vektordaten",
+                "dropZone": {
+                    "heading": "<p> <h4> Legen Sie hier Ihre Kartenkonfigurations- oder Vektordateien ab </h4> <small> oder nutzen Sie </small> </p>",
+                    "selectFiles": "Dateien auswählen...",
+                    "infoSupported": "<p> <small> Unterstützte Dateien zur Kartenkonfiguration: MapStore Legacy-Format, WMC.<br />Unterstützte Vektor-Layer-Dateien: Shapefiles (müssen in einem Zip-Archiv enthalten sein), KML / KMZ, GPX, GeoJSON oder Annotations </small> </p>",
+                    "note": "<p> <small> <i> <strong> Hinweis </strong>: Die aktuelle Karte wird bei der Verwendung von Kartenkonfigurationsdateien überschrieben </i> </small> </p>"
+                },
+                "errors": {
+                    "fileNotSupported": "Datei wird nicht unterstützt",
+                    "unknownError": "Beim Import ist ein unbekannter Fehler aufgetreten",
+                    "projectionNotSupported": "Die Projektion der Datei, die Sie importieren möchten, wird nicht unterstützt",
+                    "fileBeyondBoundaries": "Die Datei {Dateiname} kann nicht importiert werden, da sie nicht zu den Kartengrenzen passt"
+                }
+            },
+        "mapExport": {
+            "title": "Karte exportieren",
+            "tooltip": "Exportieren Sie die aktuelle Karte",
+            "exportPanel": {
+                "title": "<p><h4>Wählen Sie ein Format</h4></p>",
+                "exportButtonLabel": "Export"
+            },
+            "formats": {
+                "mapstore2": {
+                    "label": "MapStore",
+                    "description": "<p><small>Format zur Kartenkonfiguration innerhalb von MapStore</small></p>"
+                },
+                "wmc": {
+                    "label": "WMC",
+                    "description": "<p><small>Format OGC Web Map Context</small></p>",
+                    "note": "<p><small><i><strong>Hinweis</strong>: Das WMC-Format unterstützt <strong>nur WMS-Ebenen</strong></i></small></p>"
+                }
+            },
+            "errorTitle": "Kartenexport fehlgeschlagen",
+            "wmcNoLayersError": "Mindestens eine WMS-Schicht, die für den Export nach WMC benötigt wird, hat Null gefunden"
+        },
+        "catalog": {
+            "start": "Startdatum ",
+            "end": "Enddatum ",
+            "notAvailable": "Nicht verfügbar",
+            "title": "Katalog",
+            "tooltip": "Fügen Sie der Karte Ebenen hinzu",
+            "autoload": "Suche in Serviceauswahl",
+            "clearValueText": "Auswahl aufheben",
+            "noResultsText": "keine Ergebnisse gefunden",
+            "addToMap": "Zur Karte hinzufügen",
+            "getWMSLink": "WMS Link erhalten",
+            "error": "Beim Laden der Daten ist ein Fehler aufgetreten",
+            "pageInfo": "Resultat {start}-{end} von {total}",
+            "resultInfo": "{total, plural, =0 {Keine Gegenstände} =1 {{total} von {total} stimmt überein} other {{start}-{end} von {total}}}",
+            "pageInfoInfinite": "{total, plural, =undefined {} =0 {Keine Ergebnisse} =1 {{total} von {total} stimmt überein} other {Geladen {loaded} von {total} übereinstimmend}",
+            "noRecordsMatched": "Kein passender Eintrag",
+            "wmsGetCapLink": "WMS",
+            "wfsGetCapLink": "WFS",
+            "share": "Teilen",
+            "copyToClipboard": "In die Zwischenablage kopieren",
+            "copied": "Kopiert!",
+            "textSearchPlaceholder": "Zu suchender Text...",
+            "search": "Suche",
+            "delete": "Löschen",
+            "reset": "Zurücksetzen",
+            "options": "Optionen",
+            "srs_not_allowed": "Das Koordinatensystem der Karte wird von dieser Anwendung nicht unterstützt",
+            "add": "Hinzufügen",
+            "service": "Service",
+            "servicePlaceholder": "Geben Sie einen Service ein",
+            "url": "Url",
+            "urlPlaceholder": "Geben Sie eine URL ein",
+            "type": "Typ",
+            "serviceTitle": "Titel",
+            "serviceTitlePlaceholder": "Geben Sie einen Titel ein",
+            "tms": {
+              "provider": "Anbieter",
+              "urlTemplate": "URL-Vorlage",
+              "urlTemplateHint": "<p> Vorlagen-URL für Ihren benutzerdefinierten TMS-Dienst mit der Möglichkeit, Variablen einzufügen (ausgedrückt in geschweiften Klammern, z. B. <code> {var_name} </ code>), die von der Anwendung ersetzt werden. <br />. Die Variablen <code> {x} </ code>, <code> {y} </ code> und <code> {z} </ code> sind für Kachelgitterkoordinatenwerte reserviert. Sie können auch Variablen verwenden <code> {s} </ code> für Subdomains. Jede andere in der URL angegebene Variable muss auch in den Optionen unter \"Benutzerdefinierte TMS-Konfiguration\" (Erweiterte Einstellungen) angegeben werden.</p>",
+              "customTMSConfiguration": "Benutzerdefinierte TMS-Konfiguration",
+              "customTMSConfigurationHint": "<p> Optionen können Folgendes enthalten: <br/> <ul> <ul> <li> <code>\"subdomains\": ['a', 'b'] </ code>: Wird für mehrere Domains verwendet. Ersetzen des <code> {s} </code> in der URL-Vorlage </li> <li> <code> \"maxNativeZoom\": 20 </code>: Maximaler Zoom vom Server </li> </ul> </p>",                  "forceDefaultTileGrid": "Standard-Kachelraster erzwingen",
+              "forceDefaultTileGridDescription": "Verwenden Sie das Kachelraster der globalen Projektion anstelle des vom Server bereitgestellten Ursprungs und der vom Server bereitgestellten Auflösungen. Dies ist nützlich für einige TMS-Dienste, die falsche Ursprünge oder Ergebnisse anzeigen."
+            },
+            "tileprovider": {
+              "tooltip": "x, y, z sind Kachelpositionen, s ist die Unterdomäne (Standard)"
+            },
+            "missingReference": "Fehlende OGC-Referenzmetadaten",
+            "showDescription": "Vollständige Beschreibung anzeigen",
+            "hideDescription": "Vollständige Beschreibung ausblenden",
+            "templateFormatDescriptionExample": "Die Beschreibung der Ebene lautet",
+            "showTemplate": "Metadatenvorlage anzeigen",
+            "showPreview": "Vorschau zeigen",
+            "advancedSettings": "Erweiterte Einstellungen",
+            "templateMetadataAvailable": "Metadaten im Dublin Core-Format verfügbar: abstract, boundingBox, contributor, creator, description, format, identifier, references, rights, source, subject, temporal, title, type, uri",
+            "invalidUrlHttpProtocol": "Dieser Katalog kann nicht zu den verfügbaren hinzugefügt werden, da er ein http-Protokoll verwendet. Bitte geben Sie eine Katalog-URL an, die das https-Protokoll verwendet.",
+            "notification": {
+                "errorTitle": "Error",
+                "errorSearchingRecords": "Einige Datensätze wurden nicht gefunden: {records} . Bitte überprüfen Sie die URL des Abfrageparameters",
+                "warningAddCatalogService": "Geben Sie eine gültige URL und einen Titel ein",
+                "addCatalogService": "Service wurde korrekt hinzugefügt",
+                "duplicatedServiceTitle": "Ein Service mit diesem Titel existiert bereits, bitte ändere den Titel",
+                "serviceDeletedCorrectly": "Der Service wurde korrekt gelöscht",
+                "errorServiceUrl": "Service nicht verfügbar. Bitte überprüfen Sie die angegebene URL"
+            },
+            "backgroundAlreadyAdded": "Zur Hintergrundauswahl hinzugefügt",
+            "enableLocalizedLayerStyles": {
+                "label": "Lokalisierten Stil aktivieren",
+                "tooltip": "Hinweis: Diese Einstellung benötigt spezifische Konfigurationen im GeoServer"
+            },
+            "format": {
+                "noOption": "Keine Option",
+                "loading": "Wird geladen..."
+            }
+        },
+        "uploader": {
+            "filename": "Dateiname",
+            "type": "Dateityp",
+            "lastModified": "Zuletzt geändert",
+            "filesize": "Größe",
+            "beforeUpload": "Bereite Upload vor... ",
+            "uploadingFiles": "Lade Dateien hoch...",
+            "dropfile": "Ziehe Dateien für den Upload hierhier",
+            "dropfileImport": "Ziehe Dateien hierher um Sie dem Import hinzuzufügen"
+        },
+        "importer": {
+            "title": "Daten Import",
+            "imports": "Importe",
+            "importN": "Import {id}",
+            "creatingImportProcess": " Erstelle Import... ",
+            "dropfile": "Ziehe Dateien hierher um einen neuen Import zu beginnen",
+            "dropfileImport": "Ziehe Dateien hierher um Sie dem aktuellen Import hinzuzufügen",
+            "process": "Import",
+            "number": "#",
+            "workspace": {
+                "create": "Erstellen",
+                "createWS": "Erstelle einen neuen Workspace: ",
+                "target": "Ziel Workspace: ",
+                "failure": "Fehler beim Erstellen des Workspace: {statusWS}",
+                "success": "Workspace {statusWS} erfolgreich erstellt",
+                "select": "Wähle Ziel Workspace",
+                "new": "Name des neuen Workspaces..."
+            },
+            "import": {
+                "actions": "Aktionen",
+                "tasks": "Packages",
+                "runImport": "Ausführen",
+                "deleteImport": "Import löschen",
+                "deleteTask": "Löschen",
+                "status": "Status",
+                "archive": "Archiv",
+                "deleting": "Löschen...",
+                "analyzing": "Analyse des Packages...",
+                "applyingPreset": "Wende Voreinstellungen an..."
+            },
+            "task": {
+                "panelTitle": "Package Import {id}",
+                "general": "Allgemeine Info",
+                "status": "Status",
+                "updateMode": "Aktualisierungsmodus",
+                "originalData": "Original Datei",
+                "file": "Datei Name",
+                "format": "Format",
+                "targetStore": "Ziel",
+                "storeType": "Art des Ziels",
+                "storeName": "Name des Ziels",
+                "layer": "Ebene",
+                "transforms": "Transformationen-Kette",
+                "update": "Update",
+                "run": "Importiere dieses Package",
+                "edit": "Bearbeite Standard Stil",
+                "delete": "Lösche dieses Package"
+            },
+            "transform": {
+                "panelTitle": "Transformation {id}",
+                "type": "Transformations Art",
+                "actions": "Aktionen",
+                "options": "Transformations Optionen",
+                "overviewlevels": "Level Übersicht",
+                "delete": "Lösche diese Transformation"
+            }
+        },
+        "rasterstyler": {
+            "tooltip": "Erstelle und bearbeite den Stil der Raster Ebenen",
+            "paneltitle": "Raster Styler",
+            "layerlabel": "Ebene",
+            "typelabel": "Stil Art",
+            "opacitylabel": "Deckkraft",
+            "redtitle": "Rot",
+            "greentitle": "Grün",
+            "bluetitle": "Blau",
+            "graytitle": "Grau",
+            "pseudobandtitle": "Band Auswahl",
+            "eqinttitle": "Equal Interval Klassifikation",
+            "pseudotitle": "PseudoColor Einstellungen",
+            "applybtn": "Stil anwenden"
+        },
+        "bandselector": {
+            "band": "Band",
+            "enhancement": "Verbesserung",
+            "algorithmTitle": "Optionaler Algorithmus",
+            "value": "Wert",
+            "min": "Min",
+            "max": "Max",
+            "enha": {
+                "none": "Keine",
+                "Normalize": "Normalisieren",
+                "Histogram": "Histogram",
+                "GammaValue": "Gamma Korrektur"
+            },
+            "algorithm": {
+                "none": "Keiner",
+                "StretchToMinimumMaximum": "Stretch",
+                "ClipToMinimumMaximum": "Clip",
+                "ClipToZero": "Clip To Zero"
+            }
+        },
+        "equalinterval": {
+            "min": "Min",
+            "max": "Max",
+            "classes": "Classes",
+            "ramp": "Color Ramp",
+            "classify": "Klassifizieren",
+            "maxerror": "Maximum Wert muß größer als der Minimum Wert sein",
+            "minerror": "Minimum Wert muß größer als der Maximum Wert sein"
+        },
+        "colormapgrid": {
+            "color": "Farbe",
+            "quantity": "Quantität",
+            "label": "Beschreibung",
+            "minmaxerror": "Der Wert muss zwischen den Werten der vorherigen und der nächsten Zelle liegen"
+        },
+        "pseudocolorsettings": {
+            "type": "Art",
+            "extended": "Extended",
+            "colormap": "Color Map",
+            "add": "Eintrag hinzufügen",
+            "remove": "Eintrag entfernen"
+        },
+        "rasterstyletype": {
+            "rgb": "Rot Grün Blau",
+            "gray": "Grauwerte",
+            "pseudo": "PseudoColor",
+            "multi": "Multi Band",
+            "single": "Single Band"
+        },
+        "featuregrid": {
+            "columns": "Spalten",
+            "header": "Suchresultate",
+            "tools": "Werkzeugpalette",
+            "export": "Export",
+            "selectall": "Alle auswählen",
+            "deselectall": "Auswahl aufheben",
+            "backtosearch": "Zurück zur suche",
+            "resultInfo": "{total, plural, =0 {Keine Artikel} =1 {{total} von {total}} other {{start}-{end} von {total}}}",
+            "resultInfoVirtual": "{total, plural, =0 {Keine Artikel} =1 {{total}} other {{total}}}",
+            "selectedInfo": "( {selected} ausgewählt )",
+            "pageInfo": "{totalPages, plural, =0 {keine Seite} =1 {Seite {totalPages} von {totalPages}} other {Seite {page} von {totalPages}}}",
+            "pagination": {
+                "page": "Seite",
+                "of":   "von",
+                "to":   "bis",
+                "more": "viele"
+            },
+            "noFeaturesAvailable": "Keine Objekte verfügbar",
+            "errorProjFetch": "Fehler beim Abrufen der proj4-String-Definition von spatialreference.org. Das Synchronisierungstool kann den räumlichen Filter nicht anwenden.",
+            "errorSaving": "Beim Speichern des Vorgangs ist ein Fehler aufgetreten",
+            "notSupportedGeometryTitle": "Geometrietyp wird nicht unterstützt ",
+            "notSupportedGeometry": "Der aktuelle Ebenengeometrietyp wird von der Bearbeitung nicht unterstützt, Sie können jedoch weiterhin Attribute bearbeiten",
+            "yesButton": "ja",
+            "noButton": "nein",
+            "deleteButton": "Löschen",
+            "clear": "Sind Sie sicher, dass Sie alle vorgenommenen Änderungen rückgängig zu machen wollen?",
+            "featureClose": "Wollen Sie das Raster wirklich schließen?",
+            "delete": "Wollen Sie die {count} Elemente entfernen?",
+            "missingGeometry": "Fehlende Geometrie",
+            "filter": {
+                "placeholders": {
+                    "default": "Beispiele...",
+                    "string": "Geben Sie Text ein, um Ergebnisse zu filtern ...",
+                    "date": "Geben Sie das zu filternde Datum ein...",
+                    "number": "Geben Sie eine Zahl oder einen Ausdruck ein..."
+                },
+                "tooltips": {
+                    "editMode": "Die Schnellsuche ist im Bearbeitungsmodus nicht verfügbar",
+                    "default": "Beispiele...",
+                    "string": "Geben Sie Text ein, um Ergebnisse zu filtern ...",
+                    "number": "Geben Sie eine Zahl oder einen Ausdruck ein. Examples: 10, > 2, < 10",
+                    "date": "Geben Sie ein Datum oder einen Ausdruck ein. Verwenden Sie {format} für das Datum.",
+                    "geometry": {
+                        "disabled": "Klicken Sie auf die Karte, um zu filtern / Alt + Maus ziehen, um einen Box-Filter zu zeichnen. Halten Sie auch die Strg-Taste gedrückt, um dem aktuellen Filter weitere Funktionen hinzuzufügen",
+                        "enabled": "Klicken Sie auf die Karte, um ein Feature auszuwählen / Alt + Maus ziehen, um einen Boxfilter zu zeichnen. Halten Sie die Strg-Taste gedrückt und klicken Sie, um mehrere Features auszuwählen",
+                        "applied": "Auswahl bereinigen"
+                    }
+                }
+            },
+            "toolbar": {
+                "synchPopoverTitle": "Karte mit Filter synchronisieren ",
+                "synchPopoverText": "Verwenden Sie dieses Werkzeug, um die Karte mit dem ausgewählten Filter zu synchronisieren",
+                "notShowAgain": "Diese Nachricht nicht erneut anzeigen",
+                "editMode": "Bearbeitungsmodus",
+                "advancedFilter": "Erweiterte Suche",
+                "quitEditMode": "Beenden Sie den Bearbeitungsmodus",
+                "addNewFeatures": "Neues Objekt hinzufügen",
+                "editFeature": "Bearbeiten Sie das Objekt",
+                "drawGeom": "Geometrie zeichnen",
+                "stopDrawGeom": "Geometrieerstellung abbrechen",
+                "addGeom": "Fügen Sie ein Element an die vorhandene Geometrie",
+                "deleteSelectedFeatures": "Ausgewähltes Objekt löschen",
+                "saveChanges": "Änderungen speichern",
+                "saving": "Speichern...",
+                "cancelChanges": "Änderungen abbrechen",
+                "deleteGeometry": "Geometrie löschen",
+                "downloadGridData": "Daten herunterladen",
+                "hideShowColumns": "Spalten aus- / einblenden",
+                "zoomAll": "Auf Seitenausdehnung zoomen",
+                "syncOnMap": "Karte mit Filter synchronisieren",
+                "enableTimeSync": "Mit der ausgewählten Zeit oder dem ausgewählten Zeitintervall synchronisieren",
+                "disableTimeSync": "Nicht mit der ausgewählten Zeit oder dem ausgewählten Intervall synchronisieren",
+                "createNewChart": "Diagramm für die ausgewählte Ebene erstellen"
+            }
+        },
+        "layerdownload": {
+            "title": "Daten exportieren",
+            "format": "Dateiformat",
+            "srs": "Räumliches Bezugssystem",
+            "export": "Export",
+            "downloadonlycurrentpage": "Nur aktuelle Ansicht herunterladen",
+            "cropDataSet": "Zuschneiden des Datensatzes in das aktuelle Ansichtsfenster",
+            "downloadFilteredDataSet": "Laden Sie den gefilterten Datensatz herunter",
+            "advancedOptions": "Erweiterte Optionen",
+            "compression": "Kompression",
+            "tileWidth": "Fliesenbreite",
+            "tileHeight": "Fliesenhöhe",
+            "quality": "Qualität",
+            "error": {
+                "title": "Fehler beim Export",
+                "invalidOutputFormat": "Das ausgewählte Exportformat ist nicht verfügbar",
+                "downloadEstimatorTitle": "DownloadEstimator-Fehler",
+                "downloadEstimatorFailed": "Die DownloadEstimator-Anforderung ist fehlgeschlagen. Dies bedeutet, dass die exportierte Datei die konfigurierten Serverlimits überschreitet. Versuchen Sie, die Download-Optionen zu ändern oder Filter zu Ihrer Ebene hinzuzufügen, und versuchen Sie es erneut."
+            },
+            "exportResultsMessages": {
+                "newExport": "Die Datei ist hier verfügbar, wenn der Export abgeschlossen ist",
+                "exportFailure": "Export für Layer \"{layerTitle}\" fehlgeschlagen! Öffnen Sie den Dialog mit den Exportergebnissen, um weitere Informationen zu erhalten.",
+                "exportSuccess": "Der Export für die Ebene \"{layerTitle}\" wurde erfolgreich abgeschlossen.",
+                "invalidHref": "Die Antwort vom Server enthielt keine gültige URL-Adresse für exportierte Dateien!"
+            },
+            "wpsExecuteError": {
+                "processFailed": "Download-Vorgang fehlgeschlagen! Der Server hat den folgenden Ausnahmebericht zurückgegeben: \"{exceptionReport}\"",
+                "badResponse": "Download-Vorgang fehlgeschlagen! Der Server hat falsche Daten zurückgegeben, Fehlercode: \"{errorCode}\"",
+                "executeProcessXhrFailed": "ExecuteProcess-Anforderung fehlgeschlagen! Der Server ist möglicherweise falsch konfiguriert oder nicht mehr erreichbar",
+                "getExecutionStatusXhrFailed": "GetExecutionStatus-Anforderung fehlgeschlagen! Der Server ist möglicherweise falsch konfiguriert oder nicht mehr erreichbar",
+                "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten"
+            },
+            "noSupportedServiceFound": "Der Server unterstützt keinen WFS- oder WPS-Download für diese Ebene!"
+        },
+        "exportDataResults": {
+            "title": "Datenergebnisse exportieren",
+            "emptyStateMessage": "Die Exportliste ist leer"
+        },
+        "widgets": {
+            "types": {
+                "map": {
+                    "title": "Karte",
+                    "caption": "Eine Karte hinzufügen"
+                },
+                "legend": {
+                    "title": "Legende",
+                    "caption": "fügen Sie eine Legende hinzu"
+                },
+                "chart": {
+                    "title": "Grafik",
+                    "caption": "fügen Sie ein Diagramm hinzu"
+                },
+                "text": {
+                    "title": "Text",
+                    "caption": "fügen Sie einen Textbereich hinzu"
+                },
+                "table": {
+                    "title": "Tabelle",
+                    "caption": "fügen Sie eine Tabelle hinzu"
+                },
+                "counter": {
+                    "title": "Zähler",
+                    "caption": "fügen Sie einen Zähler hinzu"
+                }
+            },
+            "selectWidgetType": "Wählen Sie den Widgettyp",
+            "selectChartType": {
+                "title": "Wählen Sie den Diagrammtyp aus"
+            },
+            "selectMap": {
+                "TOC": {
+                    "noLayerTitle": "Keine Ebenen",
+                    "noLayerDescription": "Es gibt keine Ebenen in der Karte. Wenn Sie eine Ebene aus dem Katalog hinzufügen möchten, klicken Sie auf die Schaltfläche '+' in der Symbolleiste oben"
+                 },
+                 "emptyMap": {
+                    "title": "Leere Karte",
+                    "description": "Mit leerer Karte beginnen"
+                }
+            },
+            "title": "Titel",
+            "description": "Beschreibung",
+            "errors": {
+                "notext": "Kein Text verfügbar",
+                "nodata": "Keine Daten für den ausgewählten Layer / Filter verfügbar",
+                "noLegend": "Keine Legenden zu zeigen",
+                "noLegendDescription": "Die verbundene Karte hat keine Ebenen, die in der Legende angezeigt werden",
+                "nodatainviewport": "Keine Daten im aktuellen Ansichtsfenster",
+                "timeoutExpired": "Der Aufruf des Service hat zu lange gedauert. Vielleicht ist die Abfrage zu komplex oder der Server ist beschäftigt",
+                "genericError": "Beim Abrufen der Daten ist ein Fehler aufgetreten",
+                "genericErrorWithMessage": "Beim Abrufen der Daten ist ein Fehler aufgetreten: \"{message}\""
+            },
+            "builder": {
+                "header": {
+                    "title": "Widget"
+                },
+                "wizard": {
+                    "backToTypeSelection": "Zurück zur Typenauswahl",
+                    "backToWidgetTypeSelection": "Zurück zur Auswahl des Widget-Typs",
+                    "backToFeatureGrid": "Zurück zum Feature-Raster",
+                    "backToLayerSelection": "Zurück zur Ebenenauswahl",
+                    "backToMapSelection": "Zurück zur Kartenauswahl",
+                    "backToPreview": "Zurück zur Vorschau",
+                    "backToChartOptions": "Zurück zu den Diagrammoptionen",
+                    "selectALayer": "Wähle eine Ebene",
+                    "selectAMap": "Wählen Sie eine Karte",
+                    "configureChartOptions": "Diagrammoptionen konfigurieren",
+                    "configureWidgetOptions": "Widget-Optionen konfigurieren",
+                    "backToTableOptions": "Zurück zu den Tabellenoptionen",
+                    "configureTableOptions": "Konfigurieren Sie die Tabellenoptionen",
+                    "resetColumnsSizes": "Setzen Sie alle Änderungen an den Spaltengrößen zurück",
+                    "updateWidget": "Aktualisieren Sie das Widget",
+                    "addTheWidget": "Hinzufügen des Widget",
+                    "titlePlaceholder": "Gib den Titel ein...",
+                    "textPlaceholder": "Text eingeben...",
+                    "useThisMap": "Benutze diese Karte",
+                    "configureMapOptions": "Kartenoptionen konfigurieren",
+                    "enableIdentifyTool": "Identifizierungswerkzeug aktivieren",
+                    "disableIdentifyTool": "Identifizierungswerkzeug deaktivieren",
+                    "preview": "Vorschau",
+                    "addLayer": "Fügt der Karte eine Ebene hinzu",
+                    "useTheSelectedLayer": "Verwende die ausgewählte Ebene",
+                    "connectToAMap": "Stellen Sie eine Verbindung zu einem anderen Widget her",
+                    "connectToTheMap": "Stellen Sie eine Verbindung mit dem anderen Widget her",
+                    "selectMapToConnect": "Wählen Sie das zu verbindende Widget aus",
+                    "clearConnection": "Verbindung löschen"
+                },
+                "errors": {
+                    "noAttributesTitle": "Keine Attribute zum Anzeigen",
+                    "noAttributesDescription": "Die ausgewählte Ebene enthält keine anzuzeigenden Attribute. Bitte wählen Sie einen anderen Widget-Typ oder Layer",
+                    "noWidgetsAvailableTitle": "Das Widget für die ausgewählte Ebene kann nicht erstellt werden",
+                    "noWidgetsAvailableDescription": "<p><strong>Bitte wählen Sie eine andere Ebene oder einen anderen Widgets-Typ</strong></p><p>Der Server bietet nicht die erforderlichen Dienste für die Ebene und den ausgewählten Widget-Typ</p><p> Mögliche Ursachen sind: <ul> <li> Der ausgewählte Layer ist ein Raster-Layer </li> <li> Der WFS-Service ist nicht verfügbar </li> <li> Der WPS-Prozess <code>gs:aggregate</code> ist nicht verfügbar </li> </ul> </p>",
+                    "checkAtLeastOneAttribute": "Sie müssen mindestens eine Spalte auswählen",
+                    "noMapAvailableForLegend": "Keine Karte verfügbar",
+                    "noMapAvailableForLegendDescription": "Sie benötigen mindestens ein Karten-Widget, um die Legende zu erstellen"
+                },
+                "setupFilter": "Konfigurieren Sie einen Filter für die Widgetdaten"
+            },
+            "widget": {
+                "menu": {
+                    "showChartData": "Diagrammdaten anzeigen",
+                    "edit": "Bearbeiten",
+                    "delete": "Löschen",
+                    "collapse": "Reduzieren",
+                    "confirmDelete": "Sind Sie sicher?",
+                    "downloadData": "Daten herunterladen",
+                    "exportImage": "Bild exportieren",
+                    "maximize": "Maximieren",
+                    "minimize": "Minimieren",
+                    "pin": "Pin",
+                    "unpin": "Unpin",
+                    "hide": "Verbergen",
+                    "hideDescription": "Verstecken Sie dieses Widget für andere Benutzer",
+                    "unhide": "Einblenden",
+                    "unhideDescription": "Blenden Sie das Widget für andere Benutzer ein"
+                }
+            },
+            "chartType": {
+                "bar": {
+                    "title": "Balkendiagramm",
+                    "description": "Erstellen Sie ein Balkendiagramm, das der Karte hinzugefügt werden soll",
+                    "caption": "bar"
+                },
+                "pie": {
+                    "title": "Kuchendiagramm",
+                    "description": "Erstellen Sie ein Kreisdiagramm, um es der Karte hinzuzufügen",
+                    "caption": "pie"
+                },
+                "line": {
+                    "title": "Liniendiagramm",
+                    "description": "Erstellen Sie ein Liniendiagramm, das der Karte hinzugefügt werden soll",
+                    "caption": "line"
+                },
+                "gauge": {
+                    "title": "Messuhr",
+                    "description": "Erstellen Sie ein Messdiagramm, um es der Karte hinzuzufügen.",
+                    "caption": "gauge"
+                }
+            },
+            "chartOptionsTitle": "Daten konfigurieren",
+            "widgetOptionsTitle": "Widget-Informationen konfigurieren",
+            "placeHolder":{
+                "default":"Wählen Sie Attribut"
+            },
+            "operations": {
+                "COUNT": "COUNT",
+                "SUM": "SUM",
+                "AVG": "AVG",
+                "STDDEV": "STDDEV",
+                "MIN": "MIN",
+                "MAX": "MAX",
+                "NONE": "No Operation"
+              },
+            "groupByAttributes": {
+                "line": "X-Attribut",
+                "pie": "Gruppiere nach",
+                "bar": "X-Attribut",
+                "gauge": "Gruppiere nach",
+                "counter": "Gruppiere nach",
+                "default": "Gruppiere nach"
+            },
+            "aggregationAttribute": {
+                "line": "Y-Attribut",
+                "pie": "Benutzen",
+                "bar": "Y-Attribut",
+                "gauge": "Benutzen",
+                "counter": "Benutzen",
+                "default": "Benutzen"
+            },
+            "aggregateFunction": {
+                "line": "Betrieb",
+                "pie": "Betrieb",
+                "bar": "Betrieb",
+                "gauge": "Betrieb",
+                "counter": "Betrieb",
+                "default": "Betrieb"
+            },
+            "colorRamp": {
+                "line": "Farbe",
+                "pie": "Farbrampe",
+                "bar": "Farbe",
+                "gauge": "Farbe",
+                "counter": "Farbe",
+                "default": "Farbe"
+            },
+            "uom": {
+                "line": "Maßeinheit",
+                "pie": "Maßeinheit",
+                "bar": "Maßeinheit",
+                "gauge": "Maßeinheit",
+                "counter": "Maßeinheit",
+                "default": "Maßeinheit"
+            },
+            "mapSync": "Live-Filter nach Ansichtsfenster",
+            "displayLegend": {
+                "line": "Legende anzeigen",
+                "pie": "Legende anzeigen",
+                "bar": "Legende anzeigen",
+                "gauge": "Legende anzeigen"
+            },
+            "advanced": {
+                "displayCartesian": "Gitter ausblenden",
+                "xAxis": "X-Achse",
+                "xAxisAngle": "Etikettendrehung",
+                "hideLabels": "Labels ausblenden",
+                "format": "Format",
+                "prefix": "Präfix",
+                "suffix": "Suffix",
+                "examples": "Beispiele",
+                "formatExamples": "<div> <ul> <li> <code> .0% </code>: gerundeter Prozentsatz, '12% '</li> <li> <code> .2s </code>: SI -Präfix mit zwei signifikanten Ziffern, '42M' </li> <li> <code>, .2r </code>: gruppierte Tausende mit zwei signifikanten Ziffern '4.200' </li> </ul> <em>Weitere Informationen zur Formatierungssyntax <a target=\"_blank\" href=\"https://d3-wiki.readthedocs.io/zh_CN/master/Formatting/\"> hier</a>. </em> </div> ",
+                "formula": "Formel",
+                "formulaExamples": "<div>Transformiert den Wert mithilfe einer Formel. Verwenden Sie die Variable <code> value </code> im Ausdruck: <h5> Beispiele </h5> <ul> <li> <code> value + 2 </code> </li> <li> <code> value / 100 </code> </li> </ul><em>Weitere Informationen zur Syntax <a target=\"_blank\" href=\"https://github.com/m93a/filtrex#expressions\">hier</a>.</em></div>",
+                "xAxisType": "Type",
+                "forceTicks": "Überspringe niemals Etik.",
+                "maxXAxisLabels": "Die Beschriftungen dürfen nicht mehr als {max} sein",
+                "yAxis": "Y-Achse",
+                "yAxisType": "Type",
+                "yAxisLabel": "Legend Label",
+                "title": "Erweiterte Optionen",
+                "legend": "Legende",
+                "axisTypes": {
+                  "auto": "Auto",
+                  "linear": "linear",
+                  "category": "Kategorie",
+                  "log": "Logarithmus",
+                  "date": "Datum"
+                }
+             },
+            "tray": {
+                "title": "Widgets",
+                "expandTray": "Widgetleiste erweitern",
+                "collapseTray": "Widgetleiste ausblenden",
+                "expandAll": "Alle Widgets öffnen",
+                "collapseAll": "Alle Widgets schließen",
+                "notifications": {
+                    "collapsed": {
+                        "message": "Zeitleiste und Widgets können nicht gleichzeitig bleiben. In der Taskleiste des Widgets verwenden, um zwischen Zeitleiste und Widgets zu wechseln",
+                        "timelineTitle": "Zeitleiste wurde reduziert",
+                        "widgetsTitle": "Widgets wurden reduziert"
+                    }
+                }
+            }
+        },
+        "dashboard": {
+            "loadingSpinner": "Dashboard wird geladen",
+            "errors":{
+                "loading": {
+                    "title": "Fehler beim Laden des Dashboards",
+                    "dashboardNotAccessible": "Sie sind nicht berechtigt, auf dieses Dashboard zuzugreifen. Wenden Sie sich an den Ressourcenbesitzer",
+                    "pleaseLogin": "Dieses Dashboard ist nicht öffentlich. Bitte versuchen Sie sich einzuloggen",
+                    "dashboardDoesNotExist": "Das Dashboard, auf das Sie zugreifen möchten, existiert nicht",
+                    "unknownError":  "Beim Laden des Dashboards ist ein Fehler aufgetreten. Bitte wenden Sie sich an den Administrator.",
+                    "notFound": "Dashboard nicht gefunden",
+                    "notAccessible": "Dashboard nicht zugänglich"
+                },
+                "resourceAlreadyExists": "Eine Ressource mit diesem Namen existiert bereits",
+                "forbidden": "Ein unerwarteter Fehler ist aufgetreten (403 Verboten). Bitte wenden Sie sich an den Administrator",
+                "forbidden405": "Ein unerwarteter Fehler ist aufgetreten (405 Verboten). Bitte wenden Sie sich an den Administrator"
+            },
+            "editor": {
+                "save": "Speichern Sie das Dashboard",
+                "addACardToTheDashboard": "Ein Widget zum Dashboard hinzufügen",
+                "showConnections": "Verbindungen anzeigen",
+                "hideConnections": "Verbindungen ausblenden"
+            },
+            "emptyTitle": "Das Dashboard ist leer"
+        },
+        "dashboardEmbedded": {
+            "loadingSpinner": "Dashboard wird geladen",
+            "errors":{
+                "loading": {
+                    "title": "Fehler beim Laden des Dashboards",
+                    "dashboardNotAccessible": "Sie sind nicht berechtigt, auf dieses Dashboard zuzugreifen",
+                    "pleaseLogin": "Dieses Dashboard ist nicht öffentlich",
+                    "dashboardDoesNotExist": "Das Dashboard, auf das Sie zugreifen möchten, existiert nicht",
+                    "unknownError":  "Beim Laden des Dashboards ist ein Fehler aufgetreten",
+                    "notFound": "Dashboard nicht gefunden",
+                    "notAccessible": "Dashboard nicht zugänglich"
+                }
+            },
+            "emptyTitle": "Das Dashboard ist leer"
+        },
+        "context": {
+            "loadingSpinner": "Loading Context",
+            "errors": {
+                "loading": {
+                    "title": "Fehler beim Laden Kontext",
+                    "notAccessible": "Ressource nicht zugänglich",
+                    "pleaseLogin": "Einige Ressource kann nicht öffentlich. Bitte versuchen Sie sich einloggen",
+                    "unknownError": "Es gab einen Fehler in der Karte oder den Kontext geladen. Bitte kontaktieren Sie den Administrator",
+                    "notFound": "Ressource nicht gefunden"
+                },
+                "context": {
+                    "notAccessible": "Sie haben nicht das Recht, die Erlaubnis zu diesem Kontext zuzugreifen. Bitte kontaktieren Sie den Administrator-Zugriff zu erhalten",
+                    "pleaseLogin": "Dieser Zusammenhang ist nicht öffentlich. Bitte versuchen Sie sich einloggen",
+                    "unknownError": "Es gab einen Fehler den Kontext geladen. Bitte kontaktieren Sie den Administrator",
+                    "notFound": "Der Kontext Sie zugreifen möchten, existiert nicht"
+                },
+                "template": {
+                    "title": "Fehler beim Laden der Vorlage",
+                    "notAccessible": "Sie haben keine Berechtigung, auf diese Vorlage zuzugreifen. Bitte wenden Sie sich an den Eigentümer der Ressource",
+                    "pleaseLogin": "Diese Vorlage ist nicht öffentlich. Bitte versuchen Sie sich einzuloggen",
+                    "unknownError": "Beim Laden der Vorlage ist ein Fehler aufgetreten. Bitte wenden Sie sich an den Administrator",
+                    "notFound": "Die Vorlage, auf die Sie zugreifen möchten, ist nicht vorhanden"
+                },
+                "map": {
+                    "notAccessible": "Sie haben nicht das Recht, die Erlaubnis zu dieser Karte zuzugreifen. Bitte kontaktieren Sie den Administrator-Zugriff zu erhalten",
+                    "pleaseLogin": "Diese Karte oder die Karte ist nicht öffentlich. Bitte versuchen Sie sich einloggen",
+                    "unknownError": "Es gab einen Fehler in der Karte geladen werden. Bitte kontaktieren Sie den Administrator",
+                    "notFound": "Die Karte, die Sie zugreifen möchten, existiert nicht"
+                },
+                "plugins": {
+                  "upload": "Fehler beim Hochladen des Plugins",
+                  "uninstall": "Fehler beim Deinstallieren des Plugins"
+                },
+                "resourceAlreadyExists": "Eine Ressource mit diesem Namen existiert bereits"
+            }
+        },
+        "wizard": {
+            "next": "Nächster",
+            "prev": "Bisherige",
+            "finish": "Fertig"
+        },
+        "vectorstyler": {
+            "tooltip": "Erstelle und bearbeite den Vektor Ebenen Stil",
+            "paneltitle": "Vektor Styler",
+            "layerlabel": "Ebene",
+            "rulelabel": "Regeln",
+            "namelabel": "Regel Name",
+            "symboltitle": "Symbol",
+            "labeltitle": "Label",
+            "conditiontitle": "Bedingungen",
+            "applybtn": "Stil anwenden",
+            "addrulebtn": "Regel hinzufügen",
+            "removerulebtn": "Regel entfernen"
+        },
+        "scaledenominator": {
+            "minlabel": "Skalierungs Minimum Nenner",
+            "maxlabel": "Skalierungs Maximum Nenner",
+            "maxerror": "Maximum Wert muß größer als der Minimum Wert sein",
+            "minerror": "Minimum Wert muß größer als der Maximum Wert sein",
+            "none": "None"
+        },
+        "markNameSelector": {
+            "circle": "Kreis",
+            "square": "Rechteck",
+            "triangle": "Dreieck",
+            "star": "Stern",
+            "cross": "Kreuz",
+            "x": "X"
+        },
+        "styler": {
+            "tooltip": "Erstelle und bearbeite den Ebenen Stil",
+            "paneltitle": "Gestalter",
+            "layerlabel": "Ebene"
+        },
+        "styleeditor": {
+            "styleListfilterPlaceholder": "Filtern Sie Stile nach Name, Titel oder Abstract",
+            "templateFilterPlaceholder": "Filterstile Vorlagen nach Titel",
+            "createStyleFromTemplate": "Wählen Sie eine Vorlage aus, um einen neuen Stil zu erstellen",
+            "titleRequired": "<div> Titel ist Pflicht! </div> <div> Titel und Abstract müssen alphanumerisch sein </div>",
+            "titleSettings": "Titel",
+            "titleSettingsplaceholder": "Titel eingeben (alphanumerisch)",
+            "abstractSettings": "Zusammenfassung",
+            "abstractSettingsplaceholder": "Zusammenfassung eingeben (alphanumerisch)",
+            "createStyleModalTitle": "Erstellen Sie einen neuen Stil",
+            "filterMatchNotFound": "Keine Stile entsprechen dem eingegebenen Textfilter",
+            "backToList": "Zurück zur Stilliste",
+            "createNewStyle": "Erstellen Sie einen neuen Stil",
+            "editSelectedStyle": "Bearbeiten Sie den ausgewählten Stil",
+            "saveCurrentStyle": "Aktuellen Stil speichern",
+            "addSelectedTemplate": "Fügen Sie die ausgewählte Vorlage zur Liste der Stile hinzu",
+            "deleteSelectedStyle": "Löschen Sie den ausgewählten Stil",
+            "closeWithoutSaveAlertTitle": "Der Stil hat sich geändert",
+            "closeWithoutSaveAlert": "Sie beenden den Style-Editor, ohne Ihre Änderungen zu speichern",
+            "deleteStyleAlertTitle": "Löschen Sie den Stil",
+            "deleteStyleAlert": "Der ausgewählte Stil wird endgültig gelöscht",
+            "delete": "Löschen",
+            "defaultStyle": "Standardstil",
+            "availableStyle": "Verfügbarer Stil",
+            "styleNotFound": "Stil nicht gefunden",
+            "noPermission": "Benutzer kann keine Stile bearbeiten",
+            "deletedStyleSuccessTitle": "Löschen Sie den Stil",
+            "deletedStyleSuccessMessage": "Der Stil wurde erfolgreich gelöscht",
+            "deletedStyleErrorTitle": "Stilfehler löschen",
+            "deletedStyleErrorMessage": "Der aktuelle Stil konnte nicht gelöscht werden",
+            "savedStyleTitle": "Stil gespeichert",
+            "savedStyleMessage": "Der Style wurde erfolgreich gespeichert",
+            "errorTitle": "StyleEditor-Fehler",
+            "parsingCapabilitiesError": "<h4>Mögliche Ursachen:</h4>Es war nicht möglich, die Cababilites zu analysieren und die Stile abzurufen",
+            "globalError": "<h4>Mögliche Ursachen:</h4> Es war nicht möglich, eine Verbindung zum Dienst herzustellen",
+            "missingAvailableStylesMessage": "<ul><h4> Mögliche Ursachen: </h4> <li> Die ausgewählte Ebene ist eine Ebenengruppe. </li> <li> Die Ebene ist nicht serverseitig richtig konfiguriert. </li></ul>",
+            "createTmpErrorTitle": "Neuer temporärer Stil",
+            "createTmpStyleErrorMessage": "Temporärer Stil konnte nicht erstellt werden. Dies könnte aufgrund eines nicht unterstützten Formatformats des Style-Service erfolgen",
+            "updateTmpErrorTitle": "Temporäre Stilaktualisierung",
+            "updateTmpStyleErrorMessage": "Temporärer Stil konnte nicht aktualisiert werden. Dies kann auf ein nicht unterstütztes Format- oder Verbindungsproblem zurückzuführen sein.",
+            "createStyleErrorTitle": "Neuer Stil",
+            "createStyleErrorMessage": "Stil konnte nicht im Stildienst gespeichert werden. Dies kann auf ein nicht unterstütztes Format- oder Verbindungsproblem zurückzuführen sein.",
+            "updateStyleErrorTitle": "Stil bearbeiten",
+            "updateStyleErrorMessage": "Der Stil konnte im Stildienst nicht aktualisiert werden. Dies kann auf ein nicht unterstütztes Format- oder Verbindungsproblem zurückzuführen sein.",
+            "validationErrorTitle": "Validierungsfehler",
+            "genericValidationError": "Stil ist nicht gültig und konnte nicht angewendet werden.",
+            "setDefaultStyle": "Legen Sie den ausgewählten Stil als Standard für die aktuelle Ebene fest",
+            "setDefaultStyleSuccessTitle": "Erfolg beim Setzen des Standardstils",
+            "setDefaultStyleSuccessMessage": "Der Standardstil wurde erfolgreich angewendet",
+            "setDefaultStyleErrorTitle": "Fehler beim Festlegen des Standardstils",
+            "setDefaultStyleErrorMessage": "Es ist nicht möglich, den ausgewählten Stil als Standard anzuwenden",
+
+            "enterLegendLabelPlaceholder": "Legendenbezeichnung eingeben",
+            "addMarkSymbolizer": "Markensymbolisierer hinzufügen",
+            "addMarkRule": "Markierungsregel hinzufügen",
+            "shape": "Form",
+            "fill": "Farbe füllen",
+            "strokeColor": "Linienfarbe",
+            "strokeWidth": "Linienbreite",
+            "radius": "Radius",
+            "rotation": "Rotation",
+            "addIconSymbolizer": "Symbol-Symbolisierer hinzufügen",
+            "addIconRule": "Symbolregel hinzufügen",
+            "image": "Bild",
+            "format": "Format",
+            "opacity": "Deckkraft",
+            "size": "Größe",
+            "addLineSymbolizer": "Liniensymbolisierer hinzufügen",
+            "addLineRule": "Zeilenregel hinzufügen",
+            "lineStyle": "Linienstil",
+            "lineCap": "Line cap",
+            "lineJoin": "Line join",
+            "addFillSymbolizer": "Füllsymbolisierer hinzufügen",
+            "addFillRule": "Füllregel hinzufügen",
+            "outlineColor": "Umrissfarbe",
+            "outlineWidth": "Umrissbreite",
+            "addTextSymbolizer": "Textsymbolisierer hinzufügen",
+            "addTextRule": "Textregel hinzufügen",
+            "label": "Label",
+            "fontFamily": "Schriftfamilie",
+            "fontColor": "Schriftfarbe",
+            "fontSize": "Schriftgröße",
+            "fontStyle": "Schriftstil",
+            "fontWeight": "Schriftgewicht",
+            "haloColor": "Halo color",
+            "haloWidth": "Halo width",
+            "offsetX": "Offset x",
+            "offsetY": "Offset y",
+            "addRasterSymbolizer": "Rastersymbolisierer hinzufügen",
+            "addRasterRule": "Rasterregel hinzufügen",
+            "colorRamp": "Farbrampe",
+            "reverse": "umgekehrte Reihenfolge",
+            "attribute": "Attribut",
+            "method": "Methode",
+            "intervals": "Intervalle",
+            "continuous": "kontinuierliche Farben",
+            "lineCapButt": "Butt",
+            "lineCapRound": "Round",
+            "lineCapSquare": "Square",
+            "lineJoinBevel": "Bevel",
+            "lineJoinRound": "Round",
+            "lineJoinMiter": "Miter",
+            "fontStyleNormal": "Normal",
+            "fontStyleItalic": "Italic",
+            "fontWeightNormal": "Normal",
+            "fontWeightBold": "Bold",
+            "boolTrue": "True",
+            "boolFalse": "False",
+            "addRuleBefore": "Fügen Sie zuvor einen neuen Eintrag hinzu",
+            "addRuleAfter": "Neuen Eintrag hinzufügen nach",
+            "remove": "Entfernen",
+            "circle": "Kreis",
+            "square": "Quadrat",
+            "triangle": "Dreieck",
+            "star": "Stern",
+            "cross": "Kreuz",
+            "x": "X",
+            "verticalLine": "Vertikale Linie",
+            "horizontalLine": "Horizontale Linie",
+            "slash": "Schrägstrich",
+            "backslash": "Backslash",
+            "dot": "Punkt",
+            "plus": "Plus",
+            "times": "Zeiten",
+            "openArrow": "Pfeil öffnen",
+            "closedArrow": "Geschlossener Pfeil",
+            "band": "Band",
+            "none": "keine",
+            "normalize": "Normalisieren",
+            "histogram": "Histogramm",
+            "contrastEnhancement": "Kontrastverbesserung",
+            "placeholderInput": "Wert eingeben",
+            "placeholderEnterImageUrl": "Bild-URL eingeben",
+            "selectPlaceholder": "Wert auswählen",
+            "noResultsSelectInput": "Keine Ergebnisse",
+            "channelAuto": "Auto",
+            "openFilterBuilder": "Filter Builder öffnen",
+            "removeRule": "Regel entfernen",
+            "openScaleDenominator": "Open Scale Nenner Filter",
+            "selectScale": "Select scale",
+            "noResultScales": "Keine Skala entspricht Ihrem Filter",
+            "maxScaleDenominator": "Max scale",
+            "minScaleDenominator": "Min scale",
+            "simpleStyle": "Einfacher Stil",
+            "classificationStyle": "Klassifizierungsstil",
+            "patternMarkStyle": "Mustermarkierungsstil",
+            "patternIconStyle": "Mustersymbolstil",
+            "singleBand": "Single band",
+            "rgbaBands": "RGB-Bänder",
+            "pseudoColor": "Pseudofarbe",
+            "undoStyle": "Stil rückgängig machen",
+            "redoStyle": "Redo style",
+            "equalInterval": "Gleiches Intervall",
+            "uniqueInterval": "Einzigartiges Intervall",
+            "quantile": "Quantil",
+            "jenks": "Natürliche Pausen (Jenks)",
+            "standardDeviation": "Varianz",
+            "switchToTextareaEditor": "Zum Textarea-Editor wechseln",
+            "switchToVisualEditor": "Zum visuellen Editor wechseln",
+            "alertForceTranslate": "Sie verlieren alle im Textaree hinzugefügten Änderungen, wenn Sie zum visuellen Editor wechseln. Sind Sie sicher, dass Sie zum visuellen Stil-Editor wechseln?",
+            "stayInTextareaEditor": "Nein, weiter im Textbereich",
+            "useLatestValidStyle": "Ja, zum visuellen Editor wechseln",
+            "validationError": "Validierungsfehler",
+            "incorrectPropertyInputError": "Dies liegt wahrscheinlich an einem fehlenden oder ungültigen Wert in den Eigenschaftseingaben des Stileditors.",
+            "emptyRuleEditorTitle": "Neue Regeln hinzufügen",
+            "emptyRuleEditor": "Es gibt keine Regeln für diesen Stil. Fügen Sie eine neue Regel hinzu, indem Sie in der Symbolleiste auf den gewünschten Symbolisierungstyp klicken",
+            "classificationError": "Dienst nicht verfügbar. Derzeit ist es nicht möglich, eine Klassifizierung zu erstellen",
+            "classificationRasterError": "Dienst nicht verfügbar. Derzeit ist es nicht möglich, eine Rasterklassifizierung zu erstellen.",
+            "classificationUniqueIntervalError": "Maximale Intervallgrenzen überschritten! Sie versuchen, eine eindeutige Intervallklassifizierung mit einem Attribut zu generieren, das mehr als {intervalsForUnique} verschiedene Klassen enthält. Eine eindeutige Intervallklassifizierung sollte auf Attribute mit einem begrenzten Satz von Intervallen angewendet werden, um eine bessere Lesbarkeit des Stils zu ermöglichen. Sie können eine andere Methode für das ausgewählte Attribut ausprobieren",
+            "redChannel": "Red channel",
+            "greenChannel": "Green channel",
+            "blueChannel": "Blue channel",
+            "grayChannel": "Channel",
+            "ruleClassification": "Classification",
+            "ruleRaster": "Raster",
+            "customInterval": "Custom Interval",
+            "styleEmpty": "Dieser Stil hat keine Regeln",
+            "incompleteClassification": "Die Klassifizierung ist unvollständig, da die Einträge nicht verfügbar sind. Stellen Sie sicher, dass alle Eigenschaften korrekt bereitgestellt werden.",
+            "imageSrcEmpty": "Fehlende Bild-URL im Symbolstil",
+            "imageSrcLoadError": "Die angegebene Bildquelle konnte nicht geladen werden. Versuchen Sie es mit einer anderen URL oder stellen Sie sicher, dass die Quelle über MapStore erreichbar ist.",
+            "imageSrcInvalidBase64": "Dies ist kein gültiges base64-Image. Einige Style-Renderer unterstützen diesen Quelltyp nicht. Sie können stattdessen eine externe URL-Quelle verwenden.",
+            "imageSrcNotSupportedBase64Image": "Einige Style-Renderer unterstützen Base64-Images nicht, selbst wenn die aktuelle Quelle gültig ist",
+            "imageFormatEmpty": "Das Bildformat kann nicht identifiziert werden. Bitte wählen Sie das Bildformat aus den verfügbaren in der Dropdown-Liste 'Format' aus",
+            "warningTextOrderTitle": "Warnung",
+            "warningTextOrder": "Die Reihenfolge der Regeln, die den Textstil enthalten, konnte nicht mit der Renderreihenfolge auf der Karte übereinstimmen. Dieses Verhalten hängt mit einigen Rendering-Engines zusammen, die Beschriftungen über andere Regeln ziehen"
+        },
+        "playback": {
+            "settings": {
+                "tooltip": "die Einstellungen",
+                "title": "Wiedergabeeinstellungen",
+                "frameDuration": "Frame-Dauer",
+                "range": {
+                    "title": "Animationsdauer",
+                    "zoomTooltip": "Zoom auf den aktuellen Animationsbereich",
+                    "animationStart": "Animation beginnt",
+                    "animationEnd": "Ende der Animation",
+                    "zoomToCurrentPlayackRange": "Zoom auf den aktuellen Wiedergabebereich",
+                    "setToCurrentViewRange": "Auf aktuellen Ansichtsbereich setzen",
+                    "fitToSelectedLayerRange": "An den Bereich der ausgewählten Ebene anpassen"
+                },
+                "step": {
+                    "tooltip": "Wenn die Option 'An Führungsebene anpassen' deaktiviert ist, können Sie den Animationsschritt anpassen",
+                    "label": "Animationsschritt",
+                    "year": "{number, plural, =0 {Jahr} =1 {Jahr} other {Jahre}}",
+                    "week": "{number, plural, =0 {Woche} =1 {Woche} other {Wochen}}",
+                    "day": "{number, plural, =0 {Tag} =1 {Tag} other {Tage}}",
+                    "hour": "{number, plural, =0 {Stunde} =1 {Stunde} other {Stunden}}",
+                    "minute": "{number, plural, =0 {Minute} =1 {Minute} other {Minuten}}",
+                    "second": "{number, plural, =0 {Sekunde} =1 {Sekunde} other {Sekunden}}"
+                },
+                "mode": {
+                    "title": "Modus",
+                    "following": "Folge der Animation",
+                    "followingDescription": "Wenn die Animation aktiv ist, folgen Sie dem Cursor"
+                }
+            },
+            "backwardStep": "Schritt zurück",
+            "forwardStep" : "Schritt vorwärts",
+            "play": "Abspielen",
+            "pause": "Pause",
+            "paused": "Abspielen (pausiert)",
+            "stop": "Stopp"
+        },
+        "timeline": {
+            "settings": {
+                "title": "Zeitleisten-Einstellungen",
+                "snapToGuideLayer": "Auf Führungsebene ausrichten",
+                "snapToGuideLayerTooltip": "Zwingt den Zeitcursor, sich an den Daten der ausgewählten Ebene zu fangen. Deaktivieren Sie diese Option, um die Zeitcursor zu entsperren und die Anpassung des Animationsschritts zu aktivieren."
+            },
+            "hide": "Zeitleiste ausblenden",
+            "show": "Zeitleiste anzeigen",
+            "mapSyncOn": "Alle Zeiten anzeigen, ohne nach Ansichtsfenster zu filtern",
+            "mapSyncOff": "Nur Zeiten anzeigen, die im aktuellen Ansichtsfenster verfügbar sind",
+            "currentTime": "Gehe zur aktuellen Uhrzeit",
+            "rangeStart": "Gehe zum aktuellen Zeitbereich",
+            "rangeEnd": "Gehe zum aktuellen Zeitbereich",
+            "hideLayerName": "Namen der Ebenen ausblenden",
+            "showLayerName": "Layer-Namen anzeigen",
+            "enableRange": "Zeitraum aktivieren",
+            "disableRange": "Zeitbereich deaktivieren",
+            "enablePlayBack": "Aktivieren Sie die Wiedergabesteuerung",
+            "disablePlayBack": "Deaktivieren Sie die Wiedergabesteuerung",
+            "expand" : "Erweitern Sie den Zeitschieberegler",
+            "collapse" : "Schieberegler für die Zeitspanne reduzieren",
+            "collapsed": {
+                "title": "Zeitleiste wurde reduziert",
+                "tooltip": "Klicken Sie hier, um es erneut zu erweitern"
+            },
+            "errors": {
+                "multidim_error_title": "Der Backend-Service reagiert nicht",
+                "multidim_error_message": "Die erforderlichen Dienste für die mehrdimensionale Unterstützung reagieren nicht. Bitte versuchen Sie es später erneut oder wenden Sie sich an den Administrator."
+            }
+        },
+        "rulesmanager": {
+            "apply": "Anwenden",
+            "remove": "Entfernen Sie die Geometrie",
+            "resetconstraints": "Setzt Einschränkungen zurück",
+            "constraintsmsg": "Wenn Sie die Berechtigung, den Arbeitsbereich oder die Ebene ändern, werden die Details gelöscht. Sind Sie sicher, dass Sie das machen wollen?",
+            "defstyle": "Standardstil",
+            "avstyle": "Verfügbare Stile",
+            "clearbtn": "Alles Löschen",
+            "selectbtn": "Alle auswählen",
+            "placeholders": {
+                "filter": "Suche...",
+                "role": "Nach Rollen suchen",
+                "user": "Benutzer suchen",
+                "service": "Suchdienste",
+                "request": "Type to serach Requests",
+                "workspace": "Suchanfragen",
+                "layer": "Suche Ebenen",
+                "access": "Suchzugriff",
+                "ip": "###.###.###.###/##",
+                "priority": "Wählen Sie Priorität"
+            },
+            "menutitle": "GeoFence-Regeln Verwalten",
+            "tooltip": {
+                "addT": "Fügen Sie eine Regel hinzu",
+                "editT": "Bearbeiten Sie die ausgewählte regel",
+                "addBeT": "Fügen Sie eine neue Regel hinzu, bevor Sie ausgewählt werden",
+                "addAfT": "Fügen Sie nach der Auswahl eine neue Regel hinzu",
+                "deleteT": "Entferne ausgewählte Regeln",
+                "cacheT": "Cache leeren",
+                "save": "Aktuelle Regel speichern",
+                "close": "Beenden Sie die Regel erstellen"
+            },
+            "navItems": {
+                "main": "Allgemeine Regel",
+                "style": "Stil",
+                "filter": "Filter",
+                "attribute": "Attribute Regel"
+            },
+            "rule": "Regle",
+            "cachetitle": "Cache leeren",
+            "cachemsg": "Möchten Sie den GeoFence-Cache wirklich löschen?",
+            "deltitle": "Regel Löschen",
+            "delmsg": "Möchten Sie diese Regel wirklich löschen?",
+            "invalidForm": "Das Formular ist ungültig. Überprüfen Sie die Felderwerte",
+            "ip": "IP",
+            "title": "Zugangs Regeln",
+            "role": "Rolle",
+            "user": "Benutzer",
+            "priority": "Priorität",
+            "service": "Service",
+            "request": "Anfrage",
+            "workspace": "Workspace",
+            "layer": "Ebene",
+            "filters": "Filter",
+            "rules": "Regeln",
+            "access": "Zugang",
+            "newModal": "Neue Regel",
+            "editModal": "Regel bearbeiten",
+            "newButton": "Erstellen",
+            "editButton": "Speichern",
+            "close": "Schließen",
+            "previous": "vorheriger",
+            "next": "nächster",
+            "cacheCleaned": "Der Cache wurde erfolgreich bereinigt",
+            "errorTitle": "Geofence",
+            "errorCQL": "Geometrie nicht gültig!",
+            "errorCleaningCache": "Fehler beim Reinigen des Geofence-Cache.",
+            "errorLoadingRoles": "Fehler beim Laden der Rollen.",
+            "errorLoadingUsers": "Fehler beim Laden der Benutzer.",
+            "errorLoadingWorkspaces": "Fehler beim Laden der Workspaces.",
+            "errorLoadingLayers": "Fehler beim Laden der Ebenen.",
+            "errorLoadingRules": "Fehler beim Laden der Regeln.",
+            "errorMovingRules": "Fehler beim Ändern der Regeln.",
+            "errorDeletingRules": "Fehler beim Löschen der Regeln.",
+            "errorAddingRule": "Fehler beim Hinzufügen der Regel.",
+            "errorUpdatingRule": "Fehler beim Ändern der Regel.",
+            "errorDuplicateRule": "Duplizierte Regel",
+            "errorLoading": "Ladefehler",
+            "deleteModal": "Regeln löschen",
+            "selectedRulesDelete": "Ausgewählte Regeln löschen ?",
+            "deleteButton": "Löschen",
+            "cancelButton": "Abbrechen",
+            "cqlRead": "CQL Filter Lese Regeln",
+            "cqlWrite": "CQL Filter Write Rules",
+            "missingconfig": "Der Regeln-Manager vermisst die Konfiguration. Zugriff abgelehnt!",
+            "selectworkspace": "Sie müssen den Arbeitsbereich auswählen, um erweiterte Optionen zu aktivieren."
+        },
+        "geostory": {
+            "storyResources": "Story Ressourcen",
+            "geostoreMap": "MapStore-Karten",
+            "loadingSpinner": "Story wird geladen",
+            "addTitleSection": "Titelabschnitt hinzufügen",
+            "addBannerSection": "Bannerbereich hinzufügen",
+            "addParagraphSection": "Absatzabschnitt hinzufügen",
+            "addImmersiveSection": "Immersive Section hinzufügen",
+            "addMediaSection": "Medienabschnitt hinzufügen",
+            "addWebPageSection": "Webseitenabschnitt hinzufügen",
+            "addImmersiveContent": "Fügen Sie immersiven Inhalt hinzu",
+            "addTextContent": "Textinhalt hinzufügen",
+            "addMediaContent": "Medieninhalt hinzufügen",
+            "zoomToContent": "Zum Inhalt zoomen",
+            "addWebPageContent": "Webseitenabschnitt hinzufügen",
+            "emptyTitle": "Diese Geschichte ist leer",
+            "emptyDescription": "Erstellen Sie eine fantastische Geostory, indem Sie neuen Inhalt hinzufügen",
+            "closeFullscreenMap": "Schließen Vollbild-Karte",
+            "showFullscreenMap": "Vollbild-Anzeige Karte",
+            "contentToolbar": {
+                "contentSize": "Größe ändern",
+                "contentHeightAuto": "Passen Sie diesen Abschnitt an die Höhe des Inhalts an",
+                "contentHeightView": "Stellen Sie diesen Abschnitt so ein, dass er vertikal in die Ansicht passt",
+                "smallSizeLabel": "Klein",
+                "mediumSizeLabel": "Mittel",
+                "largeSizeLabel": "Groß",
+                "fullSizeLabel": "Voll",
+                "contentAlign": "Inhalt ausrichten",
+                "leftAlignLabel": "Links",
+                "centerAlignLabel": "Center",
+                "rightAlignLabel": "Rechten",
+                "contentTheme": "Feldthema ändern",
+                "brightThemeLabel": "Hell",
+                "brightTextThemeLabel": "Heller text",
+                "darkThemeLabel": "Dunkel",
+                "darkTextThemeLabel": "Dark text",
+                "defaultThemeLabel": "Standard",
+                "customizeThemeLabel": "Anpassen",
+                "customizeThemeRemoveLabel": "Remove Anpassung",
+                "cover": "Stellen Sie sicher, dass der Hintergrund den gesamten Containerraum bedeckt",
+                "fit": "Machen Sie den gesamten Hintergrund im Container sichtbar",
+                "editMedia": "Ändern Sie die Medienquelle",
+                "remove": "Entfernen",
+                "removeConfirmTitle": "Sind Sie sicher?",
+                "removeConfirmContent": "Wollen Sie diesen Inhalt aus der Geschichte entfernen?",
+                "editMap": "Bearbeiten Sie die ursprüngliche Kartenausdehnung",
+                "resetMap": "Setzen Sie die Karte auf die ursprüngliche Konfiguration zurück",
+                "resetMapConfirm": "Kartenkonfiguration zurücksetzen",
+                "resetConfirmContent": "Die ursprüngliche Kartenkonfiguration wiederherstellen?",
+                "saveChanges": "Änderungen speichern",
+                "closeMapEditing": "Schließen",
+                "confirmCloseMapEditing": "Schließen Sie die Kartenbearbeitung",
+                "pendingChangesDiscardConfirm": "Aktuelle Kartenänderungen verwerfen?",
+                "editURL": "Webseiten-URL bearbeiten",
+                "advancedMapEditor": "Öffnen Sie den erweiterten Karteneditor",
+                "enableAudio": "Audio aktivieren",
+                "disableAudio": "Video stumm schalten",
+                "enableAutoplay": "Aktivieren autoplay",
+                "disableAutoplay": "Deaktiviere autoplay",
+                "enableLoop": "Schleife aktivieren",
+                "disableLoop": "Schleife deaktivieren",
+                "hideCaption": "Beschriftung ausblenden",
+                "showCaption": "Verwenden Sie die Beschreibung als Beschriftung"
+            },
+            "navigation": {
+                "edit": "Bearbeiten Sie die Geschichte"
+            },
+            "builder": {
+                "defaults": {
+                    "htmlTitlePlaceholder": "Titel einfügen",
+                    "htmlPlaceholder": "Text hier einfügen...",
+                    "titleTitle": "Titelbereich",
+                    "titleBanner": "Banner-Bereich",
+                    "titleParagraph": "Absatz Abschnitt",
+                    "titleImmersiveContent": "Immersiver Inhalt",
+                    "titleImmersive": "Immersive Section",
+                    "titleMedia": "Medienbereich",
+                    "titleImage": "Bild",
+                    "titleText": "Text",
+                    "titleWebPage": "Website",
+                    "titleWebPageSection": "Web Page Section",
+                    "titleUnknown": "UNKNOWN"
+                },
+                "delete": "Ausgewählten Abschnitt entfernen",
+                "preview": "Vorschau zeigen",
+                "edit": "Bearbeiten Sie die Geschichte",
+                "noContents": "Keine Inhalte verfügbar",
+                "collapseAll": "Alles einklappen",
+                "expandAll": "Alle erweitern",
+                "fullscreen": "Vorschau im Vollbild anzeigen",
+                "settings": {
+                    "tooltip": "die Einstellungen",
+                    "back": "Zurück zum Baumeister",
+                    "backConfirmTitle": "Geänderte Einstellungen",
+                    "backConfirmBody": "Möchten Sie das Einstellungsfenster wirklich schließen, ohne Ihre Änderungen zu speichern?",
+                    "backConfirmNo": "Nein",
+                    "backConfirmYes": "Ja",
+                    "save": "Einstellungen speichern",
+                    "storyTheme" : "Story-Thema",
+                    "storyHeader" : "Story-Header",
+                    "title": "Titel",
+                    "titlePlaceholder": "Titel eingeben",
+                    "logo": "Logo",
+                    "logoPlaceholder": "Legen Sie Ihr Logo hier ab oder klicken Sie, um eine Bilddatei auszuwählen (unterstützte Formate sind PNG und JPEG).",
+                    "autoplay": "Automatisches Abspielen",
+                    "enableAutoplay": "Aktivieren Sie die automatische Wiedergabe",
+                    "autoplayInterval": "Autoplay-Intervall (Sekunden)",
+                    "autoplayIntervalPlaceholder": "Aktivieren Sie das Autoplay-Intervall",
+                    "navbar": "Navigationsleiste",
+                    "showNavbar": "Navigationsleiste anzeigen",
+                    "theme": "Standardthema",
+                    "fontFamily": "Schriftfamilie",
+                    "webFontLoadError": "Fehler beim Laden einiger Schriftarten aus der lokalen Konfiguration",
+                    "fontSize": "Schriftgröße",
+                    "overlay": "Überlagerung",
+                    "templateTooltip":"Mit dieser Einstellung können Sie die Identifizierungsfunktion auf der Karte aktivieren, indem Sie ein generisches Format für alle Ebenen definieren. Mit dem erweiterten Karteneditor (Stiftsymbol) kann für jede Ebene ein anderes Format konfiguriert werden. Weitere Informationen finden Sie im <a href='https://mapstore.readthedocs.io/en/latest/user-guide/layer-settings/#templates' target='_blank'> Benutzerhandbuch </a>. Wenn ein Layer sein eigenes Identifizierungsformat definiert hat, wird er anstelle des auf Kartenebene festgelegten generischen Formats verwendet."
+                }
+            },
+            "errors": {
+                "loading": {
+                    "notFound": "Geostory nicht gefunden",
+                    "title": "Error",
+                    "unknownError": "Unbekannter Fehler",
+                    "pleaseLogin": "Bitte loggen Sie sich ein",
+                    "notAccessible": "Diese Geschichte ist nicht zugänglich",
+                    "geostoryNotAccessible": "Sie haben keine Berechtigung, auf diese Geschichte zuzugreifen. Bitte wenden Sie sich an den Eigentümer der Ressource",
+                    "geostoryDoesNotExist": "Diese Geschichte existiert nicht",
+                    "video": "Es tut uns leid! Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut."
+                }
+            },
+            "mapEditor": {
+                "configureMapOptions": "Karte konfigurieren",
+                "settings": "Einstellungen",
+                "settingsSubTitle": "Benutzerinteraktionen verwalten",
+                "toc": "Ebenen",
+                "pan": "Pan-Interaktion",
+                "zoom": "Vergrößern / Verkleinern von Interaktionen",
+                "topLeft": "Oben links",
+                "topRight": "Oben rechts",
+                "bottomLeft": "Unten links",
+                "bottomRight": "Unten rechts",
+                "identify": "Identifiziere"
+            },
+            "webPageCreator": {
+                "title": "Website",
+                "saveButton": "Speichern",
+                "error": "Bitte geben Sie eine gültige URL der Webseite an",
+                "url": {
+                    "label": "URL"
+                }
+            },
+            "customizeTheme": {
+                "backgroundColorLabel": "Hintergrund",
+                "textColorLabel": "Text",
+                "shadowLabel": "Schatten",
+                "useAlternativeTextColor": "Verwenden Sie alternative Textfarbe",
+                "alternativeTextColorPopover": "<p>Achtung: die ausgewählte Textfarbe konnte auf diesem Hintergrund nicht lesbar sein.</p> <p>Eine alternative Textfarbe ist {color} &nbsp;<span class=\"ms-custom-theme-picker-alternative-text\" style=\"background-color:{color}\"></span></p>"
+            }
+        },
+        "geostoryEmbedded" : {
+            "loadingSpinner": "Story wird geladen",
+            "errors": {
+                "loading": {
+                  "notFound": "Geostory nicht gefunden",
+                  "title": "Error",
+                  "unknownError": "Unbekannter Fehler",
+                  "notAccessible": "Diese Geschichte ist nicht zugänglich",
+                  "pleaseLogin": "Ressource ist nicht öffentlich",
+                  "geostoryNotAccessible": "Sie haben keine Berechtigung, auf diese Geschichte zuzugreifen",
+                  "geostoryDoesNotExist": "Diese Geschichte existiert nicht"
+                }
+            }
+        },
+        "saveDialog": {
+            "title": "Eigenschaften bearbeiten",
+            "name": "Name",
+            "description": "Beschreibung",
+            "createdAt": "Erstellt",
+            "modifiedAt": "Geändert",
+            "namePlaceholder": "Geben Sie einen Namen ein ...",
+            "descriptionPlaceholder": "Geben Sie eine Beschreibung ein ...",
+            "confirmCloseText": "Es gibt ausstehende Änderungen, sind Sie sicher, dass Sie schließen möchten, ohne zu speichern?",
+            "close": "Schließen",
+            "cancel": "Abbrechen",
+            "saveSuccessTitle": "Erfolg",
+            "saveSuccessMessage": "Erfolgreich gespeichert"
+        },
+        "mapEditor": {
+            "modalTitle": "Map Editor",
+            "confirmExitTitle": "Schließen Sie den Karteneditor",
+            "confirmExitContent": "Ausstehende Änderungen verwerfen?"
+        },
+        "mediaEditor": {
+            "modalTitle": "Medien",
+            "images": "Bilder",
+            "videos": "Videos",
+            "maps": "Karten",
+            "preview": "Vorschau",
+            "apply": "Sich bewerben",
+            "confirmExitTitle": "Schließen Media Editor",
+            "confirmExitContent": "Ausstehende Änderungen verwerfen?",
+            "mediaPicker": {
+                "services": "Dienstleistungen: ",
+                "clean": "Saubere Ergebnisse",
+                "noResults": "Keine Ergebnisse",
+                "selectService": "Wählen Sie einen Dienst aus",
+                "add": "Hinzufügen",
+                "back": "Zurück",
+                "save": "Sparen",
+                "edit": "Bearbeiten",
+                "sourcePlaceholder": "Geben Sie eine Quelle ein",
+                "source": "Quelle",
+                "titlePlaceholder": "Geben Sie einen Titel ein",
+                "title": "Titel",
+                "altTextPlaceholder": "Geben Sie einen alternativen Text ein",
+                "altText": "Alternative text",
+                "descriptionPlaceholder": "Geben Sie eine Beschreibung ein",
+                "description": "Beschreibung",
+                "creditsPlaceholder": "Geben Sie Credits ein",
+                "credits": "Credits",
+                "mapFilter": "Karten filtern",
+                "videoFilter": "Filtern Sie Videos",
+                "imageFilter": "Filtern Sie Bilder",
+                "import": "Ressource in lokalen Speicher importieren",
+                "trash": "Remove resource",
+                "videoUrl": "Video URL",
+                "videoUrlPlaceholder": "Geben Sie eine Video-URL ein",
+                "thumbnail": "Miniaturbild hinzufügen (maximale Größe 500 KB)",
+                "createVideoThumbnail": "Erstellen Sie eine Miniaturansicht aus einer Videoquelle",
+                "thumbnailCreateError": "Es ist nicht möglich, ein Miniaturbild aus der aktuellen Videoquelle zu erstellen. Klicken oder löschen Sie ein Bild in der Miniaturansicht, um es manuell hochzuladen"
+            },
+            "mediaform": {
+                "confirmExitTitle": "Schließen Media Form",
+                "confirmExitContent": "Ausstehende Änderungen verwerfen?"
+            },
+            "mapForm": {
+                "thumbnailMessage": "Die Größe der Bilder sollte ein Quadrat von 98 x 98 Pixel sein, maximal 100 KB",
+                "confirmMapSaveTitle": "Kartenupdate",
+                "confirmMapSaveContent": "Durch das Aktualisieren dieser Karte werden alle abhängigen Karten in der Story zurückgesetzt, die zuvor über den Inline-Editor angepasst wurden. Bestätigen Sie?"
+            },
+            "mediaList" : {
+                "removeResourceTitle": "Sind Sie sicher?",
+                "confirmRemoveResource": "Möchten Sie diese Medienressource aus der Story entfernen?",
+                "confirmRemoveUsedResource": "Diese Ressource wird auch aus allen Abschnitten / Inhalten entfernt, in denen sie verwendet wird und sie bleiben leer. Möchten Sie es aus der Geschichte entfernen?",
+                "resultsCount": "{count} von {total} {total, plural, one {Ergebnis} other {Ergebnisse}}"
+            },
+            "imageList": {
+                "emptyList": "Klicken Sie auf das Pluszeichen, um ein neues Bild hinzuzufügen. Weitere Informationen finden Sie im Benutzerhandbuch <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#images' target='_blank'/> hier </a>"
+            },
+            "mapList": {
+                "emptyList": "Klicken Sie auf die Plus-Schaltfläche, um eine Karte zu erstellen oder einen anderen Kartendienst auszuwählen. Weitere Informationen finden Sie im Benutzerhandbuch <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#maps' target='_blank'/> hier </a>"
+            },
+            "videoList": {
+                "emptyList": "Klicken Sie auf das Pluszeichen, um ein neues Video hinzuzufügen. Weitere Informationen finden Sie im Benutzerhandbuch <a href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/#videos' target='_blank'/> hier </a>"
+            }
+        },
+        "backgroundDialog": {
+            "addTitle": "Neuen Hintergrund hinzufügen",
+            "editTitle": "Aktuellen Hintergrund bearbeiten",
+            "title": "Titel",
+            "titlePlaceholder": "Den angezeigten Namen eingeben",
+            "add": "Hinzufügen",
+            "thumbnailMessage": "Die Größe der Bilder sollte ein Quadrat von 98 x 98 Pixel oder 128 x 128 Pixel sein, maximal 500kb",
+            "additionalParameters": "Zusätzliche Parameter",
+            "addAdditionalParameterTooltip": "Parameter hinzufügen",
+            "removeAdditionalParameterTooltip": "Parameter entfernen",
+            "parameter": "Parameter",
+            "value": "Wert",
+            "string": "Reihe",
+            "number": "Nummer",
+            "boolean": "Boolean"
+        },
+        "defaultMapBackgroundsServiceTitle": "Standardhintergründe",
+        "backgroundSelector": {
+            "addTooltip": "Neuen Hintergrund hinzufügen",
+            "confirmDelete": "Möchten Sie den \"{title}\" - Hintergrund wirklich löschen?"
+        },
+        "stepper": {
+            "back": "Zurück",
+            "next": "Nächste"
+        },
+        "newMapDialog": {
+            "title": "Wählen Sie einen Kontext",
+            "noContexts": "Keine Kontexte gefunden",
+            "filterPlaceholder": "Suchkontexte..."
+        },
+        "plugins": {
+          "About": {
+            "description": "Tool, das das Fenster \"Info\" anzeigt",
+            "title": "About"
+          },
+          "AddGroup": {
+            "description": "Ermöglicht Benutzern das Erstellen neuer Layergruppen im Inhaltsverzeichnis",
+            "title": "Ebenengruppe hinzufügen"
+          },
+          "Annotations": {
+            "description": "Werkzeug zum Zeichnen von Anmerkungen auf der Karte",
+            "title": "Anmerkungen"
+          },
+          "AutoMapUpdate": {
+            "description": "Ermöglicht dem Benutzer das Aktualisieren der Karte (alte Mapstore-Version)",
+            "title": "Automatische Kartenaktualisierung"
+          },
+          "BackgroundSelector": {
+            "description": "Ermöglicht die Auswahl des Kartenhintergrunds",
+            "title": "Hintergrundauswahl"
+          },
+          "BurgerMenu": {
+            "description": "Menü oben rechts auf der Karte, das andere Plug-ins enthält",
+            "title": "Burger Menu"
+          },
+          "CRSSelector": {
+            "description": "Ermöglicht das Umschalten der Kartenprojektion",
+            "title": "CRS-Auswahl"
+          },
+          "Details": {
+            "description": "Eventuell Detailkarte für eine Karte anzeigen lassen",
+            "title": "Kartendetails"
+          },
+          "Expander": {
+            "description": "Hilfsprogramm für die Seitenleiste (Navigation), mit dem einige Schaltflächen ausgeblendet werden können",
+            "title": "Expander"
+          },
+          "FeatureEditor": {
+            "description": "Durchsuchen Sie Attribute in einer Tabelle",
+            "title": "Attributtabelle"
+          },
+          "FilterLayer": {
+            "description": "Ermöglicht das Hinzufügen eines Filters zu einer Ebene",
+            "title": "Filterebene"
+          },
+          "HelpLink": {
+            "description": "Eine Schaltfläche für den Zugriff auf die MapStore-Dokumentation",
+            "title": "Dokumentationslink"
+          },
+          "Home": {
+            "description": "Link zur Homepage",
+            "title": "Home"
+          },
+          "Identify": {
+            "description": "Fragen Sie die Objekte auf der Karte ab",
+            "title": "Identifizieren"
+          },
+          "Locate": {
+            "description": "Finde und verfolge die Position des Benutzers auf der Karte",
+            "title": "Ortungswerkzeug"
+          },
+          "Login": {
+            "description": "Login Tool",
+            "title": "Login"
+          },
+          "MapCatalog": {
+            "description": "Ermöglicht das Durchsuchen, Bearbeiten, Löschen und Laden von Karten, die auf dem Server verfügbar sind",
+            "title": "Kartenkatalog"
+          },
+          "MapExport": {
+            "description": "Ermöglicht das Exportieren einer Karte in eine Datei",
+            "title": "Kartenexport"
+          },
+          "MapImport": {
+            "description": "Ermöglicht den Import von Daten (SHP, KML / KMZ, GeoJSON, GPX) oder das Neuladen exportierter Karten.",
+            "title": "Einführen"
+          },
+          "MapLoading": {
+            "description": "Ein Drehfeld in der Seitenleiste, das anzeigt, ob die Karte geladen wird",
+            "title": "Kartenladeanzeige"
+          },
+          "Measure": {
+            "description": "Ermöglicht das Messen von Entfernungen und Bereichen auf der Karte",
+            "title": "Messen"
+          },
+          "MetadataExplorer": {
+            "description": "Durchsuchen Sie Dienste (WMS / WMTS / CSW), um der Karte Layer hinzuzufügen",
+            "title": "Katalog"
+          },
+          "MousePosition": {
+            "description": "Zeigt die Koordinaten des mit dem Mauszeiger gezeigten an",
+            "title": "Mausposition"
+          },
+          "Print": {
+            "description": "Ermöglicht das Drucken der aktuellen Karte mit Legende",
+            "title": "Druckwerkzeug"
+          },
+          "Save": {
+            "description": "Ermöglicht das Speichern von Änderungen an der Karte",
+            "title": "Speichern"
+          },
+          "SaveAs": {
+            "description": "Ermöglicht das Erstellen oder Klonen von Maps auf dem Server",
+            "title": "Speichern als..."
+          },
+          "ScaleBox": {
+            "description": "Ein Indikator und ein Selektor des aktuellen Kartenmaßstabs",
+            "title": "Skalenselektor"
+          },
+          "Search": {
+            "description": "Textsuchwerkzeug (GeoCoder)",
+            "title": "Suchleiste"
+          },
+          "Settings": {
+            "description": "Ermöglicht das Bearbeiten einiger Einstellungen für die Karte (Sprache, Standard-Info-Format ...)",
+            "title": "die Einstellungen"
+          },
+          "Share": {
+            "description": "Ermöglicht das Teilen der Karte auf verschiedene Arten (Link, QR-Code, Einbettung, soziale Netzwerke ...)",
+            "title": "Freigabe-Tool"
+          },
+          "StyleEditor": {
+            "description": "Stileditor der Ebene",
+            "title": "Stil-Editor"
+          },
+          "TOC": {
+            "description": "Bietet eine Liste von Ebenen, die sortiert werden können",
+            "title": "Liste der Ebenen"
+          },
+          "TOCItemsSettings": {
+            "description": "Erlaubt das Bearbeiten der Ebeneneinstellungen",
+            "title": "Ebeneneinstellungen"
+          },
+          "Timeline": {
+            "description": "Ermöglicht Zeitreisen für Daten mit Zeitdimension",
+            "title": "Timeline"
+          },
+          "Tutorial": {
+            "description": "Fügt ein Tutorial hinzu, um die verschiedenen Funktionen zu erklären",
+            "title": "Tutorial"
+          },
+          "UserExtensions": {
+            "description": "Ermöglicht dem Benutzer das Aktivieren / Deaktivieren von Benutzererweiterungen",
+            "title": "User Extensions"
+          },
+          "UserSession": {
+            "title": "User Session",
+            "description": "Aktiviert eine automatisch gespeicherte Benutzersitzung für jeden Kontext."
+          },
+          "Version": {
+            "description": "Zeigt die Version von MapStore in den Karteneinstellungen an",
+            "descriptionGeorchestra": "Zeigt die Version von GeOrchestra in den Karteneinstellungen an",
+            "title": "Ausführung"
+          },
+          "LayerDownload": {
+            "description": "Ermöglicht das Herunterladen von Daten aus der Attributtabelle",
+            "title": "Daten herunterladen"
+          },
+          "Widgets": {
+            "description": "Ermöglicht das Hinzufügen und Anzeigen von Widgets auf der Karte",
+            "title": "Widgets"
+          },
+          "WidgetsTray": {
+            "description": "Eine Taskleiste zum Ausblenden und Erweitern von Widgets auf der Karte.",
+            "title": "Widgets-Fach"
+          },
+          "Globe": {
+            "description": "Sidebar-Taste zum Ein- und Ausschalten des 3D-Modus",
+            "title": "3D"
+          },
+          "ZoomAll": {
+            "description": "Sidebar-Schaltfläche, um den Kartenausschnitt der Karte zu vergrößern",
+            "title": "Maximal zoomen"
+          },
+          "ZoomIn": {
+            "description": "Schaltfläche zum Erhöhen der Zoomstufe der Karte",
+            "title": "Zoom In"
+          },
+          "ZoomOut": {
+            "description": "Schaltfläche zum Verringern der Zoomstufe der Karte",
+            "title": "Zoom Out"
+          }
+        },
+        "contextCreator": {
+            "generalSettings": {
+                "label": "Allgemeine Einstellungen",
+                "title": "Erstellen Sie einen neuen App-Kontext",
+                "name": "Name",
+                "namePlaceholder": "Geben Sie den Namen des App-Kontexts ein...",
+                "windowTitle": "Fenstertitel",
+                "windowTitlePlaceholder": "Fenstertitel eingeben..."
+            },
+            "configurePlugins": {
+                "label": "Plugins konfigurieren",
+                "pluginsFilterPlaceholder": "Plugins nach Namen filtern...",
+                "availablePlugins": "Verfügbare Plugins",
+                "enabledPlugins": "Aktivierte Plugins",
+                "availablePluginsEmpty": "Alle verfügbaren Plugins sind aktiviert",
+                "enabledPluginsEmpty": "Fügen Sie der Konfiguration Plugins aus der Liste der verfügbaren Plugins hinzu",
+                "searchResultsEmpty": "Es wurden keine Plugins gefunden, die den Suchkriterien entsprechen",
+                "cfgParsingError": {
+                    "title": "Konfigurationsfehler",
+                    "body": "Konfigurations-JSON-Analyse fehlgeschlagen.\nDer folgende Fehler ist aufgetreten:\n\"{error}\""
+                },
+                "uploadLabel": "Ziehen Sie ein Erweiterungspaket oder klicken Sie, um es zu durchsuchen und hochzuladen",
+                "uploadTitle": "Installieren Sie ein MapStore-Plugin",
+                "uploadParseError": "Datei index.json con formato errato",
+                "uploadMissingIndexError": "index.json-Datei fehlt in zip",
+                "uploadMissingPluginError": "In index.json sind keine Plugins definiert",
+                "uploadMissingBundleError": "Kein Javascript-Bundle in der hochgeladenen Datei",
+                "uploadTooManyBundlesError": "Zu viele Javascript-Bundles im Zip-Paket",
+                "uploadWrongFileFormatError": "Falsches Dateiformat, Zip-Datei erwartet",
+                "uploadAlreadyInstalledError": "Erweiterung bereits installiert. Aktuelle Erweiterung vor Neuinstallation entfernen",
+                "confirmRemovePlugin": "Möchten Sie die Erweiterung wirklich entfernen?",
+                "cancelUpload": "Schließen",
+                "install": "Install",
+                "uploadError": "Fehler bei der Installation: ",
+                "uploadOk": "Erweiterung wurde korrekt installiert",
+                "tooltips": {
+                    "enableUserPlugin": "Aktiviert die Auswahl des aktuellen Plugins für den Benutzer",
+                    "disableUserPlugin": "Deaktivieren Sie die Auswahl des aktuellen Plugins für den Benutzer",
+                    "activatePlugin": "Aktivieren Sie das Laden dieses Plugins beim Start",
+                    "deactivatePlugin": "Deaktivieren Sie das Laden dieses Plugins beim Start",
+                    "editConfiguration": "Plugin Konfiguration bearbeiten",
+                    "pluginDocumentation": "Öffnen Sie die Dokumentation zur Plugin-Konfiguration",
+                    "uploadPlugin": "Fügen Sie MapStore eine Erweiterung hinzu",
+                    "removePlugin": "Entfernen Sie diese Erweiterung aus MapStore",
+                    "mapTemplatesConfig": "Vorlagen konfigurieren"
+                },
+                "tutorialPlugins": {
+                    "availableTitle": "Verfügbares Plugin",
+                    "availableDescription": "Dieses Plugin ist deaktiviert",
+                    "enabledTitle": "Aktiviertes Plugin",
+                    "enabledDescription": "Dieses Plugin ist aktiviert"
+                },
+                "saveCfgErrorNotification":  {
+                    "title": "Syntaxfehler in der Plugin-Konfiguration",
+                    "message": "Plugin \"{pluginName}\" enthält einen Konfigurationsfehler. Bitte korrigieren, bevor Sie fortfahren"
+                }
+            },
+            "configureTemplates": {
+                "title": "Vorlagen konfigurieren",
+                "availableTemplates": "Verfügbare Vorlagen",
+                "enabledTemplates": "Aktivierte Vorlagen",
+                "templatesFilterPlaceholder": "Vorlagen nach Namen filtern...",
+                "availableTemplatesEmpty": "Alle verfügbaren Vorlagen sind aktiviert",
+                "enabledTemplatesEmpty": "Fügen Sie der Konfiguration Vorlagen aus der Liste der verfügbaren Vorlagen hinzu",
+                "searchResultsEmpty": "Es wurden keine Vorlagen gefunden, die den Suchkriterien entsprechen",
+                "fileDrop": {
+                    "label": "Vorlage",
+                    "clear": "Löschen oder klicken Sie, um eine Kartenvorlagendatei auszuwählen (exportierte JSON MapStore-Karten oder WMC-Dateien werden unterstützt)."
+                },
+                "uploadDialog": {
+                    "title": "Kartenvorlage hochladen",
+                    "save": "Hochladen",
+                    "jsonParsingError": "JSON-Analyse fehlgeschlagen: \"{error}\"",
+                    "fileReadError": "Beim Lesen der Datei ist ein unerwarteter Fehler aufgetreten"
+                },
+                "tooltips": {
+                    "uploadTool": "Neue Vorlage hochladen",
+                    "editTemplate": "Vorlageneigenschaften bearbeiten",
+                    "deleteTemplate": "Vorlage löschen"
+                },
+                "deleteError": "Die Vorlage konnte nicht gelöscht werden, ein Fehler ist aufgetreten",
+                "deleteConfirm": "Möchten Sie die Vorlage \"{templateName}\" wirklich löschen?"
+            },
+            "configureMap": {
+                "label": "Karte konfigurieren",
+                "reload": "Karte neu laden",
+                "confirm": "Dadurch werden alle aktuellen Kartenänderungen verworfen. Vorgehen?"
+            },
+            "saveErrorNotification": {
+                "titleContext": "Das Speichern des Kontexts ist fehlgeschlagen",
+                "titleTemplate": "Das Speichern der Vorlage ist fehlgeschlagen",
+                "conflict": "Eine Ressource mit diesem Namen ist bereits vorhanden",
+                "defaultMessage": "Unbekannter Fehler",
+                "categoryError": "Das Erstellen der fehlenden Kategorie \"{categoryName}\" ist fehlgeschlagen"
+            },
+            "loadTemplateErrorNotification": {
+                "forbidden": "Konnte nicht auf die Vorlagendaten zugreifen, dem Benutzer fehlen die erforderlichen Berechtigungen!",
+                "defaultMessage": "Ein unerwarteter Fehler ist aufgetreten"
+            },
+            "contextNameErrorNotification": {
+                "title": "Falscher Kontextname",
+                "unknownError": "Ein unerwarteter Fehler ist aufgetreten"
+            },
+            "undo": "Möchten Sie die Kontextbearbeitungssitzung wirklich abbrechen?",
+            "showTutorial": "Tutorial anzeigen"
+        },
+        "contextManager": {
+            "title": "Kontexte verwalten",
+            "gridTitle": "Kontexte",
+            "searchPlaceholder": "suche...",
+            "newContext": "Neuer Kontext",
+            "editContextTooltip": "Kontext bearbeiten"
+        },
+        "userExtensions": {
+          "title": "Benutzererweiterungen",
+          "emptyTitle": "Kein Ergebnis",
+          "emptyDescription": "Eingegebenen Filter Namen oder die Beschreibung von jedem nicht von Erweiterungen entsprechen",
+          "filterPlaceholder": "Filterebenen",
+          "addExtension": "Erweiterung hinzufügen",
+          "removeExtension": "Erweiterung entfernen"
+        },
+        "mapTemplates": {
+            "title": "Kartenvorlagen",
+            "favouritesTitle": "Favoriten",
+            "allTitle": "Alle",
+            "filterPlaceholder": "Kartenvorlagen filtern...",
+            "transfer": "Ersetzen Sie die Karte durch diese Vorlage",
+            "merge": "Diese Vorlage zur Karte hinzufügen",
+            "favouriteAdd": "Zu Favoriten hinzufügen",
+            "favouriteRemove": "Von den Favoriten entfernen",
+            "emptyTitle": "Kein Ergebnis",
+            "emptyDescription": "Der eingegebene Filter stimmt nicht mit dem Namen oder der Beschreibung einer der Vorlagen überein",
+            "noTemplatesTitle": "Keine Vorlagen gefunden",
+            "noTemplatesDescription": "Der aktuelle Kontext enthält keine Vorlagen",
+            "confirmReplaceTitle": "Ersetzen Sie den Karteninhalt",
+            "confirmReplaceMessage": "Sie ersetzen alle Layer und die Kartenkonfiguration durch die ausgewählte Vorlage, indem Sie auf die Schaltfläche Ersetzen klicken",
+            "confirmReplaceConfirmButton": "Ersetzen"
+        },
+        "mapCatalog": {
+            "title": "Kartenkatalog",
+            "tooltip": "Karten durchsuchen und laden",
+            "filterPlaceholder": "Karten suchen...",
+            "deleteConfirmContent": "Möchten Sie die Karte \"{mapName}\" wirklich löschen?",
+            "tooltips": {
+                "edit": "Eigenschaften bearbeiten",
+                "delete": "Ressource löschen",
+                "share": "Teilen"
+            },
+            "deletedMap": {
+                "title": "Karte gelöscht",
+                "message": "Die Karte wurde erfolgreich gelöscht"
+            },
+            "updatedMap": {
+                "title": "Gespeicherte Karte",
+                "message": "Die Karte wurde erfolgreich gespeichert"
+            },
+            "deleteError": "Beim Löschen der Karte ist ein unerwarteter Fehler aufgetreten",
+            "updateError": "Beim Speichern der Karte ist ein unerwarteter Fehler aufgetreten"
+        },
+        "layerInfo": {
+            "title": "Titel und Beschreibungen der Ebenen aktualisieren",
+            "noLayers": "Keine Ebenen gefunden",
+            "syncButton": "Titel und Beschreibungen synchronisieren",
+            "selectAll": "Alle auswählen",
+            "deselectAll": "Alle abwählen",
+            "updatingLayers": "Aktualisiere Ebenen {updatedCount}/{totalCount}",
+            "tooltips": {
+                "syncSuccess": "Titel und Beschreibung wurden für diese Ebene erfolgreich aktualisiert",
+                "syncError": "Es ist nicht möglich, den Titel und die Beschreibung dieser Ebene zu aktualisieren. Sie können im Einstellungsfeld überprüfen, ob alle Ebenenoptionen korrekt sind"
+            },
+            "syncingLayersSavingToServerError": {
+                "title": "Server-Speicherfehler",
+                "message": "Beim Speichern aktualisierter Ebenen auf dem Server ist ein unerwarteter Fehler aufgetreten"
+            },
+            "syncingLayersGeneralError": {
+                "title": "Allgemeiner Fehler",
+                "message": "Während der Ebenensynchronisierung ist ein unerwarteter Fehler aufgetreten. Es gibt wahrscheinlich einen Fehler im MapStore"
+            },
+            "layerType": "Typ: {type}"
+        },
+        "tutorial": {
+            "title": "Anleitung",
+            "back": "zurück",
+            "next": "weiter",
+            "close": "schließen",
+            "skip": "überspringen",
+            "last": "Ende",
+            "start": "Anfang",
+            "checkbox": "Zeige diese Nachricht nicht mehr an",
+            "error": "Fehler: Ziel wurde nicht gefunden",
+            "intro": {
+                "title": "Willkommen bei MapStore",
+                "text": "Framework zum Erstellen von Web Mapping-Anwendungen mit Standard-Mapping-Bibliotheken wie OpenLayers und Leaflet."
+            },
+            "drawerMenu": {
+                "title": "Hauptmenü",
+                "text": "Hier finden Sie Informationen und Tools zum Verwalten der Layer"
+            },
+            "searchBar": {
+                "title": "Suchleiste",
+                "text": "Suchen Sie nach Adressen und Orten z.B. 'Vienna International Airport' oder fügen Sie Koordinaten im Format 48.12,16.56 ein, um Objekte zu finden. Ändern Sie rechts in der Suchleiste das Suchwerkzeug, um gezielt nach Koordinaten zu suchen."
+            },
+            "home": {
+                "title": "Startseite",
+                "text": "Klicken Sie hier, um zurück zur Startseite zu gelangen"
+            },
+            "searchButton": {
+                "title": "Suche",
+                "text": "Suchen Sie nach Adressen und Orten z.B. 'Vienna International Airport' oder fügen Sie Koordinaten im Format 48.12,16.56 ein, um Objekte zu finden. Ändern Sie rechts in der Suchleiste das Suchwerkzeug, um gezielt nach Koordinaten zu suchen."
+            },
+            "burgerMenu": {
+                "title": "Optionen",
+                "text": "Hier können Sie weitere Werkzeuge, Einstellungen und Hilfe finden"
+            },
+            "zoomInButton": {
+                "title": "Zoom In",
+                "text": "Klicken Sie hier, um die Karte zu vergrößern"
+            },
+            "zoomOutButton": {
+                "title": "Zoom Out",
+                "text": "Klicken Sie hier, um die Karte zu verkleinern"
+            },
+            "fullscreen": {
+                "title": "Vollbild",
+                "text": "Umschalten auf Vollbild"
+            },
+            "identifyButton": {
+                "title": "Info",
+                "text": "Drücken Sie hier, um das Werkzeug zu aktivieren, und klicken Sie dann auf die Karte, um Informationen aus den Layern abzurufen"
+            },
+            "mapType": {
+                "title": "Bibliothek",
+                "text": "Sie können Leaflet oder OpenLayers auswählen, um Ihre Karten zu rendern"
+            },
+            "mapsGrid": {
+                "title": "Karten",
+                "text": "Hier einige Beispiele von MapStore. Klicken Sie auf ein Bild, um die Demo zu testen."
+            },
+            "examples": {
+                "title": "benutzerdefinierte Anwendung",
+                "text": "Sie können Komponenten und Plugins von MapStore verwenden, um benutzerdefinierte Anwendungen zu erstellen"
+            },
+            "introCesium": {
+                "title": "3D Kartenanweisungen",
+                "text": "Klicken Sie auf Weiter, um das Tutorial zu starten"
+            },
+            "cesium": {
+                "title": "Interaktionen mit der Karte",
+                "pan": "Verschieben",
+                "zoom": "Zoom-Ansicht",
+                "tilt": "Kippansicht",
+                "rotate": "Ansicht drehen",
+                "oneDrag": "ein Finger ziehen",
+                "twoPinch": "Zwei Finger Prise",
+                "twoDragSame": "Ziehen mit zwei Fingern, gleiche Richtung",
+                "twoDragOpposite": "Ziehen mit zwei Fingern, entgegengesetzte Richtung",
+                "leftClick": "Linksklick + Ziehen",
+                "rightClick": "Rechtsklicke + Ziehen oder Mausrad scrollen",
+                "middleClick": "Mittlerer Klick + Ziehen, oder STRG + Links / Rechts klicken + ziehen"
+
+            },
+            "cesiumCompass": {
+                "title": "Kompass",
+                "text": "Sie können den Kompass verwenden, um den Globus zu umkreisen. Ziehen Sie, um die Karte zu drehen"
+            },
+            "cesiumNavigation": {
+                "title": "Navigation",
+                "text": "Hier finden Sie die Schaltflächen zum Vergrößern und Verkleinern"
+            },
+            "dashboardIntro": {
+                "title": "Dashboard Tutorial",
+                "text": "Überblick über die Funktionen des Dashboards"
+            },
+            "dashboardNav": {
+                "title": "Navigationsleiste",
+                "text": "Hier finden Sie Sprachauswahl, Login, Homepage-Link und Optionsmenü"
+            },
+            "dashboardContainer": {
+                "title": "Instrumententafel",
+                "text": "<p> Ein Dashboard in MapStore bietet eine Reihe von Informationen, die passend gesammelt werden, um aggregierte Daten in der One-Shot-Ansicht anzuzeigen. Geodaten, die in einer Karte angezeigt werden, können Seite an Seite mit verwandten Attributtabellen, Diagrammen und anderen platziert werden, mit dem Ziel, verschiedene Arten von Informationen zu verbinden, statistische Details und textuelle Beschreibungen zu einem bestimmten Kontext anzuzeigen. </p> <p> Alle Benutzer können veröffentlichte Dashboards visualisieren und mit ihnen interagieren, aber nur Benutzer, die sie bearbeiten dürfen, können alle Widgets in einem Dashboard hinzufügen, anordnen, ihre Größe ändern oder löschen </ p>"
+            },
+            "dashboardAddWidget": {
+                "title": "Widget hinzufügen",
+                "text": "Um ein Widget zum Dashboard hinzuzufügen, können Sie auf die Schaltfläche + klicken"
+            },
+            "dashboardBuilder": {
+                "title": "Erstelle ein neues Widget",
+                "text": "Sie können auswählen, welche Art von Widget Sie möchten und dann zum Dashboard hinzufügen, indem Sie eines der Elemente in der Liste auswählen"
+            },
+            "dashboardAddChart": {
+                "title": "Diagramm Widget",
+                "text": "<p> Es ist ein Widget, das Daten in Kreis-, Linien- oder Balkendiagrammen anzeigt und aggregiert. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Vektorebene </li> <li> Diagrammtyp auswählen </li> <li> Diagrammdaten konfigurieren </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
+            },
+            "dashboardAddText": {
+                "title": "Text Widget",
+                "text": "<p> Fügen Sie Ihrem Dashboard Ihren eigenen Text hinzu. </p> <p> Schritte: </p> <p> <ul> <li> Bearbeiten Sie Text im Editor </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
+            },
+            "dashboardAddTable": {
+                "title": "Tabellen Widget",
+                "text": "<p> Fügen Sie dem Dashboard, das Daten von einer ausgewählten Vektorebene enthält, eine Attributtabelle hinzu. Sie können auch Daten filtern, um Ihre Tabelle anzupassen. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Vektorebene aus </li> <li> Tabellendaten konfigurieren </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
+            },
+            "dashboardAddCounter": {
+                "title": "Zähler Widget",
+                "text": "<p> Fügen Sie dem Dashboard einen neuen Zähler hinzu. Counter zeigt numerische Werte an, die Daten einer ausgewählten Vektorebene aggregieren. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Vektorebene </li> <li> Zählerdaten konfigurieren </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
+            },
+            "dashboardAddMap": {
+                "title": "Karten Widget",
+                "text": "<p> Fügen Sie eine neue interaktive Karte zum Dashboard hinzu. Sie können mehr als eine Karte mit der Möglichkeit hinzufügen, andere Widgets mit ihnen zu verbinden. Nach dem Speichern der ersten Karte wird das Legenden-Widget zur Liste hinzugefügt. Das Legenden-Widget zeigt eine Legende zur verbundenen Karte. </p> <p> Schritte: </p> <p> <ul> <li> Wählen Sie eine Karte </li> <li> Verbessern Sie die Karte, indem Sie neue Ebenen hinzufügen </li> <li> Speichern und zum Dashboard hinzufügen </li> </ul> </p>"
+            },
+            "contextCreator": {
+                "generalSettings": {
+                    "intro": {
+                        "title": "Tutorial zur Kontexterstellung",
+                        "text": "Dies ist ein schrittweiser Assistent zum Erstellen und Bearbeiten von MapStore-Kontexten"
+                    },
+                    "stepsOverview": {
+                        "title": "Schritte zur Kontexterstellung",
+                        "text": "<p>Jeder Kontext wird in drei Schritten erstellt:</p><p><ul><li>Allgemeine Einstellungen</li><li>Karte konfigurieren</li><li>Plugins konfigurieren</li></ul></p>"
+                    },
+                    "navigation": {
+                        "next": {
+                            "title": "Navigation: Weiter",
+                            "text": "<p>Drücken Sie diese Taste, um zum nächsten Schritt zu gelangen. Wenn die Schaltfläche deaktiviert ist, bedeutet dies, dass entweder die von Ihnen konfigurierten Daten überprüft werden oder sie ungültig sind.</p>"
+                        },
+                        "back": {
+                            "title": "Navigation: Zurück",
+                            "text": "<p>Drücken Sie diese Taste, um zum vorherigen Schritt zu gelangen.</p>"
+                        },
+                        "close": {
+                            "title": "Navigation: Schließen",
+                            "text": "<p>Drücken Sie diese Taste, um den Kontexterstellungsprozess ohne Speichern zu verlassen. Dies kann zu jedem Zeitpunkt im Erstellungsprozess erfolgen.</p>"
+                        }
+                    },
+                    "fields": {
+                        "title": "Allgemeine Einstellungen",
+                        "text": "<p>Im ersten Erstellungsschritt müssen Sie den Namen des Kontexts angeben, der auch seine eindeutige URL definiert, und den Titel, der als Titel des Browserfensters verwendet wird, wenn der Kontext geöffnet und aktiv ist. Hinweis: Der Kontextname darf nur lateinische Buchstaben, Ziffern 0-9 und Unterstriche enthalten. Der Fenstertitel darf nicht leer sein.</p>"
+                    },
+                    "showTutorial": {
+                        "title": "Tutorial anzeigen",
+                        "text": "<p>Wenn Sie das Tutorial noch einmal für einen Schritt durchgehen möchten, können Sie dies jederzeit durch Drücken dieser Taste tun.</p>"
+                    }
+                },
+                "configureMap": {
+                    "intro": {
+                        "title": "Karte konfigurieren",
+                        "text": "<p>In diesem Schritt können Sie mithilfe der MapStore Map Viewer-Tools die Standardkarte konfigurieren, die beim Zugriff auf den Kontext geöffnet wird.</p>"
+                    },
+                    "reloadMap": {
+                        "title": "Schaltfläche \"Karte neu laden\"",
+                        "text": "<p>Wenn Sie alle Änderungen, die Sie bisher an der Karte vorgenommen haben, verwerfen und von vorne beginnen möchten, können Sie dies tun, indem Sie auf diese Schaltfläche klicken.</p>"
+                    }
+                },
+                "configurePlugins": {
+                    "intro": {
+                        "title": "Plugins konfigurieren",
+                        "text": "<p>In diesem Schritt können Sie Plugins konfigurieren, die im Kontext vorhanden sind.</p>"
+                    },
+                    "availablePlugins": {
+                        "title": "Verfügbare Plugins",
+                        "text": "<p>Diese Liste enthält MapStore-Plugins, die einem Kontext hinzugefügt werden können. Um ein Plugin auszuwählen, klicken Sie einfach auf die Karte. Wenn Sie die STRG-Taste gedrückt halten, können Sie auch mehrere Plugins auswählen.</p>"
+                    },
+                    "pluginManipulation": {
+                        "title": "Plugins verschieben",
+                        "text": "<p>Einmal ausgewählt, können verfügbare Plugins in die rechte Spalte verschoben werden, sodass sie im Kontext aktiviert werden. Für einige Plugins müssen andere Plugins funktionieren. In diesem Fall werden sie neben den explizit aktivierten Plugins automatisch aktiviert.</p><p>Plugins können auch von der Spalte \"aktiviert\" in die Spalte \"verfügbar\" verschoben werden, um sie zu entfernen Plugins aus dem Kontext. Wenn Sie ein Plugin entfernen, werden auch alle Plugins deaktiviert, die für die Funktion erforderlich sind, es sei denn, es gibt derzeit aktivierte Plugins, für die ebenfalls ein solches Plugin erforderlich ist.</p>"
+                    },
+                    "enabledPlugins": {
+                        "title": "Aktivierte Plugins",
+                        "text": "<p>Diese Liste enthält MapStore-Plugins, die sich im Kontext befinden. Jedes Plugin hier kann mithilfe von Tool-Schaltflächen weiter konfiguriert werden.</p>"
+                    },
+                    "userPlugin": {
+                        "title": "Plugin-Tools: Benutzer-Plugins",
+                        "text": "<p>Durch Drücken dieser Taste können Sie zulassen, dass ein Plugin von Benutzern aktiviert / deaktiviert wird, sodass es zu einem Benutzer-Plugin wird. Solche Plugins werden im User Extensions-Plugin angezeigt. Dieses Plugin wird automatisch zum Kontext hinzugefügt, wenn mindestens ein Benutzer-Plugin aktiviert ist.</p>"
+                    },
+                    "userPluginCheckbox": {
+                        "title": "Plugin-Tools: Benutzer-Plugins",
+                        "text": "<p>Wenn ein Plugin ein Benutzer-Plugin ist, steuert dieses Kontrollkästchen, ob ein Benutzer-Plugin beim Laden des Kontexts automatisch aktiviert werden soll.</p>"
+                    },
+                    "cfgTool": {
+                        "title": "Plugin-Tools: Konfigurationstool",
+                        "text": "<p>Durch Drücken dieser Taste wird ein Editor angezeigt, in dem Sie die Standardkonfiguration des Plugins bearbeiten können.</p>"
+                    },
+                    "cfgEditor": {
+                        "title": "Plugin Tools: Konfigurationseditor",
+                        "text": "<p>Der Editor unterstützt die Syntaxhervorhebung. Alle Ihre Änderungen werden beim Bearbeiten kontinuierlich gespeichert. Wenn die Konfiguration einen Syntaxfehler enthält, werden Sie entsprechend informiert. Der Fehler muss behoben sein, bevor Sie fortfahren.</p>"
+                    },
+                    "documentationTool": {
+                        "title": "Plugin Tools: Dokumentation",
+                        "text": "<p>Durch Drücken dieser Taste gelangen Sie zur Dokumentationsseite des Plugins, auf der Sie Informationen darüber abrufen können, was das Plugin tut und welche Konfigurationsparameter es unterstützt.</p>"
+                    },
+                    "mapTemplatesTool": {
+                        "title": "Plugin-Tools: Kartenvorlagen",
+                        "text": "<p>Das Plugin für Kartenvorlagen verfügt außerdem über ein spezielles Tool, mit dem Sie Kartenvorlagen konfigurieren können, auf die im Kontext zugegriffen werden kann.</p>"
+                    },
+                    "extensions": {
+                        "title": "Erweiterungen",
+                        "text": "<p>MapStore unterstützt auch das Hochladen von benutzerdefinierten Erweiterungspaketen. Klicken Sie dazu auf diese Schaltfläche.</p>"
+                    },
+                    "extensionsDelete": {
+                        "title": "Erweiterungen",
+                        "text": "<p>Bereits hochgeladene Erweiterungen können jederzeit durch Drücken dieser Schaltfläche gelöscht werden.</p>"
+                    }
+                }
+            },
+            "geostoryIntro": {
+              "title": "Story Tutorial",
+              "text": "<p>Übersicht über die Story-Funktionen</p><p>Lesen Sie das zugehörige Benutzerhandbuch.<a target = '_blank' href='https://mapstore.readthedocs.io/en/latest/user-guide/exploring-stories/'> hier </a>"
+            },
+            "geostoryViewHeader": {
+              "title": "Header",
+              "text": "Hier finden Sie Sprachauswahl, Login, Homepage-Link und Optionsmenü"
+            },
+            "geostoryViewNavItems": {
+              "title": "Navigierbare Elemente",
+              "text": "Hier finden Sie Elemente in der Geschichte, mit denen Sie navigieren / springen können. Es zeigt auch die aktuelle Position in der Geschichte"
+            },
+            "geostoryViewNavTitle": {
+              "title": "Titel der Geschichte",
+              "text": "Hier sehen Sie den Titel der Geschichte"
+            },
+            "geostoryViewNavLogo": {
+              "title": "Story-Logo",
+              "text": "Hier sehen Sie das Story-Logo"
+            },
+            "geostoryViewContent": {
+              "title": "Inhalt der Geschichte",
+              "text": "Dies wird der Inhalt der Geschichte sein"
+            },
+            "geostoryViewEditButton": {
+              "title": "Story bearbeiten",
+              "text": "Wenn Sie hier klicken, können Sie den Inhalt und die Einstellungen der Story bearbeiten"
+            },
+            "geostoryEditSidebar": {
+              "title": "Seitenleiste",
+              "text": "<p> In der Seitenleiste sehen Sie eine Übersicht über die Geschichte, in der jedes Element durch ein anderes Symbol gekennzeichnet ist, oder mit einer Vorschau bei Bildern oder Karten. </p> <p> Hier können Sie: </p> <ul> <li> Ändern Sie den Titel in jeden Abschnitt oder Inhaltstitel. </li> <li> Ordnen Sie ihn mit Drag-Drop-Abschnitten und seinem Inhalt neu an. </li> <li> Zoomen Sie mit der Sanduhr-Taste auf einen bestimmten Inhalt </li></ul>"
+            },
+            "geostoryEditSidebarToolbar": {
+              "title": "Werkzeuge",
+              "text": "<p> Von links nach rechts: </p> <ul> <li> Ausgewählten Abschnitt löschen </li> <li> In den Ansichtsmodus wechseln </li> <li> Einstellungen bearbeiten </li> <li> Reduzieren / Alle erweitern </li> </ul>"
+            },
+            "geostoryEditSidebarSettings": {
+              "title": "Story-Einstellungen",
+              "text": "<p> Von links nach rechts: </p> <ul> <li> Ausgewählten Abschnitt löschen </li> <li> In den Ansichtsmodus wechseln </li> <li> Einstellungen bearbeiten </li> <li> Reduzieren / Alle erweitern </li> </ul><p> Weitere Informationen finden Sie im zugehörigen Benutzerhandbuch <a target='_blank' href='https://mapstore.readthedocs.io/en/latest/user-guide/story-setting/'> hier </a>"
+            },
+            "geostoryEditContainer": {
+              "title": "Inhalt der Geschichte",
+              "text": "Hier können Sie den Inhalt der Geschichte sehen, sie bearbeiten, indem Sie Abschnitte, Absätze usw. hinzufügen oder entfernen.</p><p>Mit jeder Symbolleiste können Sie beispielsweise den Inhalt der Story bearbeiten:</p><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALsAAAAfCAIAAAAwfyvFAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAWqSURBVHhe7ZhJbFtFGIB9Q0gIsUiUVWxFXBAcuCCQANEDSBxBQqxCSOXQAwIJcaHc4EApRG3SNKjQQps4zUqd0jRRQkOSJk1CkpKN7Iuz76ljx4mdOOGTZvT0YsfPb7xEocynX5bnzf/s53nf/DPPDo9Go4LDr9Go4AhqNCo4NjQaFRwhjUYFx2YshpeW19Y3ZCMZ+AJBV5/b2TVE5HcPz/j8smM7ox4vaSTLtib1MNqlA2NVI1ProZA8FIFjy5KywYn70/O/rG4NbITkoYSZ8K48+eNvj2QWPn6yiDcX+kZlx3aKe937s4pJlm3bdMwu5f4zLKJ2dGZzUx4X0OSgkUCy7NhLeALBw9WtH12qCwsO0iWTks28f+0VZ/ktR84RB0vrg6Gd77iVMejy6vmK7M7B5EqDBC/nlMVUIW5jvq5r23csDx2JN4qrwoaY5gcXa0UvaSTLjr0Ev5rfLm6eOeIbEAvE/Lk+vWDWxfqLohqDLvel57+YXTbp9fOhSZSGS7E2ZtrnP1TecLqtn+su6Bn5qvp6WJ2wBglsemA/c5dhE/Cne9oohEZwkC6ZlAxaphf2Hc+759j5x04WGboQz58tXVoLyKTt7GyMN7D+1oVqcXLSpZny+Q84yy2MaZ9dxBUWrLvSch86UfBmRJ2wJtXGLK4G5lZWI28cI9M2s0hpHF9eSeptTSFc86eVTbd+l224QjDyFot11BqDYpR08RGpqDTWXBufpcLx1bgVTfZofHutgxhb9oVN0LAgQWTK02zzXkkNNTJM4qtjMw9mFIjhIl7Lq1C9bEHMyxZBmjwhMVaC6x/+fvXhE4WGNNa6gNU+JqXSMAuZqVQaI6g95o/lu6gu8Y07MNfFlUcLEmSqIpHGjHp8T51yMURuj49V42zHwO3fOzNaumW3CtS8sOvcMeK+eDNCF+LGWtCoNJktPbI7ClbGwHIg+I6rRlxlcqVhxBl38ckiWE0bJ+dkd8LspjFFPW4WUDYZook0vuC6eK/KrtUYQxfeMHu/qW+/4wcn0vBAMHzDK5N2IoYxkCJpbiZjKAzGxWe19oonYd6I3j1IpC4v5ZQhyhdXmgnr2xrbGAiTJq2p64msYh5N87qHZYY6N5Mxv7QPMEFFjUEUnt7Z05AmelWhRPG0aF6vzUFXgo9Lhi6M9qm/+w5Xt6ILhUB2x8KWMWCW5t7jeexM8cbiGSwmwVCocnjSXGkLe0bm/Wuye2traMnL3I27jO2mMQOLyzydvl9Sy82gyU199szFuI3hRjJ5wq7WiATnldCFEujqGxXPFmLdkN02sGsMCGlYsKvcUzTZqD79k+tMe7/oTS7o8szPJSyrB0vrVaU53dZPNE/Ni9UhWpAgMuVptkEFNrYoIv4G/KSikYOU2zvTcqm7HKeX9/HtfKFv0fPCuVLx4ZFBFwkyVZHEdQEFYwBpKLl3p+V+VtnEBpsy89yvl+ZMhcEO5DMdmYiyHQG/gV/C6N92NIfvUt0w2f+XxX6mmfrxWXNppCmOs2RgyaHyBmfXkOqY7ALGYkRxjVsXUDMGWEMZI0RhGj2QUUAZUC0zjCxVnVfZjqB3wXPAWX60sXN/VjGv77pq9pQx/1HYYD2aWZTe3J2ILqBsjABvroxMsVrz3SwfFgUjkpjGALscpgLG8BiputFDgrdd1aIAlA9NhNlm3j+RtqeMKekfNf5Jsw7SSJan2YNfapwety4QpzEC7uXlwXF2M5grD9kAVziFu8WC+vHl+tbpBdmxHWGMtVg7wlAam5UjDZ1hxtDkoJGgOu4ppW5sxmLPaw7SSJan2cAXXH89v1KcS/2OWxdIyBgB3vQseNY2NmQ7Fourgc//+EvcMAtj2JmSRrJsaxKD59CW6QVvIM6/Fg2SYIzmf4U2RqOGNkajhjZGo4Y2RqOGNkajhjZGo4Y2RqOGNkajwtbWv+UsZ02x4CaBAAAAAElFTkSuQmCC'/><ul><li>Medienquelle wechseln</li><li>Passen Sie den Abschnitt an die Höhe des Inhalts an oder passen Sie ihn vertikal an die Ansicht an</li><li>Stellen Sie den Hintergrund so ein, dass er den Containerraum bedeckt oder nicht</li><li>Größe ändern</li><li>Richten Sie den Container aus (verfügbar, wenn die Größe nicht voll ist).</li><li>Thema wechseln</li></ul><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACIAAAAgCAYAAAB3j6rJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsIAAA7CARUoSoAAAAASdEVYdFNvZnR3YXJlAEdyZWVuc2hvdF5VCAUAAAIwSURBVFhHY/wPBAyDADBB6QEHow5BB1R3yIWX7xiOP30N5REPqJJY/wKN2HLnCYMwBztD+YGzYLF+F1OGV19/MHgqSzMwMzKCxfABqjjk4ccvDJ6r9jLc+/AZKgIBSgK8DNvDnBnk+XmgIrgBVaKGg4WZgYuVmYGfnZWh39mUYbanJYMQJzsDEzAgWJiIs4KgKlCwf/z5G8rDBM++fGOwWbKD4crrDwzOCpIMGYbqDLE6ygzO8hIMd95/ZnBYthOshhAg6JCXX78zmCzYwiA/bS1D3OYjDPsfvmD49vsPw4ZbjxjqDl1gYGdmZljgbc0gxs3BcPr5W4bzr94xXHvzgeHci3dgMZCcODcn1DTcgOioATlo1Y0HDPMu3Wa4ArQofcdxhp5TVxmmnrvBoC7ExyABtOzxp68MVou2MRjN38JwF5heQGIgOWISK0Vp5B8w2q69+cjAycrC4KMsw9BsZ8ggw8sFxiC2jYwYAwszldIIIbD59mOGiWeuM1Rb6zGUmmsDsQ5Dg40BmN0HTLgC7GxQlfgBxQ4BJeb5l+4w3H73CewgN0UpBmtgSIDYn37hTuTogGKHIANQAtacvQGMQWxSAFUdQgkYdQg6GDoOYQOWnLJ83DgLJS5gGWIkLgSsZ9iAtDDR2RUdEF37/vr7j+HG24/gElNfTJDhyONX4LpFioeLAd2NL4ClMKjuAWVjTmCFSAwYbTyjg1GHoINRh6CDUYegg1GHoINB4hAGBgDB977viofL1wAAAABJRU5ErkJggg=='/><p>Mit diesem Symbol können Sie die zugehörige Karte bearbeiten</p><img src=''/><b>Trinkgeld: </b>Jedes Werkzeug verfügt über einen Tooltip. Bewegen Sie den Mauszeiger darüber, um weitere Informationen anzuzeigen"
+            },
+            "geostoryEditAddbar": {
+              "title": "Neuen Inhalt hinzufügen",
+              "text": "<p>Hier können Sie verschiedene Arten von Abschnitten hinzufügen:</p><p><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAU4AAACDCAYAAADiUvK3AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsIAAA7CARUoSoAAAAASdEVYdFNvZnR3YXJlAEdyZWVuc2hvdF5VCAUAABT5SURBVHhe7Z0NcBzleccf2/iwOWwjMJYBiwGZAbmAMMTDVJMhhpm4TbBJgXFNXDRD4mJE8Zg6devg4oqicWLixIWJhiSyigiJQgN0igp2KXVmQEBHM4zMhwyxTGIRIwORMBaWOcBnRLv/1b7i1cue7vZ2b3fv7v+befTuvs9+vM/t3l/v1+5N+j8L0Th+/LidTp061U5NovYPDw/b6cyZM+3UJO7l9+tn/IwfMP5o459s/yWEEJIzFE5CCPEIhZMQQjwy6ciRI0XVx3n06FE7nTFjhp2axL38fv2Mn/EDxh9t/KxxEkKIRziqbhB3P+Nn/IDxc1SdEEKKikiEE5VcGo1Gy8fiQEGF0y1oGCGE5IubpsDCJFDhjDIQQkh5E6b+BCKcmQqqB0Gj0WiFNJNM+UEwKZ1Ojzuy11Ens2DW8ew0k9/vqBZHFRk/YPyMX2fSpEl2qvZPJBJ2qjD9fsvnSzhNUcQ6/EjV/tmE1STb+XnjMH7A+Ms7/lmzZtmpQhdGLGN/lafAelDly3se5wknnGCnQB0CKfxIsb+er9D9bmQ7P28cxg8Yf/nGDwHU41cCqYQRKfbX8xWffvqpnfotX17CqQuf2h0pDP6XXnpJpkyZMuZTYF0VXBdenWz+VCplp8lk0k5N/B4/7n7Gz/gB40+OE0SA9ZGREbnsssvGhNMUT+gTlkMXTr2prXZFqgx+COcVV1xh+wghJCyef/55WzjRx6mEUxdPpW9mH6giV+H0Paqui6YyQgiJijA0yZNw6gUwC6bss88+s6vLhBASNtAeaJCbNsEU+nI+5FXjNE+qCoUCq0ITQkjYmDpkalFQ2jQZbfZ8DH2Zph07dsxO4SeEkLBR2qS0yDRdw/xYYH2cusJjmRBCwsbUIbUcNJMxepSLYXqAnqplPR9TkCZPnmwbIYSEjdIfaJGuTWpZretpPpZ3H6eu4modBpVnjZMQEgVKf3RNUpjrfvBVNdQLZxohhISNmxYpC5JA2tSFLiQhhORCWFoUyOCQotCFJYSQiXDToELoUd7CaRZGrReikIQQkiuZtChIbcppHmem+U8qX0/xkL56UJ8QQsJE6Y+bNiE1LVN+Ngukj1MHqs5aJyEkCsLSn5znceZqas4UIYSEjdIfN20K0gKrcbKWSQiJE4XUpMCb6oQQUupQOAkhxCMUTkII8UhBhJP9nYSQKAhLe3L6eWC9MJj3hHW8fUQ9UI+3LmPuFNJPPvlEXn75ZbnuuuucPcJgSPpe3C+HnTV3ElJVWyuV06zFoT7p/t3EW7tzqsy/vFoqnDWSjVyui8bs+bKoOv6fbvrdHunpH/3traBIVNVK7Rnuv4NTSEopFvD444/LpZdeKtOmTRt7Q5L+1jZoFH57SP/NIfWbRMBN/3SUv0SEs0davrFJdlVUSgWEceRDGRpMiYxbr5Jv/+tWWTrHWn+lRb7RuBM7emSpbH6iQWqdNZKN0euS8yf99c3yxN/E/9Md2LFNHp26WOqC0vihLuk8vkLWL6t0MsJjYEezdNasGv1eBMHgTmnrXSxrI4gFhCaclggGKpwff/yxLZzXXHONs0cYjH5BpekJaVhorVoXb8PNLTJfrQ93SlP9TvlSsQrnYLe0b2+Xzn6RqsuXSv1fLpHqcT+r3SvtDduk01nLjcWyvqVeapy1wlCqwtki3Zc3BCo2LS8ukoZIhNNbLNbX3xIdZ8WNCGMBTz75pC2c06dPp3B6xhROk5G0pFKjcXpjqiRnhtwE+cQSn5st8UlXy+LFp0rvM90yMPNa2dq6SmqmONt4FSibcP4JpIdTkvMnnUhKEi2EmGOKTepAj+wdrpAFf1IlybFr4oEiEc7+/1gjax6ulc3/PsF9UybCWZ6j6lMSlgBaX1LPFrJoguF+2T9spZdeJ7euaZTN61fI0qsXSMU4NbLiOaNSKj1Z0tqr8CRcP8cMVgSiaTLw1Aa5ae0mabpzjdz2QI8E21sYJ1LS97vDkjxvnlQ5OeVMedY4cx4c0gaUImNAdv7DamnZl5DKLzdI498vkap8ajWRUJqDQ5/X0tLS9aPlsuU5x5GwavET1cbASL/s+lGTtA3Uyfo7Vski1PRiWeO0hHJHmzyeXiJrr6+xvglWq2b5Jnl22Wa5a+Yu2ZW4TlYtq5aks/UYZVLjLE/hzLmPs0YaVL9oRKT3tMjqO3dJYl6FDB0ckPS0alnxT9+T+ou/cMvGkNLv4xx6pklW39tt1zQrLFFpvaU2c03+UJc037FNdg2qemlCar+1VTbW7ZX23TESToj71k3S3DUkiYVrpbVpiVS82yHrGtqk6rv3S+3T35HmV9JSUbdWNm8w/pGzqU7iQO8LO2Vo9rWy8Setcu/tdVL5WZ88eudt0rJHbxRicGi1rPZk7dZexC8VVzXKwy1bpfGHrfLQBKKZ2tMm627dookmSEvPz9fJTX/7oOx3ciIH4t5gCWNXSqqXNUrrXZZoWtnpvv3SJ9Uyv7pKltzVKo1WbTPV1SzfaWiWrkOju5YTJTIdySBbjdPD4NDUZFISETaNe366XDY9lZTF371P1n/ZuoUPdsiGdW3S+5VGeeL2RWorDg6FSNYBlfSAdD/WIo8erJO1dtdKv3SsXSNtBxy/CzW3tMrWqGucw52yZdU26bIEcunGu6ThS593m/T+fKVs2HHluK6Iod0tcveWnZag1sn6to2yGDM9Iq5xhjUdiYNDWSxK0QS1135bahJD0vkDq5b4404ZmFMjNZa4JKbpdRsODsWCoT7pfGCDrPyr1dL0SLf0/q+qkVXJ4r+IfxeEJCqk8hTrrkgflL2798vQiJMvA9L7Skrk4hqZ7+TIyJDs371XDloV6MQplVIRxs0UI0qvjzPVLz0vdEjz/buk8sZGqb9qkdRE2EcZCIe6pWXzPbKzz2nmzbZqi83Wf/4i6OacuMYZwfSuAPhCjXOwRzp+0SLtz/W7j6onaqTeavL2390sna4bxKTGCSxB7Lp/g2z7zYDInCWy9vtrrZpkl2xbsUV6b7xfWm+o0u5Hkcqvrpeta+qkQlUw2MdZpBzqk64DCVm0bKlUHdktna/3O44iZrZ1I257SO67xbpBsT78oaSKYmS9Rx6sXykrM9qD1hbFS+pAp7TdsVKW37xJ2jKJJkj3Svud7dIz7qGFmDKlQupuH+1PTw7ukm13tEvfgb3Sbblqz8NEpD5p39BkiWbS2u5eabW2GxPNMqI0R9X9kuqTnR17ZcE1S40ndCLA+nK2PN0tU2tWyaqvVMjAf66T1Q/0ydJx/bf90rn9vzwO9tTI1bcsLvCcvGx9rx77WWNyXQZ2NMmmjh4ZGDfQ44/Y1Dg1Ugd7ZP/IfKn87d2y+qciDW1bZels/MOw8qfMl9p5Lk2eMqlxUjgNUr/fKT/+fsvoSGGiUuq+tVFu/3p1fk+EBEHKaibdtEU6pVrq/my+HH+xU7oHa2TtQ5tlyVjffbEODuXeVI/TdRnYsUFWbw92TkIchVPRs325bHruatnavir7I7psqpcf/b/ZIrf9nfPlBOkB6dq+Tm5q2CK7Djp5YZOsk/U/aZQVVu2yb3eP9M+sk4Z/2aiJJijWwaHcShDL61JG1P71w/JvbTmIZhnBGifQOsQzN74SUn3DZvnejTVffFqCFIaYXpfSqnGW1tuRQmuqW0IYqHDGYh7nRDhz7Dqn18ut148+MpZ6pklW3ovu72yE07wtS4rouvB9nBPD93E6lIRwDvdL52PN8rOneiVl3yeJz6dSHO+SbfVbMk4V+ZwwvqD5DPTkQxiDQzlQNNeFFAN8H2dQDPbIzsfa5MGn+1ybe4nqa6WxaZVUPLVG1vwq29SlML6g+Qz05EPEYlN014UUAxxV90n63W55dHuLdOyeqH/MYVqtNPxjnXQ1tmSZV0jh9AuvSzYYix8onHkytG+XtD/YJp2/TWX/YupYH2TC2sMKbwKiEZtSoPivC4XTOxROZym+wjnwSsfoz0vg4dmCQeH0Sulcl1Lqey7dfnQKpydK6T9owDf17Dqpv742oilUpVuzIfGEwukJNqMyckGDtP5wqUQzq47CScIlNOG0hDBQ4Yzy54EpnC5QOAOC1yUjkcYyHs7j9EQpfUFLCQpnRiicBYHzOD1RZpPGiwYOqGQk0r7nUoplPOzjJIQQj4QlnHw7EiGEeITCSQghHqFwEkKIRyichBDikUlHjhzxPTgE06cjvfrqq3LDDTc4exBCSDg88sgjcskll4ybjqQGhjg4RAghEcLpSISQkoHTkQghJKZQOAkhxCMUTkII8QiFkxBCPBLLwaGTdrzuLBFCyo2Pll3oLHkntMEhLARpEFAYIYSEjdIfN20K0thUJ4QQj3AeJyGkZCjqeZx6QQghJCzC0h421QkhxCMUTkII8QiFkxBCPBKYcLJfkxASJwqpSZzHSQgpGYp2HidUnrVPQkgUhKU/kzFfKZthztNE+XqKeVMwQggJG6U/btqE1LRM+dks7xqnqepqnbVNQkiUZNKiILUppyeHgNpMPTkEVdefHFKG3xzCk0MopO7HPlhG/wOWMZsfGKe3twXKb/LRRx/Z6UknnWSnJtn2L3Z/scb/3nvvyYUXXihXXnmlk+OPZ599Vl5//XU5/fTTnZxR4hq/wq+/XO9/JXp4MhHLiB9PAmEZ26ong6AneHJI/eaQMuWH/mAf1DSBOq4ik/4plD8Q4VTiCINwIkWBVJ6+HY6v9jdObaPOD78bH374oZ2efPLJdmqiBqYy7V/s/mKO/+2335bZs2fbN7Yfuru7ZWhoSM466ywn53PiHD/w6y+X+99NuKApiB/pjBkzxsQQpgQSmoJUF059Oxwf+0cqnEgzCScKqUQTqdpWCScC0lHHz/bBUjiLO/4DBw7InDlzZOHChU6ON3bv3i3vvPOOnH/++U7OeOIev19/ud3/prClUik7TwknlpU4IoXGIHUTTmyL4yONRDgBAlOiCZ8SzmPHjo0JpxJNtQ1SJZzY3zi1TbYPlsJZ/PGj5okm9sUXX+zk5saePXvk4MGDcuaZZ/L6l2H8EDnEj1QXTiWaSnOwfOKJJ44Jp9oGpo7vVzhznseJE+qpWtbzlUgq00VTiaRadhNNMJEP0F/8fgjf4cOHbSHMFWyLfc444wzf56e/OP3Kp/xqWdcaXXt0bVLLal1P87FJVg1yXCmRCdwUF4WEHyn+I+gFR4rCokaKdaX+yqdSdfxM/3FUjTaT4h89etRO8R/HjYnKD4rdX0rxo/Z4yimnyEUXXWTnZeK1116TDz74QObNm8frXybxqxqhiapxI35Vk9RrlEp7sL9e20QKg1gixfmRmuRavpyb6kAJH1L4kcJ0cURTHSmEEanyKdOb+m5kKzi/OKUVf39/vySTSVmwYIG9brJ37167X6uqqspe5/Uv7/iVcM6cOXNMDGFKOCGMSNFUV4KpCyeOjxTHR2qSa/nyEk6g1zh1M4XT9GN/pPl+cPzilF78b731lj295IILLnByRtm3b589/ebss892cnj9Gf9RW/AQvxJDZaZwmn4Y/ADHx7pJruXzJJxAb0orMdQNfqSoJps+YDbFVb4ilw8O8ItTWvFDPDESqkbL33jjDXuGhi6agNe/PONXIqfiR40T6KIIQ3chUjTVTR9MHT9TV0Cu5fMtnACpMiWcqimu+wCOj2WvH5yCX5zSjR/iiX+4AF8AUzQBrz/jhwCq+HVRBKoP0xROgFQdP3ThhF8XPrU7Upjyq6a88qk014Jl8g8PD9up+o9j4vf4cfeXUvzoykH/Jbp3kI/1N9980/afe+65dpML2+H3Y2BY5/Vn/ADx64KoUnPwx9wGx1d+N3ItX17CCfTBHVMYkWJ/PV+h+93Idn7eOMUfP5rgeHQOhoEh9EfhfsI+6r7CFwDbIoWwQmAhnvDDeP3LN34Inx6/Lo7YXwmjnq/Q+zjdyLV8nqYjAd2vCyLAOvy6MJrbmH2cJtnOzxuneOOHD49KomaJaUiZmpuZQDMN+6Pmeeqpp2Y8B4giPlBoP+//0fhnzZplpwoljtjfFE4F1oMqny/hBNmE0fT7LThvnOKMHzVGzMU87bTTPAumCQT0/ffft8UXNVaduMav8Ovn/e8evy6cwOzDNP1+y5d3U13364fQ/aZognyOr8Mbp/jix5uR0NyeO3fuuC4eP+Af9ODgoN3M19+QFMf4dfz6ef9njj9TjVKveQZVvkDeAI+C6YVTqHxa+dqhQ4fsvky8yQg3o9s2+RgEE8dEnxXO4bYNrbzMJFN+EAT60xl6EIUqMCke0KRGTRNP/aBfMmhwTNRicQ41TYeUL2HqT/B3s4YZiDJS+qCWiX5IvNCjEKKpwLFxDpwL5ySlj5umwMKkoMKZCbegaaVlGAjCezfVixZysnSv/KD5VzK9+X/k1bSLP4PhHDgXzunmp5WWxYFIhJOUNhhBB+aId1aG3pdXjlnpsffkv38/mpUr6lysdZIw8D0dyaTQfo4qxj9+NJsx0o1nzz3xxxfkm7/8g3RYi//85/VyR+1odq5ANDFQhClPUcYPCuXn/R+P+FnjJIGCZ8wxDc2zaAYAnizCuVEGQgpJIPM4dQrt53/ceMePt7TjlkKtzzM+a5wAtV30g+HJIjei/nz8+nn/s8ZJShA0lz33bQYIarrq6TVCCgVrnAZx98c9fvwQG2qbEzbVU/vkZ79+VTrMcZzPRmTvsREZsBbPSSTkHPOnt6efLvd88ypZOIEu4wUiqHW6/XQwiPrz8evn/c8aJylBcGNletehYqD7NVl3OC3PfmyYI5rgD1at8Qv+w2/Lfd1/dLZwB+dWNzchhYLCSQIFbz7KNuG9ctEl8usFc+We+YadPV3Ur61/bY6Lf/45sm7RXGcLd3BulIGQQsKmukHc/XGPv6+vT6qrq501jwQwOAQmKkPUn49fP+//eMTPeZwGcffHPX78amUchFP9KqZJ1J+PXz/v/3jEz6Y6IYR4hE11g7j74x4/m+qF9fP+Z42TkMyYU5EIiREUThIfKk6TP02KnJOcK187z8kjJIZQOEl8OHGBrLutXnpv+6osPNHJIySGUDgJIcQjFE5CCPEI53EaxN0f9/h9zeMMCM7jjG/5/fo5qk4IIUUK53EaxN0f9/h9zeMMCM7jjG/5/fpZ4ySEkCKFwkkIIR6hcBJCiEconIQQ4gmR/we6YgNq8eeDXgAAAABJRU5ErkJggg=='/></p><ul> <li> Titelabschnitt </li> <li> Absatzabschnitt </li> <li> Immersiver Abschnitt </li> <li> Medienabschnitt </li> <li> Webseitenabschnitt </li> </ul>"
+            },
+            "geostoryEditMediaEditor": {
+              "title": "Medieneditor",
+              "text": "<p> Mit dem Medieneditor können Sie verschiedene Arten von Medieninhalten in die Geschichte aufnehmen: <ul> <li> Bilder </li> <li> Videos </li> <li> Karten </li> </ul> </p><p> Weitere Informationen finden Sie im zugehÃ¶rigen Benutzerhandbuch <a target='_blank' href='https://mapstore.readthedocs.io/en/latest/user-guide/media-editor-window/'> hier </a>"
+            }
+        },
+        "userSession": {
+          "saveErrorNotification": {
+            "titleContext": "Speichern der Benutzersitzung fehlgeschlagen",
+            "categoryError": "Fehlende Kategorie erstellen \"{categoryName}\" faile",
+            "defaultMessage": "Unbekannter Fehler"
+          },
+          "removeErrorNotification": {
+            "titleContext": "Entfernen der Benutzersitzung fehlgeschlagen",
+            "defaultMessage": "Unbekannter Fehler"
+          },
+          "successRemoved": "Benutzersitzung entfernt",
+          "remove": "Benutzersitzung zurücksetzen",
+          "confirmRemove": "Möchten Sie die Standardkonfiguration wirklich wiederherstellen?"
+        }
+    }
+}


### PR DESCRIPTION
Tasks

- Script to copy translations files to map store
-  Check for unsupported locales and load them within mapstore

Translations for unsupported locales have to be created manually in the unsupported locales folder