### PR TITLE
 Make "Create new" a primary button and reorder menu items

### DIFF
--- a/geonode_mapstore_client/client/js/components/Menu/Menu.js
+++ b/geonode_mapstore_client/client/js/components/Menu/Menu.js
@@ -44,7 +44,7 @@ const Menu = forwardRef(({
                     return (
                         <li key={idx}>
                             <MenuItem
-                                variant={variant}
+                                variant={item.labelId === 'gnhome.createNew' ? 'primary' : variant}
                                 item={{ ...item, id: item.id || idx }}
                                 size={size}
                                 alignRight={alignRight}

--- a/geonode_mapstore_client/client/js/components/Menu/Menu.js
+++ b/geonode_mapstore_client/client/js/components/Menu/Menu.js
@@ -44,7 +44,7 @@ const Menu = forwardRef(({
                     return (
                         <li key={idx}>
                             <MenuItem
-                                variant={item.labelId === 'gnhome.createNew' ? 'primary' : variant}
+                                variant={item.variant || variant}
                                 item={{ ...item, id: item.id || idx }}
                                 size={size}
                                 alignRight={alignRight}

--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -311,6 +311,7 @@
                     "labelId": "gnhome.createNew",
                     "authenticated": true,
                     "type": "dropdown",
+                    "variant": "primary",
                     "perms": [
                         {
                             "type": "user",

--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -332,10 +332,10 @@
                             ]
                         },
                         {
-                            "labelId": "gnhome.createDataset",
-                            "value": "layer",
+                            "labelId": "gnhome.uploadDocument",
+                            "value": "document",
                             "type": "link",
-                            "href": "/createlayer/",
+                            "href": "/documents/upload",
                             "authenticated": true,
                             "perms": [
                                 {
@@ -345,10 +345,10 @@
                             ]
                         },
                         {
-                            "labelId": "gnhome.uploadDocument",
-                            "value": "document",
+                            "labelId": "gnhome.createDataset",
+                            "value": "layer",
                             "type": "link",
-                            "href": "/documents/upload",
+                            "href": "/createlayer/",
                             "authenticated": true,
                             "perms": [
                                 {


### PR DESCRIPTION
`Create New` button is now `primary` variant. 
Dropdown list items have been grouped in "upload" and "create".