### PR TITLE
Add hint on hover for the thumbnail editing inside the detail panel

### DIFF
--- a/geonode_mapstore_client/client/js/components/ContentsEditable/ThumbnailEditable.jsx
+++ b/geonode_mapstore_client/client/js/components/ContentsEditable/ThumbnailEditable.jsx
@@ -32,6 +32,9 @@ const ThumbnailEditable = ({
                 }}
                 message={<Message msgId="gnviewer.uploadImage"/>}
             />
+            <div className={`icon-image-preview`} >
+                <FaIcon name="file-upload" />
+            </div>
         </>
     );
 };

--- a/geonode_mapstore_client/client/js/components/ContentsEditable/ThumbnailEditable.jsx
+++ b/geonode_mapstore_client/client/js/components/ContentsEditable/ThumbnailEditable.jsx
@@ -9,6 +9,7 @@
 import React, { useState, useEffect } from 'react';
 import Thumbnail from '@mapstore/framework/components/misc/Thumbnail';
 import FaIcon from '@js/components/home/FaIcon';
+import Message from '@mapstore/framework/components/I18N/Message';
 
 const ThumbnailEditable = ({
     defaultImage,
@@ -29,11 +30,8 @@ const ThumbnailEditable = ({
                     setThumbnail(data);
                     onEdit(data);
                 }}
-
+                message={<Message msgId="gnviewer.uploadImage"/>}
             />
-            <div className={`icon-image-preview`} >
-                <FaIcon name="file-upload" />
-            </div>
         </>
     );
 };

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
@@ -126,7 +126,8 @@
             "editMetadata": "Metadaten bearbeiten",
             "editStyle": "Stil Bearbeiten",
             "editData": "Daten Bearbeiten",
-            "backToDataset": "Zurück zum Datensatz"
+            "backToDataset": "Zurück zum Datensatz",
+            "uploadImage": "Klicken oder ziehen Sie ein Bild und legen Sie es ab"
         }
 
     }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
@@ -120,6 +120,7 @@
             "errors": {
                 "noPermissions": "You dont have permissions to add a geostory"
             }
+
         },
         "gnviewer":{
             "edit": "Edit",
@@ -127,7 +128,8 @@
             "editMetadata": "Edit Metadata",
             "editStyle": "Edit Style",
             "editData": "Edit Data",
-            "backToDataset": "Back to Dataset"
+            "backToDataset": "Back to Dataset",
+            "uploadImage": "Click or drag and drop an image"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
@@ -120,6 +120,7 @@
             "errors": {
                 "noPermissions": "No tienes permisos para agregar una geohistoria"
             }
+
         },
         "gnviewer":{
             "edit": "Editar",
@@ -127,7 +128,8 @@
             "editMetadata": "Editar Metadatos",
             "editStyle": "Editar Estilo",
             "editData": "Editar Datos",
-            "backToDataset": "Volver al Conjunto de Datos"
+            "backToDataset": "Volver al Conjunto de Datos",
+            "uploadImage": "Haga clic o arrastre y suelte una imagen"
         }
 
 

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
@@ -126,7 +126,8 @@
             "editMetadata": "Modifier les Métadonnées",
             "editStyle": "Modifier le Style",
             "editData": "Modifier les Données",
-            "backToDataset": "Retour à l'Ensemble de Données"
+            "backToDataset": "Retour à l'Ensemble de Données",
+            "uploadImage": "Cliquez ou faites glisser et déposez une image"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
@@ -128,7 +128,8 @@
             "editMetadata": "Modifica Metadati",
             "editStyle": "Modifica Stile",
             "editData": "Modifica Dati",
-            "backToDataset": "Torna al Dataset"
+            "backToDataset": "Torna al Dataset",
+            "uploadImage": "Clicca o trascina un'immagine"
         }
     }
 }

--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -93,10 +93,14 @@
                 top: 50%;
                 left: 50%;
                 transform: translate(-50%, -50%);
-                font-size: 4.5em;
+                font-size: 3em;
                 opacity: 0.5;
                 z-index: 0;
                 pointer-events: none;
+                .fa-file-upload{
+                    padding-top: 2em;
+                }
+
             }
         }
     }


### PR DESCRIPTION
Currently only a semitransparent "upload" icon is visible on top of the thumbnail of the detail panel. A textual hint saying something like "change thumbnail" or "upload a new thumbnail" should be either shown on hover or under the icon.

Result in PR:

https://user-images.githubusercontent.com/4085786/123806736-82e8a480-d8ef-11eb-8878-006dad457003.mov


