### PR TITLE
#598: Fullscreen does not work for portals

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/actionnavbar/buttons.jsx
+++ b/geonode_mapstore_client/client/js/plugins/actionnavbar/buttons.jsx
@@ -88,7 +88,7 @@ export const FullScreenActionButton = connect(createSelector([
 ], (enabled) => ({
     enabled
 })), {
-    onClick: (enabled) => toggleFullscreen(enabled, "#ms-container")
+    onClick: (enabled) => toggleFullscreen(enabled)
 }
 )(({
     onClick,


### PR DESCRIPTION
This PR fixes this behavior #598 the components in overlay are visible
![Schermata 2021-11-17 alle 11 47 58](https://user-images.githubusercontent.com/4085786/142186666-97f9c075-2e5a-46f1-afc6-af4863256c46.png)


