### PR TITLE
Some fixes to the info tab

### DIFF
--- a/geonode_mapstore_client/client/js/components/DefinitionList/DefinitionList.jsx
+++ b/geonode_mapstore_client/client/js/components/DefinitionList/DefinitionList.jsx
@@ -7,8 +7,8 @@ const DefinitionList = ({itemslist}) => {
     const items = itemslist?.map( item => {
         return (
             item.value && <>
-                <dt className="DList-cell DList-cell--medium"><strong>{`${item.label}`}</strong></dt>
-                <dd className="DList-cell">{`${item.value}`}</dd>
+                <dt className="DList-cell DList-cell--medium"><strong>{item.label}</strong></dt>
+                <dd className="DList-cell">{item.value}</dd>
             </>
 
         );

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -243,7 +243,7 @@ function DetailsPanel({
     const extraItemsList = [
         {
             "label": "Point of Contact",
-            "value": <a href={`/people/profile/${resource?.owner?.username}/`}> {(resource?.poc?.first_name + resource?.poc?.last_name || resource?.poc?.username)} </a>
+            "value": <a href={`/messages/create/${resource?.owner?.pk}/`}> {(resource?.poc?.first_name + resource?.poc?.last_name || resource?.poc?.username)} </a>
         },
         {
             "label": "License",

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -24,7 +24,6 @@ import CopyToClipboardCmp from 'react-copy-to-clipboard';
 import { TextEditable, ThumbnailEditable } from '@js/components/ContentsEditable/';
 import ResourceStatus from '@js/components/ResourceStatus/';
 
-
 const CopyToClipboard = tooltip(CopyToClipboardCmp);
 
 const EditTitle = ({ title, onEdit, tagName, disabled }) => {
@@ -136,7 +135,6 @@ function DetailsPanel({
     onFavorite,
     enableFavorite
 }) {
-
     const detailsContainerNode = useRef();
     const isMounted = useRef();
     const [copiedResourceLink, setCopiedResourceLink] = useState(false);
@@ -186,7 +184,7 @@ function DetailsPanel({
         },
         {
             "label": "Owner",
-            "value": resource?.owner?.username
+            "value": <a href={`/people/profile/${resource?.owner?.username}/`}> {resource?.owner?.username} </a>
         },
         {
             "label": "Created",
@@ -202,26 +200,50 @@ function DetailsPanel({
         },
         {
             "label": "Resource Type",
-            "value": resource?.resource_type
+            "value": <a href={formatHref({
+                pathname: '/search/filter/',
+                query: {
+                    'f': resource?.resource_type
+                }
+            })}>{resource?.resource_type}</a>
         },
         {
             "label": "Category",
-            "value": resource?.category
+            "value": <a href={formatHref({
+                pathname: '/search/filter/',
+                query: {
+                    'filter{category.identifier.in}': resource.category?.identifier
+                }
+            })}>{resource.category?.identifier}</a>
         },
         {
             "label": "Keywords",
-            "value": resource?.keywords?.join(" ")
+            "value": resource?.keywords?.map((map) => {
+                return (<a href={formatHref({
+                    pathname: '/search/filter/',
+                    query: {
+                        'filter{keywords.slug.in}': map.slug
+                    }
+                })}>{map.name + " "}</a>);
+            })
         },
         {
             "label": "Regions",
-            "value": resource?.regions?.map(map => map.name + " ")
+            "value": resource?.regions?.map((map) => {
+                return (<a href={formatHref({
+                    pathname: '/search/filter/',
+                    query: {
+                        'filter{regions.name.in}': map.name
+                    }
+                })}>{map.name + " "}</a>);
+            })
         }
     ];
 
     const extraItemsList = [
         {
             "label": "Point of Contact",
-            "value": (resource?.poc?.first_name + resource?.poc?.last_name || resource?.poc?.username)
+            "value": <a href={`/people/profile/${resource?.owner?.username}/`}> {(resource?.poc?.first_name + resource?.poc?.last_name || resource?.poc?.username)} </a>
         },
         {
             "label": "License",
@@ -427,6 +449,7 @@ function DetailsPanel({
                         <ResourceStatus resource={resource} />
                         {<p>
                             {resource?.owner && <><a href={formatHref({
+                                pathname: editTitle && '/search/filter/',
                                 query: {
                                     'filter{owner.username.in}': resource.owner.username
                                 }
@@ -441,6 +464,7 @@ function DetailsPanel({
                             {resource?.category?.identifier && <div>
                                 <Message msgId="gnhome.category" />:{' '}
                                 <a href={formatHref({
+                                    pathname: editTitle && '/search/filter/',
                                     query: {
                                         'filter{category.identifier.in}': resource.category.identifier
                                     }
@@ -449,7 +473,7 @@ function DetailsPanel({
                         </p>
                     </div>
                 </div>
-                {editTitle && <div className="gn-details-panel-info"><Tabs itemsTab={itemsTab} /></div>}
+                { editTitle && <div className="gn-details-panel-info"><Tabs itemsTab={itemsTab} /></div>}
             </section>
         </div>
     );

--- a/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
+++ b/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
@@ -31,6 +31,10 @@ import Button from '@js/components/Button';
 import PropTypes from 'prop-types';
 import useDetectClickOut from '@js/hooks/useDetectClickOut';
 import OverlayContainer from '@js/components/OverlayContainer';
+import { withRouter } from 'react-router';
+import {
+    hashLocationToHref
+} from '@js/utils/SearchUtils';
 
 const ConnectedDetailsPanel = connect(
     createSelector([
@@ -85,6 +89,7 @@ const ConnectedButton = connect(
 
 
 function DetailViewer({
+    location,
     enabled,
     onEditResource,
     onEditAbstractResource,
@@ -114,6 +119,13 @@ function DetailViewer({
         }
     });
 
+    const handleFormatHref = (options) => {
+        return hashLocationToHref({
+            location,
+            ...options
+        });
+    };
+
     if (hide) {
         return null;
     }
@@ -132,6 +144,7 @@ function DetailViewer({
                 editThumbnail={handleEditThumbnail}
                 activeEditMode={enabled && canEdit}
                 enableFavorite={!!user}
+                formatHref={handleFormatHref}
             />
         </OverlayContainer>
     );
@@ -164,7 +177,7 @@ const DetailViewerPlugin = connect(
         onEditThumbnail: editThumbnailResource,
         onClose: setControlProperty.bind(null, 'rightOverlay', 'enabled', false)
     }
-)(DetailViewer);
+)(withRouter(DetailViewer));
 
 
 export default createPlugin('DetailViewer', {


### PR DESCRIPTION
This PR Fixes:

 - `category` and `keywords` are showing "Object" values (see image below)
 - the following fields should be links:
    - Owner
    - Resource Type (opens the search page with the resource type filter set)
    - Category (opens the search page with the category filter set)
    - Keywords  (opens the search page with the keyword filter set)
    - Regions (opens the search page with the region filter set)
    - Point of Contact



https://user-images.githubusercontent.com/4085786/131515866-f738933e-1718-4aa2-8efb-e6a60c4609a6.mov

