### PR TITLE
Verify extensibility of Search plugin services configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ The extended _geonode_config.html template should set the `__GEONODE_CONFIG__.ov
         */
         /*
             var cfgPluginOverride is the object to extend or override the localconfig.
-            The first level keys, are the geonode sections: map_viewer / dataset_viewer / document_viewer / geostory_viewer, each section you can extend or override  override the plugin configuration
+            The first level keys, are the geonode sections: map_viewer / dataset_viewer / document_viewer / geostory_viewer, for each section, you can extend or override the plugin configuration
 
             in the example below, we extend the configuration of the search plugin for the maps section
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ The extended _geonode_config.html template should set the `__GEONODE_CONFIG__.ov
         */
         /*
             var cfgPluginOverride is the object to extend or override the localconfig.
-            The first level keys, are the geonode section: map_viewer / dataset_viewer / document_viewer / geostory_viewer, each section you can extend or override  override the plugin configuration
+            The first level keys, are the geonode sections: map_viewer / dataset_viewer / document_viewer / geostory_viewer, each section you can extend or override  override the plugin configuration
 
             in the example below, we extend the configuration of the search plugin for the maps section
 


### PR DESCRIPTION
in PR:

- update the MapStore2 submodule to branch 2021.02.xx for master branches
- add documentation in the read me on how to extend the configuration for a plugin and link specific configuration of MapStore framework
- verify configurability of Search plugin in a custom geonode-project