### PR TITLE
Use the detail_url from the resource object

### DIFF
--- a/geonode_mapstore_client/client/js/components/ResourceCard/ResourceCard.jsx
+++ b/geonode_mapstore_client/client/js/components/ResourceCard/ResourceCard.jsx
@@ -122,18 +122,11 @@ const ResourceCard = forwardRef(({
                                         </Dropdown.Item>
                                     );
                                 }
-                                const viewResourcebase = opt.perms.filter(obj => {
-                                    return obj.value === "view_resourcebase";
-                                });
 
                                 return (
                                     <Dropdown.Item
                                         key={opt.href}
-                                        href={
-                                            (viewResourcebase.length > 0 ) ? formatHref({
-                                                pathname: `/${res.resource_type}/${res.pk}`
-                                            }) : buildHrefByTemplate(res, opt.href)
-                                        }
+                                        href={buildHrefByTemplate(res, opt.href)}
                                     >
                                         <FaIcon name={opt.icon} /> <Message msgId={opt.labelId}/>
                                     </Dropdown.Item>

--- a/geonode_mapstore_client/client/js/plugins/FitBounds.jsx
+++ b/geonode_mapstore_client/client/js/plugins/FitBounds.jsx
@@ -8,19 +8,28 @@
 
 import React from 'react';
 import { createPlugin } from '@mapstore/framework/utils/PluginsUtils';
+import { projectionSelector } from '@mapstore/framework/selectors/map';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+import isEqual from 'lodash/isEqual';
 import FitBounds from '@mapstore/framework/components/geostory/common/map/FitBounds';
 
-function FitBoundsPlugin(props) {
-    return (<FitBounds active { ...props }/>);
+const MAX_EXTENT_WEB_MERCATOR = [-180, -85.06, 180, 85.06];
+
+function FitBoundsPlugin({ mapProjection, ...props }) {
+    const geometry = ['EPSG:900913', 'EPSG:3857'].includes(mapProjection) && isEqual(props.geometry, [-180, -90, 180, 90])
+        ? MAX_EXTENT_WEB_MERCATOR
+        : props.geometry;
+    return (<FitBounds active { ...props } geometry={geometry}/>);
 }
 
 const ConnectedFitBoundsPlugin = connect(
     createSelector([
-        state => state?.controls?.fitBounds?.geometry
-    ], (geometry) => ({
-        geometry
+        state => state?.controls?.fitBounds?.geometry,
+        projectionSelector
+    ], (geometry, mapProjection) => ({
+        geometry,
+        mapProjection
     }))
 )(FitBoundsPlugin);
 

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -175,7 +175,7 @@ export const getResourceTypesInfo = () => ({
         formatEmbedUrl: (resource) => parseDevHostname(updateUrlQueryParameter(resource.embed_url, {
             config: 'dataset_preview'
         })),
-        formatDetailUrl: (resource) => (`/catalogue/#/dataset/${resource.pk}`),
+        formatDetailUrl: (resource) => resource?.detail_url && parseDevHostname(resource.detail_url),
         name: 'Dataset',
         formatMetadataUrl: (resource) => (`/datasets/${resource.alternate}/metadata`)
     },
@@ -185,28 +185,28 @@ export const getResourceTypesInfo = () => ({
         formatEmbedUrl: (resource) => parseDevHostname(updateUrlQueryParameter(resource.embed_url, {
             config: 'map_preview'
         })),
-        formatDetailUrl: (resource) => (`/catalogue/#/map/${resource.pk}`),
+        formatDetailUrl: (resource) => resource?.detail_url && parseDevHostname(resource.detail_url),
         formatMetadataUrl: (resource) => (`/maps/${resource.pk}/metadata`)
     },
     [ResourceTypes.DOCUMENT]: {
         icon: 'file',
         name: 'Document',
         formatEmbedUrl: (resource) => resource?.embed_url && parseDevHostname(resource.embed_url),
-        formatDetailUrl: (resource) => (`/catalogue/#/document/${resource.pk}`),
+        formatDetailUrl: (resource) => resource?.detail_url && parseDevHostname(resource.detail_url),
         formatMetadataUrl: (resource) => (`/documents/${resource.pk}/metadata`)
     },
     [ResourceTypes.GEOSTORY]: {
         icon: 'book',
         name: 'GeoStory',
         formatEmbedUrl: (resource) => resource?.embed_url && parseDevHostname(resource.embed_url),
-        formatDetailUrl: (resource) => (`/catalogue/#/geostory/${resource.pk}`),
+        formatDetailUrl: (resource) => resource?.detail_url && parseDevHostname(resource.detail_url),
         formatMetadataUrl: (resource) => (`/apps/${resource.pk}/metadata`)
     },
     [ResourceTypes.DASHBOARD]: {
         icon: 'dashboard',
         name: 'Dashboard',
         formatEmbedUrl: (resource) => resource?.embed_url && parseDevHostname(resource.embed_url),
-        formatDetailUrl: (resource) => (`/catalogue/#/dashboard/${resource.pk}`),
+        formatDetailUrl: (resource) => resource?.detail_url && parseDevHostname(resource.detail_url),
         formatMetadataUrl: (resource) => (`/apps/${resource.pk}/metadata`)
     }
 });

--- a/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
@@ -131,3 +131,8 @@ div#mapstore-globalspinner {
         margin: auto !important;
     }
 }
+
+// height has an incorrect value in rem so we need to override it
+.feature-grid-container .ms2-border-layout-body .react-grid-HeaderRow .react-grid-HeaderCell .rw-datetimepicker.rw-widget input {
+    height: auto;
+}


### PR DESCRIPTION
This PR fixes following issues:
- use the detail_url from the resource object instead of create it client side
- ensure that the fit bounds does not exceed the max extent of web mercator
- fix a minor style issue on date filter of attribute table