### PR TITLE
Adapt style editor component to fit inside the dataset style editor page

### DIFF
--- a/geonode_mapstore_client/client/js/actions/visualstyleeditor.js
+++ b/geonode_mapstore_client/client/js/actions/visualstyleeditor.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+export const REQUEST_DATASET_AVAILABLE_STYLES = 'GEONODE:REQUEST_DATASET_AVAILABLE_STYLES';
+export const CREATE_GEONODE_STYLE = 'GEONODE:CREATE_GEONODE_STYLE';
+export const DELETE_GEONODE_STYLE = 'GEONODE:DELETE_GEONODE_STYLE';
+
+export function requestDatasetAvailableStyles(layer, options) {
+    return {
+        type: REQUEST_DATASET_AVAILABLE_STYLES,
+        layer,
+        options
+    };
+}
+
+export function createGeoNodeStyle(title, options) {
+    return {
+        type: CREATE_GEONODE_STYLE,
+        title,
+        options
+    };
+}
+
+export function deleteGeoNodeStyle(styleName, options) {
+    return {
+        type: DELETE_GEONODE_STYLE,
+        styleName,
+        options
+    };
+}

--- a/geonode_mapstore_client/client/js/apps/gn-map.js
+++ b/geonode_mapstore_client/client/js/apps/gn-map.js
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
 import { getConfigProp, setConfigProp } from '@mapstore/framework/utils/ConfigUtils';
 import { loadPrintCapabilities } from '@mapstore/framework/actions/print';
 import { setControlProperty } from '@mapstore/framework/actions/controls';
+import { changeMapInfoFormat } from '@mapstore/framework/actions/mapInfo';
 import StandardApp from '@mapstore/framework/components/app/StandardApp';
 import withExtensions from '@mapstore/framework/components/app/withExtensions';
 
@@ -182,7 +183,8 @@ document.addEventListener('DOMContentLoaded', function() {
                             setControlProperty.bind(null, 'toolbar', 'expanded', false),
                             ...(resourceId !== undefined
                                 ? [ requestResourceConfig.bind(null, geoNodePageConfig.resourceType || ResourceTypes.MAP, resourceId) ]
-                                : [])
+                                : []),
+                            changeMapInfoFormat.bind(null, 'application/json')
                         ]
                     },
                     withExtensions(StandardApp));

--- a/geonode_mapstore_client/client/js/epics/visualstyleeditor.js
+++ b/geonode_mapstore_client/client/js/epics/visualstyleeditor.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Observable } from 'rxjs';
+import { getDatasetByName } from '@js/api/geonode/v2';
+import { updateNode } from '@mapstore/framework/actions/layers';
+import { updateStatus } from '@mapstore/framework/actions/styleeditor';
+import { setControlProperty } from '@mapstore/framework/actions/controls';
+import { updateAdditionalLayer } from '@mapstore/framework/actions/additionallayers';
+import { STYLE_OWNER_NAME } from '@mapstore/framework/utils/StyleEditorUtils';
+import StylesAPI from '@mapstore/framework/api/geoserver/Styles';
+import { styleServiceSelector } from '@mapstore/framework/selectors/styleeditor';
+import {
+    CREATE_GEONODE_STYLE,
+    DELETE_GEONODE_STYLE,
+    REQUEST_DATASET_AVAILABLE_STYLES
+} from '@js/actions/visualstyleeditor';
+
+export const gnRequestDatasetAvailableStyles = (action$, store) =>
+    action$.ofType(REQUEST_DATASET_AVAILABLE_STYLES)
+        .switchMap((action) => {
+            if (action?.layer?.availableStyles && !action?.options?.forceUpdate) {
+                return Observable.of(
+                    setControlProperty('visualStyleEditor', 'enabled', true),
+                    updateAdditionalLayer(action.layer.id, STYLE_OWNER_NAME, 'override', {}),
+                    updateStatus('edit')
+                );
+            }
+            const state = store.getState();
+            const styleService = action?.options?.styleService || styleServiceSelector(state);
+            return Observable.concat(
+                Observable.of(setControlProperty('visualStyleEditor', 'enabled', true)),
+                Observable.defer(() => getDatasetByName(action?.layer?.name))
+                    .switchMap((gnLayer) => {
+                        return Observable.defer(() => StylesAPI.getStylesInfo({
+                            baseUrl: styleService?.baseUrl,
+                            styles: (gnLayer?.styles || []).map((style) => ({
+                                title: style.sld_title,
+                                name: style.workspace ? `${style.workspace}:${style.name}` : style.name
+                            }))
+                        }))
+                            .switchMap((availableStyles) => {
+                                return Observable.of(
+                                    updateNode(action.layer.id, 'layer', { availableStyles }),
+                                    updateAdditionalLayer(action.layer.id, STYLE_OWNER_NAME, 'override', {}),
+                                    updateStatus('edit')
+                                );
+                            });
+                    })
+            );
+        });
+
+export const gnCreateStyle = (action$) =>
+    action$.ofType(CREATE_GEONODE_STYLE)
+        .switchMap(() => {
+            return Observable.empty();
+            /*
+            const state = store.getState();
+            const styleService = action?.options?.styleService || styleServiceSelector(state);
+
+            const editorMetadata = {
+                msStyleJSON: null,
+                msEditorType: 'visual'
+            };
+
+            const metadata = {
+                title: action.title,
+                description: '',
+                ...editorMetadata
+            };
+
+            return Observable.defer(
+                () => StylesAPI.createStyle({
+                    baseUrl: styleService?.baseUrl,
+                    code: '@mode \'Flat\'; @styleTitle \'' + action.title + '\'; \n* {\n\tfill: #ff0000;\n}\n',
+                    format: 'css',
+                    styleName: 'geonode:' + action.title.toLowerCase().replace(/\W/g, '') + '_' + Math.random(),
+                    metadata
+                })
+            )
+                .switchMap(() => {
+                    return Observable.empty();
+                });
+                */
+        });
+
+export const gnDeleteStyle = (action$) =>
+    action$.ofType(DELETE_GEONODE_STYLE)
+        .switchMap(() => {
+            return Observable.empty();
+        });
+
+export default {
+    gnCreateStyle,
+    gnDeleteStyle,
+    gnRequestDatasetAvailableStyles
+};

--- a/geonode_mapstore_client/client/js/plugins/VisualStyleEditor.jsx
+++ b/geonode_mapstore_client/client/js/plugins/VisualStyleEditor.jsx
@@ -185,11 +185,11 @@ function VisualStyleEditor({
     const hasTemplates = !!(styleTemplates?.length > 0);
 
     function replaceTemplateMetadata(code) {
-        const title = selectedStyle?.metadata?.title || selectedStyle?.label || selectedStyle?.title || selectedStyle?.name || '';
-        const description = selectedStyle?.metadata?.description || selectedStyle?._abstract || '';
+        const styleTitle = selectedStyle?.metadata?.title || selectedStyle?.label || selectedStyle?.title || selectedStyle?.name || '';
+        const styleDescription = selectedStyle?.metadata?.description || selectedStyle?._abstract || '';
         return code
-            .replace(/\$\{styleTitle\}/, title)
-            .replace(/\$\{styleAbstract\}/, description)
+            .replace(/\$\{styleTitle\}/, styleTitle)
+            .replace(/\$\{styleAbstract\}/, styleDescription);
     }
 
     return (

--- a/geonode_mapstore_client/client/js/plugins/VisualStyleEditor.jsx
+++ b/geonode_mapstore_client/client/js/plugins/VisualStyleEditor.jsx
@@ -1,0 +1,440 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { createPlugin } from '@mapstore/framework/utils/PluginsUtils';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import { Glyphicon, FormControl as FormControlRB } from 'react-bootstrap';
+import { StyleCodeEditor } from '@mapstore/framework/plugins/styleeditor/index';
+import styleeditor from '@mapstore/framework/reducers/styleeditor';
+import styleeditorEpics from '@mapstore/framework/epics/styleeditor';
+import visualStyleEditorEpics from '@js/epics/visualstyleeditor';
+import { setControlProperty } from '@mapstore/framework/actions/controls';
+import {
+    updateStatus,
+    initStyleService,
+    updateStyleCode,
+    toggleStyleEditor,
+    editStyleCode,
+    updateEditorMetadata
+} from '@mapstore/framework/actions/styleeditor';
+import {
+    createGeoNodeStyle,
+    deleteGeoNodeStyle,
+    requestDatasetAvailableStyles
+} from '@js/actions/visualstyleeditor';
+
+import { updateSettingsParams } from '@mapstore/framework/actions/layers';
+import { zoomToExtent } from '@mapstore/framework/actions/map';
+import {
+    getUpdatedLayer,
+    temporaryIdSelector,
+    initialCodeStyleSelector,
+    codeStyleSelector,
+    styleServiceSelector,
+    selectedStyleFormatSelector,
+    geometryTypeSelector,
+    loadingStyleSelector,
+    errorStyleSelector,
+    selectedStyleSelector
+} from '@mapstore/framework/selectors/styleeditor';
+import Select from 'react-select';
+import Message from '@mapstore/framework/components/I18N/Message';
+import SVGPreview from '@mapstore/framework/components/styleeditor/SVGPreview';
+import Popover from '@mapstore/framework/components/styleeditor/Popover';
+import Button from '@js/components/Button';
+import Portal from '@mapstore/framework/components/misc/Portal';
+import ResizableModal from '@mapstore/framework/components/misc/ResizableModal';
+import StylesAPI from '@mapstore/framework/api/geoserver/Styles';
+import { getStyleTemplates } from '@mapstore/framework/utils/StyleEditorUtils';
+import Spinner from '@js/components/Spinner';
+import localizedProps from '@mapstore/framework/components/misc/enhancers/localizedProps';
+const FormControl = localizedProps('placeholder')(FormControlRB);
+
+const defaultStyleTemplates = getStyleTemplates().filter((styleTemplate) => !['Base CSS', 'Base SLD'].includes(styleTemplate.title));
+
+function SaveStyleButton({
+    variant,
+    onClick,
+    size,
+    isStyleChanged,
+    error,
+    loading
+}) {
+    const isDisabled = !!(loading || error);
+    return (
+        <Button
+            className={isStyleChanged ? 'gn-pending-changes-icon' : ''}
+            variant={variant || "primary"}
+            size={size}
+            disabled={isDisabled}
+            onClick={isDisabled ? () => {} : () => onClick()}
+        >
+            <Message msgId="save"/>{' '}{loading && <Spinner />}
+        </Button>
+    );
+}
+
+const ConnectedSaveStyleButton = connect(
+    createSelector([
+        initialCodeStyleSelector,
+        codeStyleSelector,
+        loadingStyleSelector,
+        errorStyleSelector
+    ], (initialCode, code, loading, error) => ({
+        isStyleChanged: initialCode !== undefined && code !== undefined && initialCode !== code,
+        loading,
+        error: !!error?.edit?.status
+    })),
+    {
+        onClick: updateStyleCode
+    }
+)((SaveStyleButton));
+
+function VisualStyleEditor({
+    layer,
+    editorConfig,
+    styleService,
+    onInit,
+    onUpdateStatus,
+    onUpdateParams,
+    onReset,
+    temporaryStyleId,
+    showLayerProperties,
+    geometryType,
+    format,
+    onSelect,
+    onUpdateMetadata,
+    initialCode,
+    enabled,
+    onClose,
+    onZoomTo,
+    onRefresh,
+    onCreate,
+    onDelete,
+    selectedStyle
+}) {
+
+    const [creating, setCreating] = useState(false);
+    const [deleting, setDeleting] = useState(false);
+    const [title, setTitle] = useState('');
+
+    const deleteStyle = useRef();
+
+    deleteStyle.current = () => {
+        if (temporaryStyleId) {
+            StylesAPI.deleteStyle({
+                baseUrl: styleService.baseUrl,
+                styleName: temporaryStyleId
+            });
+        }
+    };
+
+    useEffect(() => {
+        onInit(styleService);
+        function onBeforeUnload() {
+            deleteStyle.current();
+        }
+        window.addEventListener('beforeunload', onBeforeUnload);
+        return () => {
+            window.removeEventListener('beforeunload', onBeforeUnload);
+            onReset();
+        };
+    }, []);
+
+    function handleStyleChange(option) {
+        onUpdateParams({
+            style: option.value
+        }, true);
+        onUpdateStatus('edit');
+    }
+
+    function handleSelect(styleTemplate) {
+        onSelect(styleTemplate);
+        onUpdateMetadata({ styleJSON: null });
+    }
+
+    function handleClose() {
+        onReset();
+        onClose();
+    }
+
+    function handleZoomTo() {
+        const { minx, miny, maxx, maxy } = layer.bbox.bounds;
+        const extent = [minx, miny, maxx, maxy];
+        onZoomTo(extent, layer.bbox.crs);
+    }
+
+    function handleRefresh() {
+        onRefresh(layer, { forceUpdate: true });
+    }
+
+    const styleTemplates = defaultStyleTemplates.filter((styleTemplate) => styleTemplate.types.includes(geometryType) && format === styleTemplate.format);
+
+    if (!enabled || !layer.id) {
+        return null;
+    }
+
+    const hasAvailableStyles = !!(layer?.availableStyles?.length > 0);
+    const hasTemplates = !!(styleTemplates?.length > 0);
+
+    function replaceTemplateMetadata(code) {
+        const title = selectedStyle?.metadata?.title || selectedStyle?.label || selectedStyle?.title || selectedStyle?.name || '';
+        const description = selectedStyle?.metadata?.description || selectedStyle?._abstract || '';
+        return code
+            .replace(/\$\{styleTitle\}/, title)
+            .replace(/\$\{styleAbstract\}/, description)
+    }
+
+    return (
+        <div className="gn-visual-style-editor">
+            {showLayerProperties &&
+            <div className="gn-visual-style-editor-layer-info">
+                <div className="gn-visual-style-editor-layer-title">{layer.title}</div>
+                {layer.bbox && <Button onClick={handleZoomTo}>
+                    <Glyphicon glyph="zoom-to"/>
+                </Button>}
+                <Button onClick={handleClose}>
+                    <Glyphicon glyph="1-close"/>
+                </Button>
+            </div>}
+            {(showLayerProperties && hasAvailableStyles) &&
+            <div className="gn-visual-style-editor-styles">
+                <div className="gn-visual-style-editor-styles-select">
+                    <Select
+                        value={layer.style || layer.availableStyles?.[0]?.name}
+                        options={layer.availableStyles.map((style) => ({
+                            value: style.name,
+                            label: style.title
+                        }))}
+                        clearable={false}
+                        onChange={handleStyleChange}
+                    />
+                </div>
+                <Button onClick={handleRefresh}>
+                    <Glyphicon glyph="refresh"/>
+                </Button>
+                <Button onClick={() => setDeleting(true)}>
+                    <Glyphicon glyph="trash"/>
+                </Button>
+                <Button onClick={() => setCreating(true)}>
+                    <Glyphicon glyph="plus"/>
+                </Button>
+            </div>}
+            {(hasAvailableStyles && (hasTemplates || showLayerProperties)) &&
+            <div className="gn-visual-style-editor-toolbar">
+                {showLayerProperties && <ConnectedSaveStyleButton variant="default" size="xs"/>}
+                {hasTemplates && <Popover
+                    placement="right"
+                    content={
+                        <ul className="gn-visual-style-editor-templates" >
+                            {styleTemplates.map((styleTemplate, idx) => {
+                                return (
+                                    <li
+                                        key={idx}
+                                        className="gn-visual-style-editor-template"
+                                        onClick={() => handleSelect(replaceTemplateMetadata(styleTemplate.code))}
+                                    >
+                                        <div className="gn-visual-style-editor-template-preview">
+                                            {styleTemplate?.preview?.config
+                                                ? <SVGPreview { ...styleTemplate.preview.config } />
+                                                : styleTemplate?.preview}
+                                        </div>
+                                        <div className="gn-visual-style-editor-template-title">{styleTemplate.title}</div>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    }
+                >
+                    <Button size="xs"><Message msgId="gnviewer.templates"/></Button>
+                </Popover>}
+            </div>}
+            <div className="gn-visual-style-editor-body">
+                <div>
+                    <StyleCodeEditor key={initialCode} config={editorConfig}/>
+                </div>
+            </div>
+            <Portal>
+                <ResizableModal
+                    title="Add new style"
+                    fitContent
+                    clickOutEnabled={false}
+                    show={creating}
+                    onClose={() => {
+                        setCreating(false);
+                        setTitle('');
+                    }}
+                    buttons={[
+                        {
+                            text: 'Close',
+                            onClick: () => {
+                                setCreating(false);
+                                setTitle('');
+                            }
+                        },
+                        {
+                            text: 'Create',
+                            onClick: () => {
+                                setCreating(false);
+                                onCreate(title);
+                                setTitle('');
+                            }
+                        }
+                    ]}
+                >
+                    <label>Title: </label>
+                    <FormControl
+                        value={title}
+                        onChange={event => setTitle(event?.target?.value)}
+                    />
+                </ResizableModal>
+            </Portal>
+            <Portal>
+                <ResizableModal
+                    title="Delete style"
+                    show={deleting}
+                    fitContent
+                    clickOutEnabled={false}
+                    onClose={() => {
+                        setDeleting(false);
+                    }}
+                    buttons={[
+                        {
+                            text: 'No, don\'t delete it',
+                            onClick: () => {
+                                setDeleting(false);
+                            }
+                        },
+                        {
+                            text: 'Yes, I\'m sure',
+                            onClick: () => {
+                                onDelete();
+                                setDeleting(false);
+                            }
+                        }
+                    ]}
+                >
+                    Are you sure you want to delete this style?
+                </ResizableModal>
+            </Portal>
+        </div>
+    );
+}
+
+const VisualStyleEditorPlugin = connect(
+    createSelector([
+        getUpdatedLayer,
+        temporaryIdSelector,
+        styleServiceSelector,
+        selectedStyleFormatSelector,
+        geometryTypeSelector,
+        initialCodeStyleSelector,
+        state => state?.controls?.visualStyleEditor?.enabled,
+        selectedStyleSelector
+    ], (layer, temporaryStyleId, styleService, format, geometryType, initialCode, enabled, selectedStyleName) => ({
+        layer,
+        temporaryStyleId,
+        styleService,
+        format,
+        geometryType,
+        initialCode,
+        enabled,
+        selectedStyle: layer?.availableStyles?.find((style) => style.name === selectedStyleName)
+    })),
+    {
+        onUpdateStatus: updateStatus,
+        onUpdateParams: updateSettingsParams,
+        onInit: initStyleService,
+        onReset: toggleStyleEditor.bind(null, undefined, false),
+        onSelect: editStyleCode,
+        onUpdateMetadata: updateEditorMetadata,
+        onSave: updateStyleCode,
+        onClose: setControlProperty.bind(null, 'visualStyleEditor', 'enabled', false),
+        onZoomTo: zoomToExtent,
+        onRefresh: requestDatasetAvailableStyles,
+        onCreate: createGeoNodeStyle,
+        onDelete: deleteGeoNodeStyle
+    },
+    (stateProps, dispatchProps, ownProps) => {
+        // detect if the static service has been updated with new information in the global state
+        // eg: classification methods are requested asynchronously
+        const isStaticServiceUpdated = ownProps.styleService?.baseUrl === stateProps.styleService?.baseUrl
+            && stateProps.styleService?.isStatic;
+        const newStyleService = ownProps.styleService && !isStaticServiceUpdated
+            ? { ...ownProps.styleService, isStatic: true }
+            : { ...stateProps.styleService };
+        return {
+            ...ownProps,
+            ...stateProps,
+            ...dispatchProps,
+            styleService: newStyleService
+        };
+    }
+)(VisualStyleEditor);
+
+function StyleEditorTocButton({
+    layer,
+    status,
+    onClick = () => {}
+}) {
+    if (status !== 'LAYER') {
+        return null;
+    }
+
+    function handleClick() {
+        onClick(layer);
+    }
+
+    return (
+        <Button
+            variant="primary"
+            className="square-button-md"
+            onClick={handleClick}
+        >
+            <Glyphicon glyph="dropper"/>
+        </Button>
+    );
+}
+
+const ConnectedStyleEditorTocButton = connect(createSelector([
+    getUpdatedLayer
+], (layer) => ({
+    layer
+})), {
+    onClick: requestDatasetAvailableStyles
+})(StyleEditorTocButton);
+
+export default createPlugin('VisualStyleEditor', {
+    component: VisualStyleEditorPlugin,
+    containers: {
+        ViewerLayout: {
+            name: 'VisualStyleEditor',
+            priority: 1,
+            target: 'leftColumn'
+        },
+        ActionNavbar: {
+            name: 'SaveStyle',
+            Component: ConnectedSaveStyleButton,
+            priority: 1
+        },
+        TOC: {
+            target: 'toolbar',
+            Component: ConnectedStyleEditorTocButton,
+            priority: 1
+        }
+    },
+    reducers: {
+        styleeditor
+    },
+    epics: {
+        ...styleeditorEpics,
+        ...visualStyleEditorEpics
+    }
+});

--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -383,6 +383,10 @@ export const plugins = {
     DownloadResourcePlugin: toLazyPlugin(
         'DownloadResource',
         () => import(/* webpackChunkName: 'plugins/download-resource-plugin' */ '@js/plugins/DownloadResource')
+    ),
+    VisualStyleEditorPlugin: toLazyPlugin(
+        'VisualStyleEditor',
+        () => import(/* webpackChunkName: 'plugins/visual-style-editor-plugin' */ '@js/plugins/VisualStyleEditor')
     )
 
 };

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -45,7 +45,9 @@ export const resourceToLayerConfig = (resource) => {
         title,
         perms,
         pk,
-        has_time: hasTime
+        has_time: hasTime,
+        default_style: defaultStyle,
+        styles
     } = resource;
 
     const bbox = getExtentFromResource(resource);
@@ -91,6 +93,14 @@ export const resourceToLayerConfig = (resource) => {
         style: '',
         title,
         visibility: true,
+        defaultStyle: {
+            title: defaultStyle.sld_title,
+            name: defaultStyle.workspace ? `${defaultStyle.workspace}:${defaultStyle.name}` : defaultStyle.name
+        },
+        availableStyles: [ ...styles ].map((style) => ({
+            title: style.sld_title,
+            name: style.workspace ? `${style.workspace}:${style.name}` : style.name
+        })),
         ...(params && { params }),
         ...(dimensions.length > 0 && ({ dimensions }))
     };

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -93,14 +93,18 @@ export const resourceToLayerConfig = (resource) => {
         style: '',
         title,
         visibility: true,
-        defaultStyle: {
-            title: defaultStyle.sld_title,
-            name: defaultStyle.workspace ? `${defaultStyle.workspace}:${defaultStyle.name}` : defaultStyle.name
-        },
-        availableStyles: [ ...styles ].map((style) => ({
-            title: style.sld_title,
-            name: style.workspace ? `${style.workspace}:${style.name}` : style.name
-        })),
+        ...(defaultStyle && {
+            defaultStyle: {
+                title: defaultStyle.sld_title,
+                name: defaultStyle.workspace ? `${defaultStyle.workspace}:${defaultStyle.name}` : defaultStyle.name
+            }
+        }),
+        ...(styles && {
+            availableStyles: [ ...styles ].map((style) => ({
+                title: style.sld_title,
+                name: style.workspace ? `${style.workspace}:${style.name}` : style.name
+            }))
+        }),
         ...(params && { params }),
         ...(dimensions.length > 0 && ({ dimensions }))
     };

--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -1300,12 +1300,22 @@
                             "type": "link",
                             "href": "{'#/dataset/' + (state('gnResourceData') || {}).pk}",
                             "labelId": "gnviewer.backToDataset"
+                        },
+                        {
+                            "type": "plugin",
+                            "name": "SaveStyle"
+                        }
+                    ],
+                    "rightMenuItems": [
+                        {
+                            "type": "plugin",
+                            "name": "FullScreen"
                         }
                     ]
                 }
             },
             {
-                "name": "StyleEditor",
+                "name": "VisualStyleEditor",
                 "cfg": {
                     "styleService": {
                         "baseUrl": "{state('settings') && state('settings').geonodeUrl && state('settings').geonodeUrl + 'gs/' || '/gs/'}",
@@ -1331,18 +1341,20 @@
                 }
             },
             {
+                "name": "Identify",
+                "cfg": {
+                    "showInMapPopup":true,
+                    "viewerOptions": {
+                        "container": "{context.ReactSwipe}"
+                    }
+                }
+            },
+            {
                 "name": "DrawerMenu",
                 "override": {
                     "ViewerLayout": {
                         "priority": 1
                     }
-                }
-            },
-            {
-                "name": "TOCItemsSettings",
-                "cfg": {
-                    "hideTitleTranslations": true,
-                    "showFeatureInfoTab": false
                 }
             },
             {
@@ -1361,7 +1373,8 @@
                     "tools": [
                         "measurement",
                         "draw",
-                        "box"
+                        "box",
+                        "popup"
                     ],
                     "mapOptions": {
                         "openlayers": {
@@ -1386,6 +1399,20 @@
             },
             {
                 "name": "FitBounds"
+            },
+            {
+                "name": "BackgroundSelector",
+                "override": {
+                    "ViewerLayout": {
+                        "priority": 1
+                    }
+                }
+            },
+            {
+                "name": "ScaleBox"
+            },
+            {
+                "name": "FullScreen"
             }
         ],
         "map_viewer": [

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
@@ -189,7 +189,8 @@
             "errorCompactPermissionsMessage": "Es war nicht möglich die Berechtigungen zu aktualisieren",
             "warningGeoLimitsSaveTitle": "Unvollständiger Speichervorgang",
             "warningGeoLimitsSaveMessage": "Es war nicht möglich die neuen Geolimits zu aktualisieren",
-            "saveMapThumbnail": "Klicken Sie hier, um die Karte als Bild festzulegen"
+            "saveMapThumbnail": "Klicken Sie hier, um die Karte als Bild festzulegen",
+            "templates": "Vorlagen"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
@@ -190,7 +190,8 @@
             "errorCompactPermissionsMessage": "It was not possible to update the permissions",
             "warningGeoLimitsSaveTitle": "Incomplete saving process",
             "warningGeoLimitsSaveMessage": "It was not possible to update the new geo limits",
-            "saveMapThumbnail": "Click to set the map as an image"
+            "saveMapThumbnail": "Click to set the map as an image",
+            "templates": "Templates"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
@@ -189,7 +189,8 @@
             "errorCompactPermissionsMessage": "No fue posible actualizar los permisos",
             "warningGeoLimitsSaveTitle": "Proceso de guardado incompleto",
             "warningGeoLimitsSaveMessage": "No fue posible actualizar los nuevos límites geográficos",
-            "saveMapThumbnail": "Haga clic para configurar el mapa como una imagen"
+            "saveMapThumbnail": "Haga clic para configurar el mapa como una imagen",
+            "templates": "Plantillas"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
@@ -189,7 +189,8 @@
             "errorCompactPermissionsMessage": "Il n'a pas été possible de mettre à jour les autorisations",
             "warningGeoLimitsSaveTitle": "Processus de sauvegarde incomplet",
             "warningGeoLimitsSaveMessage": "Il n'a pas été possible de mettre à jour les nouvelles limites géographiques",
-            "saveMapThumbnail": "Cliquez pour définir la carte comme une image"
+            "saveMapThumbnail": "Cliquez pour définir la carte comme une image",
+            "templates": "Modèles"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
@@ -191,7 +191,8 @@
             "errorCompactPermissionsMessage": "Non è stato possibile aggiornare i permessi",
             "warningGeoLimitsSaveTitle": "Processo di salvataggio incompleto",
             "warningGeoLimitsSaveMessage": "Non è stato possibile aggiornare i nuovi limiti geografici",
-            "saveMapThumbnail": "Clicca per impostare la mappa come immagine"
+            "saveMapThumbnail": "Clicca per impostare la mappa come immagine",
+            "templates": "Modelli"
         }
     }
 }

--- a/geonode_mapstore_client/client/themes/geonode/less/_visual-style-editor.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_visual-style-editor.less
@@ -1,0 +1,93 @@
+
+// **************
+// Theme
+// **************
+
+#gn-components-theme(@theme-vars) {
+    .gn-visual-style-editor,
+    .gn-visual-style-editor-templates {
+        .background-color-var(@theme-vars[main-bg]);
+    }
+    .gn-visual-style-editor-toolbar,
+    .gn-visual-style-editor-styles {
+        .border-bottom-color-var(@theme-vars[main-border-color]);
+    }
+}
+
+// **************
+// Layout
+// **************
+
+.gn-visual-style-editor {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    z-index: 100000;
+    height: 100%;
+    width: 500px;
+}
+
+.gn-visual-style-editor-layer-info {
+    display: flex;
+    padding: 4px;
+    align-items: center;
+    .gn-visual-style-editor-layer-title {
+        flex: 1;
+    }
+}
+
+.gn-visual-style-editor-toolbar,
+.gn-visual-style-editor-styles {
+    display: flex;
+    flex-direction: 1;
+    padding: 4px;
+    border-bottom-width: 1px;
+    border-bottom-style: solid;
+    .gn-visual-style-editor-styles-select {
+        flex: 1;
+    }
+}
+
+.gn-visual-style-editor-body {
+    position: relative;
+    flex: 1;
+    height: 100%;
+    width: 100%;
+    > div {
+        position: absolute;
+        height: 100%;
+        width: 100%; 
+    }
+}
+
+.gn-visual-style-editor-templates {
+    width: 326px;
+    max-height: 276px;
+    overflow: auto;
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0;
+    list-style-type: none;
+    padding-left: 4px;
+    padding-top: 4px;
+    .shadow-soft();
+    .gn-visual-style-editor-template {
+        width: 72px;
+        margin-right: 4px;
+        margin-bottom: 4px;
+        border: 1px solid #ddd;
+        cursor: pointer;
+        overflow: hidden;
+        padding: 2px;
+        &:hover {
+            .shadow-soft();
+        }
+        .gn-visual-style-editor-template-title {
+            font-size: @font-size-base * 0.6;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            text-align: center;
+        }
+    }
+}

--- a/geonode_mapstore_client/client/themes/geonode/less/geonode.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/geonode.less
@@ -18,6 +18,7 @@
 @import '_spinner.less';
 @import '_home-container.less';
 @import '_sub-flat-menu.less';
+@import '_visual-style-editor.less';
 
 @import '_mixins.less';
 @import '_bootstrap-variables.less';

--- a/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
@@ -139,3 +139,13 @@ div#mapstore-globalspinner {
 .feature-grid-container .ms2-border-layout-body .react-grid-HeaderRow .react-grid-HeaderCell .rw-datetimepicker.rw-widget input {
     height: auto;
 }
+
+.ms-popover-overlay {
+    z-index: 2000;
+}
+
+// show ellipsis if the title overflow the get feature info popup
+.ms-map-popup .mapstore-identify-viewer .ms-identify-swipe-header-title {
+    text-overflow: ellipsis;
+    overflow: hidden;
+}


### PR DESCRIPTION
This PR introduces a new custom plugin called VisualStyleEditor that makes use of framework components of the MapStore style editor. This plugin fits inside the dataset edit style page. 

![image](https://user-images.githubusercontent.com/19175505/137519943-d50a8f31-62de-454c-854f-726eae5843aa.png)
