### PR TITLE
Dataset without default_style crashes the application

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -79,6 +79,11 @@ const resourceTypes = {
                     .then((response) => {
                         const [mapConfig, gnLayer] = response;
                         const newLayer = resourceToLayerConfig(gnLayer);
+
+                        if (!newLayer.defaultStyle || page !== 'dataset_edit_style_viewer') {
+                            return [mapConfig, gnLayer, newLayer];
+                        }
+
                         return StylesAPI.getStylesInfo({
                             baseUrl: options?.styleService?.baseUrl,
                             styles: [newLayer.defaultStyle]


### PR DESCRIPTION
This PR handles the case of datasets that does not provide the default_style property (eg. remote services).