### PR TITLE
Update submodule to latest 2021.02.xx and dashboard app initialization

### DIFF
--- a/geonode_mapstore_client/client/js/apps/gn-dashboard.js
+++ b/geonode_mapstore_client/client/js/apps/gn-dashboard.js
@@ -15,6 +15,8 @@ import security from '@mapstore/framework/reducers/security';
 import maptype from '@mapstore/framework/reducers/maptype';
 import dashboard from '@mapstore/framework/reducers/dashboard';
 import widgets from '@mapstore/framework/reducers/widgets';
+import widgetsEpics from '@mapstore/framework/epics/widgets';
+import dashboardEpics from '@mapstore/framework/epics/dashboard';
 import gnresource from '@js/reducers/gnresource';
 import gnsettings from '@js/reducers/gnsettings';
 import { updateGeoNodeSettings } from '@js/actions/gnsettings';
@@ -124,7 +126,12 @@ document.addEventListener('DOMContentLoaded', function() {
                         widgets
                     },
                     appEpics: {
-                        ...configEpics
+                        ...configEpics,
+                        // epics related to dashboard are imported at root levele
+                        // because of the use of initial action
+                        // in particular `dashboardLoaded`
+                        ...widgetsEpics,
+                        ...dashboardEpics
                     },
                     onStoreInit,
                     initialActions: [

--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -269,11 +269,17 @@ export const plugins = {
     ),
     DashboardEditorPlugin: toLazyPlugin(
         'DashboardEditor',
-        () => import(/* webpackChunkName: 'plugins/dashboard-editor-plugin' */ '@mapstore/framework/plugins/DashboardEditor')
+        () => import(/* webpackChunkName: 'plugins/dashboard-editor-plugin' */ '@mapstore/framework/plugins/DashboardEditor'),
+        // exclude epics to import them at app level
+        // because of an issue on initialization
+        { epics: {} }
     ),
     DashboardPlugin: toLazyPlugin(
         'Dashboard',
-        () => import(/* webpackChunkName: 'plugins/dashboard-plugin' */ '@mapstore/framework/plugins/Dashboard')
+        () => import(/* webpackChunkName: 'plugins/dashboard-plugin' */ '@mapstore/framework/plugins/Dashboard'),
+        // exclude epics to import them at app level
+        // because of an issue on initialization
+        { epics: {} }
     ),
     AnnotationsPlugin: toLazyPlugin(
         'Annotations',

--- a/geonode_mapstore_client/client/js/routes/Dashboard.jsx
+++ b/geonode_mapstore_client/client/js/routes/Dashboard.jsx
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import isArray from 'lodash/isArray';
@@ -39,16 +39,15 @@ function DashboardRoute({
         ? propPluginsConfig
         : propPluginsConfig && propPluginsConfig[name] || [];
 
-    const [loading, setLoading] = useState(true);
-    const { plugins: loadedPlugins } = useLazyPlugins({
+    const { plugins: loadedPlugins, pending } = useLazyPlugins({
         pluginsEntries: lazyPlugins,
         pluginsConfig
     });
     useEffect(() => {
-        if (!loading && onMount) {
+        if (!pending && onMount) {
             onMount(true);
         }
-    }, [ loading, onMount ]);
+    }, [ pending, onMount ]);
     const Loader = loaderComponent;
     return (
         <>
@@ -60,9 +59,8 @@ function DashboardRoute({
                 pluginsConfig={pluginsConfig}
                 plugins={{ ...loadedPlugins, ...plugins }}
                 params={params}
-                onPluginsLoaded={() => setLoading(false)}
             />
-            {loading && Loader && <Loader />}
+            {pending && Loader && <Loader />}
         </>
     );
 }

--- a/geonode_mapstore_client/client/js/routes/GeoStory.jsx
+++ b/geonode_mapstore_client/client/js/routes/GeoStory.jsx
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import isArray from 'lodash/isArray';
@@ -39,16 +39,15 @@ function GeoStoryRoute({
         ? propPluginsConfig
         : propPluginsConfig && propPluginsConfig[name] || [];
 
-    const [loading, setLoading] = useState(true);
-    const { plugins: loadedPlugins } = useLazyPlugins({
+    const { plugins: loadedPlugins, pending } = useLazyPlugins({
         pluginsEntries: lazyPlugins,
         pluginsConfig
     });
     useEffect(() => {
-        if (!loading && onMount) {
+        if (!pending && onMount) {
             onMount(true);
         }
-    }, [ loading, onMount ]);
+    }, [ pending, onMount ]);
     const Loader = loaderComponent;
     return (
         <>
@@ -60,9 +59,8 @@ function GeoStoryRoute({
                 pluginsConfig={pluginsConfig}
                 plugins={{ ...loadedPlugins, ...plugins }}
                 params={params}
-                onPluginsLoaded={() => setLoading(false)}
             />
-            {loading && Loader && <Loader />}
+            {pending && Loader && <Loader />}
         </>
     );
 }

--- a/geonode_mapstore_client/client/js/routes/MapView.jsx
+++ b/geonode_mapstore_client/client/js/routes/MapView.jsx
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import url from 'url';
@@ -41,16 +41,15 @@ function MapViewerRoute({
         ? propPluginsConfig
         : propPluginsConfig && propPluginsConfig[name] || [];
 
-    const [loading, setLoading] = useState(true);
-    const { plugins: loadedPlugins } = useLazyPlugins({
+    const { plugins: loadedPlugins, pending } = useLazyPlugins({
         pluginsEntries: lazyPlugins,
         pluginsConfig
     });
     useEffect(() => {
-        if (!loading && onMount) {
+        if (!pending && onMount) {
             onMount(true);
         }
-    }, [ loading, onMount ]);
+    }, [ pending, onMount ]);
     const Loader = loaderComponent;
     return (
         <>
@@ -62,9 +61,8 @@ function MapViewerRoute({
                 pluginsConfig={pluginsConfig}
                 plugins={{ ...loadedPlugins, ...plugins }}
                 params={params}
-                onPluginsLoaded={() => setLoading(false)}
             />
-            {loading && Loader && <Loader />}
+            {pending && Loader && <Loader />}
         </>
     );
 }

--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -100,6 +100,10 @@
         {
             "name": "gnResourcePermissions",
             "path": "gnresource.permissions"
+        },
+        {
+            "name": "printEnabled",
+            "path": "print.capabilities"
         }
     ],
     "projectionDefs": [],


### PR DESCRIPTION
This PR updates the MapStore2 submodule including following fixes:

- #573 Downloading a layer with quick filter causes an error
- https://github.com/GeoNode/geonode/issues/8324

There are also improvement backported from master to optimize plugin loading and improvement to dashboard app to apply correct interactions at startup

- #584 Interactions between widgets stop working after saving a dashboard 