### PR TITLE
Reduce MapStore search bar size

### DIFF
--- a/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
@@ -28,6 +28,12 @@
     z-index: 5;
 }
 
+.MapSearchBar .input-group {
+    .searchInput {
+        min-height: 40px;
+    }
+}
+
 .gn-embed {
     // fix position of dashboard full screen button
     .widget-container .mapstore-widget-card .mapstore-widget-header .widget-icons .btn-group button {


### PR DESCRIPTION
The mapStore search bar height is reduced to match TOC button height.