### PR TITLE
Hide empty fields from the info tab

### DIFF
--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -173,34 +173,52 @@ function DetailsPanel({
     const detailUrl = resource?.pk && formatDetailUrl(resource);
     const documentDownloadUrl = (resource?.href && resource?.href.includes('download')) ? resource?.href : undefined;
     const attributeSet = resource?.attribute_set;
+
+    const validateDataType = (data) => {
+
+        let dataType;
+        switch (true) {
+        case data === 'None':
+        case data?.length === 0:
+            dataType = undefined;
+            break;
+        default:
+            dataType = data;
+        }
+
+
+        return dataType;
+    };
+
+
     const infoField = [
         {
             "label": "Title",
-            "value": resource?.title
+            "value": validateDataType(resource?.title)
         },
         {
             "label": "Abstract",
-            "value": resource?.raw_abstract
+            "value": validateDataType(resource?.raw_abstract)
         },
         {
             "label": "Owner",
-            "value": <a href={`/people/profile/${resource?.owner?.username}/`}> {resource?.owner?.username} </a>
+            "value": validateDataType(resource?.owner?.username) && <a href={`/people/profile/${resource?.owner?.username}/`}> {resource?.owner?.username} </a>
         },
         {
             "label": "Created",
-            "value": moment(resource?.created).format('MMMM Do YYYY')
+            "value": validateDataType(resource?.created) && moment(resource?.created).format('MMMM Do YYYY')
         },
         {
             "label": "Published",
-            "value": moment(resource?.date).format('MMMM Do YYYY')
+            "value": validateDataType(resource?.date) && moment(resource?.date).format('MMMM Do YYYY')
         },
         {
             "label": "Last Modified",
-            "value": moment(resource?.last_updated).format('MMMM Do YYYY')
+            "value": validateDataType(resource?.last_updated) && moment(resource?.last_updated).format('MMMM Do YYYY')
         },
         {
             "label": "Resource Type",
-            "value": <a href={formatHref({
+            "value": validateDataType(resource?.resource_type) && <a href={formatHref({
                 pathname: '/search/filter/',
                 query: {
                     'f': resource?.resource_type
@@ -209,7 +227,7 @@ function DetailsPanel({
         },
         {
             "label": "Category",
-            "value": <a href={formatHref({
+            "value": validateDataType(resource.category?.identifier) && <a href={formatHref({
                 pathname: '/search/filter/',
                 query: {
                     'filter{category.identifier.in}': resource.category?.identifier
@@ -218,7 +236,7 @@ function DetailsPanel({
         },
         {
             "label": "Keywords",
-            "value": resource?.keywords?.map((map) => {
+            "value": validateDataType(resource?.keywords) && resource?.keywords?.map((map) => {
                 return (<a href={formatHref({
                     pathname: '/search/filter/',
                     query: {
@@ -229,7 +247,7 @@ function DetailsPanel({
         },
         {
             "label": "Regions",
-            "value": resource?.regions?.map((map) => {
+            "value": validateDataType(resource?.regions) && resource?.regions?.map((map) => {
                 return (<a href={formatHref({
                     pathname: '/search/filter/',
                     query: {
@@ -240,6 +258,7 @@ function DetailsPanel({
         }
     ];
 
+
     const extraItemsList = [
         {
             "label": "Point of Contact",
@@ -247,35 +266,35 @@ function DetailsPanel({
         },
         {
             "label": "License",
-            "value": resource?.license?.name_long
+            "value": validateDataType(resource?.license?.name_long)
         },
         {
             "label": "Attribution",
-            "value": resource?.attribution
+            "value": validateDataType(resource?.attribution)
         },
         {
             "label": "Restriction",
-            "value": resource?.restriction_code_type?.identifier
+            "value": validateDataType(resource?.restriction_code_type?.identifier)
         },
         {
             "label": "Edition",
-            "value": resource?.edition
+            "value": validateDataType(resource?.edition)
         },
         {
             "label": "Maintenance Frequency",
-            "value": resource?.maintenance_frequency
+            "value": validateDataType(resource?.maintenance_frequency)
         },
         {
             "label": "Language",
-            "value": resource?.language
+            "value": validateDataType(resource?.language)
         },
         {
             "label": "Purpose",
-            "value": resource?.raw_purpose
+            "value": validateDataType(resource?.raw_purpose)
         },
         {
             "label": "Data Quality",
-            "value": resource?.raw_data_quality_statement
+            "value": validateDataType(resource?.raw_data_quality_statement)
         },
         {
             "label": "Temporal extent",
@@ -283,11 +302,11 @@ function DetailsPanel({
         },
         {
             "label": "Spatial Representation Type",
-            "value": resource?.spatial_representation_type?.identifier
+            "value": validateDataType(resource?.spatial_representation_type?.identifier)
         },
         {
             "label": "Supplemental Information",
-            "value": resource?.raw_supplemental_information
+            "value": validateDataType(resource?.raw_supplemental_information)
         }
     ];
 

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -202,7 +202,7 @@ function DetailsPanel({
         },
         {
             "label": "Owner",
-            "value":  validateDataType(resource?.owner?.username) && <a href={`/people/profile/${resource?.owner?.username}/`}> {(resource?.owner?.first_name !== "" && resource?.owner?.last_name !== "" ) ? (resource?.owner?.first_name + " " + resource?.owner?.last_name) : resource?.owner?.username} </a>
+            "value": validateDataType(resource?.owner?.username) && <a href={`/people/profile/${resource?.owner?.username}/`}> {(resource?.owner?.first_name !== "" && resource?.owner?.last_name !== "" ) ? (resource?.owner?.first_name + " " + resource?.owner?.last_name) : resource?.owner?.username} </a>
         },
         {
             "label": "Created",


### PR DESCRIPTION
This PR introduces a data value check: If a key as empty or None values the key will be hidden, in the detail panel definition list

![Schermata 2021-09-15 alle 17 23 37](https://user-images.githubusercontent.com/4085786/133463177-87c62e20-7fd3-48eb-9850-12d22cc8ebac.png)
