### PR TITLE
[FIXES #344] Real Cause of 'rest_framework namespace is not Unique' is not Fixed

### DIFF
--- a/geonode_mapstore_client/apps.py
+++ b/geonode_mapstore_client/apps.py
@@ -10,6 +10,7 @@
 #########################################################################
 from django.apps import AppConfig as BaseAppConfig
 from django.utils.translation import ugettext_lazy as _
+from django.apps import apps
 
 
 def run_setup_hooks(*args, **kwargs):
@@ -28,5 +29,6 @@ class AppConfig(BaseAppConfig):
     label = "geonode_mapstore_client"
 
     def ready(self):
-        run_setup_hooks()
+        if not apps.ready:
+            run_setup_hooks()
         super(AppConfig, self).ready()

--- a/mapstore2_adapter/api/urls.py
+++ b/mapstore2_adapter/api/urls.py
@@ -19,5 +19,5 @@ router.register(r'resources', views.MapStoreResourceViewSet, basename="resources
 
 urlpatterns = [
     url(r'^rest/', include(router.urls)),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+    url(r'^api-auth/', include('rest_framework.urls', namespace='mapstore2_adapter_apis'))
 ]

--- a/mapstore2_adapter/api/urls.py
+++ b/mapstore2_adapter/api/urls.py
@@ -18,7 +18,5 @@ router.register(r'users', views.UserViewSet)
 router.register(r'resources', views.MapStoreResourceViewSet, basename="resources")
 
 urlpatterns = [
-    url(r'^rest/', include(router.urls)),
-    # rest_framework.urls may be skipped, if it is supposed to be always inside geonode
-    url(r'^api-auth/', include('rest_framework.urls', namespace='mapstore2_adapter_apis'))
+    url(r'^rest/', include(router.urls))
 ]

--- a/mapstore2_adapter/api/urls.py
+++ b/mapstore2_adapter/api/urls.py
@@ -19,5 +19,6 @@ router.register(r'resources', views.MapStoreResourceViewSet, basename="resources
 
 urlpatterns = [
     url(r'^rest/', include(router.urls)),
+    # rest_framework.urls may be skipped, if it is supposed to be always inside geonode
     url(r'^api-auth/', include('rest_framework.urls', namespace='mapstore2_adapter_apis'))
 ]


### PR DESCRIPTION
It clears this:
![image](https://user-images.githubusercontent.com/47123144/126150455-70e9f208-4a7c-4f7d-9758-08fa9306196b.png)

It also fixes duplicate URLs, as we see for `mapstore/rest/`. 
Before it was:
![image](https://user-images.githubusercontent.com/47123144/126150354-918b88c9-a019-4e0f-8027-975784b3ff73.png)

Now it is:
![image](https://user-images.githubusercontent.com/47123144/126150293-f660f761-b448-49a2-941e-b0f6d5fd614a.png)
