### PR TITLE
Improve the positioning of the edit icons inside detail panel

### DIFF
--- a/geonode_mapstore_client/client/js/components/home/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/home/DetailsPanel.jsx
@@ -28,7 +28,7 @@ const CopyToClipboard = tooltip(CopyToClipboardCmp);
 const EditTitle = ({ title, onEdit }) => {
     return (
         <div className="editContainer">
-            <h1><TextEditable onEdit={onEdit} text={title} /></h1>
+            <TextEditable onEdit={onEdit} text={title} />
         </div>);
 };
 
@@ -233,12 +233,13 @@ function DetailsPanel({
                             {resource?.title}
                         </h1>
                         }
-                        {activeEditMode && !editModeTitle && <span className="inEdit" onClick={handleEditModeTitle} ><FaIcon name={'edit'} /></span>}
+                        {activeEditMode && !editModeTitle && <span onClick={handleEditModeTitle} ><FaIcon name={'edit'} /></span>}
 
 
-                        {editModeTitle && <><h1><EditTitle title={resource?.title} onEdit={editTitle} />
+                        {editModeTitle && <h1>
+                            <EditTitle title={resource?.title} onEdit={editTitle} />
+                            <span className="inEdit" onClick={handleEditModeTitle} ><FaIcon name={'check-circle'} /></span>
                         </h1>
-                        <span className="inEdit" onClick={handleEditModeTitle} ><FaIcon name={'check-circle'} /></span></>
                         }
                         {
                             <div className="gn-details-panel-tools">
@@ -290,21 +291,20 @@ function DetailsPanel({
                             && <>{' '}/{' '}{moment(resource.date).format('MMMM Do YYYY')}</>}
                     </p>
                     }
-                    <p>
-                        {activeEditMode && !editModeAbstract && <span className="inEdit" onClick={handleEditModeAbstract} ><FaIcon name={'edit'} /></span>}
-                        <div className="gn-details-panel-description">
-                            {editModeAbstract && <>
-                                <span className="inEdit" onClick={handleEditModeAbstract} ><FaIcon name={'check-circle'} /></span>
-                                <EditAbstract abstract={resource?.abstract} onEdit={editAbstract} />
-                            </>
-                            }
-                            {
-                                !editModeAbstract && resource?.abstract ?
-                                    <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(resource.abstract) }} />
-                                    : null
-                            }
-                        </div>
-                    </p>
+                    <div className="gn-details-panel-description">
+                        {editModeAbstract && <>
+                            <EditAbstract abstract={resource?.abstract} onEdit={editAbstract} />
+                            <span className="inEdit" onClick={handleEditModeAbstract} ><FaIcon name={'check-circle'} /></span>
+
+                        </>
+                        }
+                        {
+                            !editModeAbstract && resource?.abstract ?
+                                <span className="gn-details-panel-text" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(resource.abstract) }} />
+                                : null
+                        }
+                        {activeEditMode && !editModeAbstract && <span onClick={handleEditModeAbstract} ><FaIcon name={'edit'} /></span>}
+                    </div>
 
                     <p>
                         {resource?.category?.identifier && <div>

--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -123,8 +123,8 @@
 .gn-details-panel-content {
     padding: 1rem;
     font-size: 0.9em;
-    .inEdit{
-        margin-right: 0.5rem;
+    .fa-edit, .fa-check-circle{
+        font-size: 0.9rem;
     }
 }
 
@@ -132,19 +132,26 @@
     display: flex;
     margin-bottom: 1rem;
     h1 {
-        flex: 1;
+        display: flex;
         word-break: break-word;
         font-size: 1rem;
-        margin: 0;
+        margin: 0 0.4em 0 0;
         .fa {
             margin: 0;
             margin-right: 0.6rem;
         }
     }
     .gn-details-panel-tools{
+        display: flex;
+        flex: 1;
+        justify-content: flex-end;
         button, a{
             padding: 0 0 0 0.5rem;
         }
+    }
+    .inEdit{
+        align-items: center;
+        display: flex;
     }
 
 }
@@ -153,9 +160,15 @@
     font-size: 0.9rem;
     text-align: justify;
     word-break: break-word;
+    .gn-details-panel-text{
+        margin-right: 0.5rem;
+    }
     // force styles of html coming from WYSIWYG
     img {
         width: 100% !important;
         height: auto !important;
+    }
+    .editContainer, .gn-text-editable{
+        display: inline-block;
     }
 }


### PR DESCRIPTION
The should sit to the right of the text, otherwise it's not clear what thei serve for.

Result in PR:
![Schermata 2021-07-01 alle 09 44 49](https://user-images.githubusercontent.com/4085786/124086085-02da5000-da51-11eb-9417-efee75d083b2.png)
