### PR TITLE
Client - Create new geostory does not show an empty story

### DIFF
--- a/geonode_mapstore_client/client/js/epics/__tests__/gnviewer-test.js
+++ b/geonode_mapstore_client/client/js/epics/__tests__/gnviewer-test.js
@@ -83,14 +83,15 @@ describe("gnviewer epics", () => {
 
     it("should call setNewResource, setResource, setResourceType, setGeoStoryResource when user has permissions", (done) => {
         mockAxios.onGet().reply(() => [200, newGeostoryConfig]);
-        const NUM_ACTIONS = 4;
+        const NUM_ACTIONS = 5;
         testEpic(
             gnViewerRequestNewGeoStoryConfig,
             NUM_ACTIONS,
             requestNewGeostoryConfig(),
             (actions) => {
                 try {
-                    expect(actions.map(({type}) => type )).toEqual(["GEONODE:SET_NEW_RESOURCE", "GEOSTORY:SET_CURRENT_STORY", "GEONODE:SET_RESOURCE_TYPE", "GEOSTORY:SET_RESOURCE"]);
+                    expect(actions.map(({type}) => type )).toEqual(["GEONODE:SET_NEW_RESOURCE", "GEOSTORY:SET_CURRENT_STORY", "GEONODE:SET_RESOURCE_TYPE",
+                        "GEOSTORY:CHANGE_MODE", "GEOSTORY:SET_RESOURCE"]);
                     done();
                 } catch (error) {
                     done(error);

--- a/geonode_mapstore_client/client/js/epics/__tests__/gnviewer-test.js
+++ b/geonode_mapstore_client/client/js/epics/__tests__/gnviewer-test.js
@@ -9,6 +9,49 @@ import { testEpic } from '@mapstore/framework/epics/__tests__/epicTestUtils';
 
 let mockAxios;
 
+export const newGeostoryConfig = {
+    "type": "cascade",
+    "resources": [],
+    "settings": {
+        "theme": {
+            "general": {
+                "color": "#333333",
+                "backgroundColor": "#ffffff",
+                "borderColor": "#e6e6e6"
+            },
+            "overlay": {
+                "backgroundColor": "rgba(255, 255, 255, 0.75)",
+                "borderColor": "#dddddd",
+                "boxShadow": "0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22)",
+                "color": "#333333"
+            }
+        }
+    },
+    "sections": [
+        {
+            "type": "title",
+            "id": "section_id",
+            "title": "Abstract",
+            "cover": true,
+            "contents": [
+                {
+                    "id": "content_id",
+                    "type": "text",
+                    "size": "large",
+                    "align": "center",
+                    "theme": "",
+                    "html": "",
+                    "background": {
+                        "fit": "cover",
+                        "size": "full",
+                        "align": "center"
+                    }
+                }
+            ]
+        }
+    ]
+};
+
 describe("gnviewer epics", () => {
     beforeEach(done => {
         mockAxios = new MockAdapter(axios);
@@ -39,7 +82,7 @@ describe("gnviewer epics", () => {
     });
 
     it("should call setNewResource, setResource, setResourceType, setGeoStoryResource when user has permissions", (done) => {
-        mockAxios.onGet().reply(() => [200, {}]);
+        mockAxios.onGet().reply(() => [200, newGeostoryConfig]);
         const NUM_ACTIONS = 4;
         testEpic(
             gnViewerRequestNewGeoStoryConfig,
@@ -47,7 +90,7 @@ describe("gnviewer epics", () => {
             requestNewGeostoryConfig(),
             (actions) => {
                 try {
-                    expect(actions.map(({type}) => type )).toEqual(["GEONODE:SET_NEW_RESOURCE", "GEONODE:SET_RESOURCE", "GEONODE:SET_RESOURCE_TYPE", "GEOSTORY:SET_RESOURCE"]);
+                    expect(actions.map(({type}) => type )).toEqual(["GEONODE:SET_NEW_RESOURCE", "GEOSTORY:SET_CURRENT_STORY", "GEONODE:SET_RESOURCE_TYPE", "GEOSTORY:SET_RESOURCE"]);
                     done();
                 } catch (error) {
                     done(error);

--- a/geonode_mapstore_client/client/js/epics/gnviewer.js
+++ b/geonode_mapstore_client/client/js/epics/gnviewer.js
@@ -9,6 +9,7 @@
 import { Observable } from 'rxjs';
 import axios from '@mapstore/framework/libs/ajax';
 import turfBbox from '@turf/bbox';
+import uuid from "uuid";
 import {
     REQUEST_LAYER_CONFIG,
     REQUEST_MAP_CONFIG,
@@ -176,7 +177,8 @@ export const gnViewerRequestNewGeoStoryConfig = (action$, { getState = () => {}}
                 .switchMap((gnGeoStory) => {
                     return Observable.of(
                         setNewResource(),
-                        setResource(gnGeoStory),
+                        setCurrentStory({...gnGeoStory, sections: [{...gnGeoStory.sections[0], id: uuid(),
+                            contents: [{...gnGeoStory.sections[0].contents[0], id: uuid()}]}]}),
                         setResourceType('geostory'),
                         setGeoStoryResource({
                             canEdit: true

--- a/geonode_mapstore_client/client/js/epics/gnviewer.js
+++ b/geonode_mapstore_client/client/js/epics/gnviewer.js
@@ -40,7 +40,7 @@ import {
 
 import {
     setCurrentStory,
-    setResource as setGeoStoryResource
+    setResource as setGeoStoryResource, setEditing
 } from '@mapstore/framework/actions/geostory';
 
 export const gnViewerRequestLayerConfig = (action$) =>
@@ -180,6 +180,7 @@ export const gnViewerRequestNewGeoStoryConfig = (action$, { getState = () => {}}
                         setCurrentStory({...gnGeoStory, sections: [{...gnGeoStory.sections[0], id: uuid(),
                             contents: [{...gnGeoStory.sections[0].contents[0], id: uuid()}]}]}),
                         setResourceType('geostory'),
+                        setEditing(true),
                         setGeoStoryResource({
                             canEdit: true
                         })


### PR DESCRIPTION

Expected result:
- empty geostory is loaded and the geostory mode is set to edit

![image](https://user-images.githubusercontent.com/19175505/122741149-f56cdb00-d284-11eb-97c6-6ec2c1715a6b.png)

Current result:
- the empty geostory page is visible


