### PR TITLE
UI improvements to the toolbars for the editor page

### DIFF
--- a/geonode_mapstore_client/client/js/components/ActionNavbar/ActionNavbar.jsx
+++ b/geonode_mapstore_client/client/js/components/ActionNavbar/ActionNavbar.jsx
@@ -146,6 +146,7 @@ ActionNavbar.propTypes = {
 ActionNavbar.defaultProps = {
     leftItems: [],
     rightItems: [],
+    titleItems: [],
     query: {},
     formatHref: () => '#',
     variant: 'primary'

--- a/geonode_mapstore_client/client/js/components/ActionNavbar/ActionNavbar.jsx
+++ b/geonode_mapstore_client/client/js/components/ActionNavbar/ActionNavbar.jsx
@@ -11,10 +11,10 @@ import PropTypes from 'prop-types';
 import Menu from '@js/components/Menu';
 import BurgerMenu from '@js/components/Menu/BurgerMenu';
 import useResizeElement from '@js/hooks/useResizeElement';
-
+import FaIcon from '@js/components/FaIcon';
+import NavLink from '@js/components/Menu/NavLink';
 
 const LeftContentMenu = ({ items, formatHref, query, variant, size }) => {
-
     const navbarContentLeft = useRef();
     const navbarLeft = useRef();
     const { width: widthContentLeft } = useResizeElement(navbarContentLeft);
@@ -29,12 +29,11 @@ const LeftContentMenu = ({ items, formatHref, query, variant, size }) => {
             className={`gn-menu-content-side gn-menu-content-left`}
             ref={navbarContentLeft}
         >
-            {
-                (switchToBurgerMenu) && items && <BurgerMenu items={items} variant={variant}/>
-            }
+            {switchToBurgerMenu && items && (
+                <BurgerMenu items={items} variant={variant} />
+            )}
 
-            { (!switchToBurgerMenu) && items &&
-
+            {!switchToBurgerMenu && items && (
                 <Menu
                     ref={navbarLeft}
                     items={items}
@@ -44,24 +43,17 @@ const LeftContentMenu = ({ items, formatHref, query, variant, size }) => {
                     variant={variant}
                     size={size}
                 />
-
-            }
+            )}
         </div>
-
     );
 };
 
-
 const RightContentMenu = ({ items, formatHref, query, variant, size }) => {
-
     const navbarRight = useRef();
 
     return (
-        <div
-            className={`gn-menu-content-right`}
-        >
-
-            {items &&
+        <div className={`gn-menu-content-right`}>
+            {items && (
                 <Menu
                     ref={navbarRight}
                     items={items}
@@ -72,70 +64,75 @@ const RightContentMenu = ({ items, formatHref, query, variant, size }) => {
                     alignRight
                     size={size}
                 />
-
-            }
-
+            )}
         </div>
-
-
     );
 };
 
-
-const ActionNavbar = forwardRef(({
-    style,
-    leftItems,
-    rightItems,
-    query,
-    formatHref,
-    variant,
-    size,
-    children
-}, ref) => {
-
-    return (
-        <nav
-            ref={ref}
-            className={`gn-menu gn-${variant}`}
-            style={style}
-        >
-            <div className={`gn-menu-container`}>
-
-                <div
-                    className={`gn-menu-content`}
-                >
-
-                    {
-                        leftItems.length > 0 &&
-                        <LeftContentMenu
-                            items={leftItems}
-                            formatHref={formatHref}
-                            query={query}
-                            variant={variant}
-                            size={size}
-                        />
-                    }
-                    {children}
-                    {
-
-                        rightItems.length > 0 &&
-                        <RightContentMenu
-                            items={rightItems}
-                            formatHref={formatHref}
-                            query={query}
-                            variant={variant}
-                            size={size}
-                        />
-                    }
+const ActionNavbar = forwardRef(
+    (
+        {
+            style,
+            leftItems,
+            rightItems,
+            query,
+            formatHref,
+            variant,
+            size,
+            resource,
+            titleItems
+        },
+        ref
+    ) => {
+        return (
+            <nav ref={ref} className={`gn-menu gn-${variant}`} style={style}>
+                <div className="gn-menu-container">
+                    <div className="gn-menu-content">
+                        <div className="gn-action-navbar-title">
+                            <NavLink
+                                href="/catalogue/"
+                                className="gn-action-navbar-breadcrumb-link"
+                            >
+                                <FaIcon name="home" />
+                            </NavLink>
+                            <FaIcon
+                                name="angle-right"
+                                className="gn-action-navbar-breadcrumb-seperator"
+                            />
+                            <p
+                                title={resource?.title}
+                                className="gn-action-navbar-resource-title"
+                            >
+                                {resource?.title}
+                            </p>
+                            {titleItems.map(({ Component, name }) => (
+                                <Component key={name} />
+                            ))}
+                        </div>
+                        {leftItems.length > 0 && (
+                            <LeftContentMenu
+                                items={leftItems}
+                                formatHref={formatHref}
+                                query={query}
+                                variant={variant}
+                                size={size}
+                            />
+                        )}
+                        {rightItems.length > 0 && (
+                            <RightContentMenu
+                                items={rightItems}
+                                formatHref={formatHref}
+                                query={query}
+                                variant={variant}
+                                size={size}
+                            />
+                        )}
+                    </div>
                 </div>
-
-
-            </div>
-
-        </nav>
-
-    );
-});
+            </nav>
+        );
+    }
+);
 
 ActionNavbar.propTypes = {
     style: PropTypes.object,
@@ -153,6 +150,5 @@ ActionNavbar.defaultProps = {
     formatHref: () => '#',
     variant: 'primary'
 };
-
 
 export default ActionNavbar;

--- a/geonode_mapstore_client/client/js/components/ActionNavbar/ActionNavbar.jsx
+++ b/geonode_mapstore_client/client/js/components/ActionNavbar/ActionNavbar.jsx
@@ -90,7 +90,7 @@ const ActionNavbar = forwardRef(
                     <div className="gn-menu-content">
                         <div className="gn-action-navbar-title">
                             <NavLink
-                                href="/catalogue/"
+                                href="#"
                                 className="gn-action-navbar-breadcrumb-link"
                             >
                                 <FaIcon name="home" />

--- a/geonode_mapstore_client/client/js/components/ActionNavbar/ActionNavbar.jsx
+++ b/geonode_mapstore_client/client/js/components/ActionNavbar/ActionNavbar.jsx
@@ -106,7 +106,7 @@ const ActionNavbar = forwardRef(
                                 {resource?.title}
                             </p>
                             {titleItems.map(({ Component, name }) => (
-                                <Component key={name} />
+                                <Component key={name} variant="info"/>
                             ))}
                         </div>
                         {leftItems.length > 0 && (

--- a/geonode_mapstore_client/client/js/components/ActionNavbar/__test__/ActionNavbar-test.jsx
+++ b/geonode_mapstore_client/client/js/components/ActionNavbar/__test__/ActionNavbar-test.jsx
@@ -13,6 +13,13 @@ import ActionNavbar from '../ActionNavbar';
 
 
 const conf = {
+    titleNavbarItems: [
+        {
+            "type": "plugin",
+            "name": "DetailViewerButton",
+            "Component": 'i'
+        }
+    ],
     leftItems: [
         {
             "labelId": "gnhome.data",
@@ -194,6 +201,7 @@ describe('Test GeoNode action navbar component', () => {
         ReactDOM.render( <ActionNavbar
             leftItems={conf.leftItems.items}
             rightItems={conf.rightItems.items}
+            titleItems={conf.titleNavbarItems}
         />, document.getElementById("container"));
 
         const el = document.querySelector('.gn-menu');

--- a/geonode_mapstore_client/client/js/plugins/ActionNavbar.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ActionNavbar.jsx
@@ -13,7 +13,6 @@ import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import ActionNavbar from '@js/components/ActionNavbar';
 
-import FaIcon from '@js/components/FaIcon';
 import usePluginItems from '@js/hooks/usePluginItems';
 import {
     getResourcePerms,
@@ -23,7 +22,6 @@ import {
     getSelectedLayerPermissions
 } from '@js/selectors/resource';
 import { hasPermissionsTo, reduceArrayRecursive } from '@js/utils/MenuUtils';
-import { getResourceTypesInfo } from '@js/utils/ResourceUtils';
 
 function checkResourcePerms(menuItem, resourcePerms) {
     if (menuItem.disableIf) {
@@ -35,61 +33,82 @@ function checkResourcePerms(menuItem, resourcePerms) {
     return true;
 }
 
-function ActionNavbarPlugin({
-    items,
-    leftMenuItems,
-    rightMenuItems,
-    resourcePerms,
-    resource,
-    isDirtyState,
-    selectedLayerPermissions
-}, context) {
-
-    const types = getResourceTypesInfo();
-    const { icon } = types[resource?.resource_type] || {};
+function ActionNavbarPlugin(
+    {
+        items,
+        leftMenuItems,
+        rightMenuItems,
+        resourcePerms,
+        resource,
+        isDirtyState,
+        selectedLayerPermissions,
+        titleItems
+    },
+    context
+) {
     const { loadedPlugins } = context;
-    const configuredItems = usePluginItems({ items, loadedPlugins }, [resource?.pk, selectedLayerPermissions]);
+    const configuredItems = usePluginItems({ items, loadedPlugins }, [
+        resource?.pk,
+        selectedLayerPermissions
+    ]);
 
     const leftMenuItemsPlugins = reduceArrayRecursive(leftMenuItems, (item) => {
-        configuredItems.find(plugin => {
-            if ( item.type === 'plugin' && plugin.name === item.name ) {
+        configuredItems.find((plugin) => {
+            if (item.type === 'plugin' && plugin.name === item.name) {
                 item.Component = plugin?.Component;
             }
         });
 
-        item.className = item.showPendingChangesIcon && isDirtyState ? 'gn-pending-changes-icon' : '';
-        return (item);
+        item.className =
+            item.showPendingChangesIcon && isDirtyState
+                ? 'gn-pending-changes-icon'
+                : '';
+        return item;
     });
 
-    const rightMenuItemsPlugins = reduceArrayRecursive(rightMenuItems, (item) => {
-        configuredItems.find(plugin => {
-            if ( item.type === 'plugin' && plugin.name === item.name ) {
-                item.Component = plugin?.Component;
-            }
-        });
-        return (item);
-    });
-
-    const leftItems = reduceArrayRecursive(
-        leftMenuItemsPlugins,
-        menuItem => checkResourcePerms(menuItem, resourcePerms)
+    const rightMenuItemsPlugins = reduceArrayRecursive(
+        rightMenuItems,
+        (item) => {
+            configuredItems.find((plugin) => {
+                if (item.type === 'plugin' && plugin.name === item.name) {
+                    item.Component = plugin?.Component;
+                }
+            });
+            return item;
+        }
     );
 
-    const rightItems = reduceArrayRecursive(
-        rightMenuItemsPlugins,
-        menuItem => checkResourcePerms(menuItem, resourcePerms)
+    const titleItemsPlugins = reduceArrayRecursive(titleItems, (item) => {
+        configuredItems.find((plugin) => {
+            if (item.type === 'plugin' && plugin.name === item.name) {
+                item.Component = plugin?.Component;
+            }
+        });
+        return item;
+    });
+
+    const leftItems = reduceArrayRecursive(leftMenuItemsPlugins, (menuItem) =>
+        checkResourcePerms(menuItem, resourcePerms)
+    );
+
+    const rightItems = reduceArrayRecursive(rightMenuItemsPlugins, (menuItem) =>
+        checkResourcePerms(menuItem, resourcePerms)
+    );
+
+    const titleNavbarItems = reduceArrayRecursive(
+        titleItemsPlugins,
+        (menuItem) => checkResourcePerms(menuItem, resourcePerms)
     );
 
     return (
-
         <ActionNavbar
             leftItems={leftItems}
             rightItems={rightItems}
-            variant="default"
+            variant="primary"
             size="sm"
-        >
-            <h1 className="gn-action-navbar-title">{icon && <FaIcon name={icon}/>}{'  '}{resource?.title}</h1>
-        </ActionNavbar>
+            resource={resource}
+            titleItems={titleNavbarItems}
+        />
     );
 }
 
@@ -106,20 +125,32 @@ ActionNavbarPlugin.defaultProps = {
 };
 
 const ConnectedActionNavbarPlugin = connect(
-    createSelector([
-        getResourcePerms,
-        canAddResource,
-        getResourceData,
-        getResourceDirtyState,
-        getSelectedLayerPermissions
-    ], (resourcePerms, userCanAddResource, resource, dirtyState, selectedLayerPermissions) => ({
-        resourcePerms: (resourcePerms.length > 0 ) ?
-            resourcePerms : ((userCanAddResource)
-                ? [ "change_resourcebase"] : [] ),
-        resource,
-        isDirtyState: !!dirtyState,
-        selectedLayerPermissions
-    }))
+    createSelector(
+        [
+            getResourcePerms,
+            canAddResource,
+            getResourceData,
+            getResourceDirtyState,
+            getSelectedLayerPermissions
+        ],
+        (
+            resourcePerms,
+            userCanAddResource,
+            resource,
+            dirtyState,
+            selectedLayerPermissions
+        ) => ({
+            resourcePerms:
+                resourcePerms.length > 0
+                    ? resourcePerms
+                    : userCanAddResource
+                        ? ['change_resourcebase']
+                        : [],
+            resource,
+            isDirtyState: !!dirtyState,
+            selectedLayerPermissions
+        })
+    )
 )(ActionNavbarPlugin);
 
 export default createPlugin('ActionNavbar', {

--- a/geonode_mapstore_client/client/js/plugins/ActionNavbar.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ActionNavbar.jsx
@@ -115,13 +115,15 @@ function ActionNavbarPlugin(
 ActionNavbarPlugin.propTypes = {
     items: PropTypes.array,
     leftMenuItems: PropTypes.array,
-    rightMenuItems: PropTypes.array
+    rightMenuItems: PropTypes.array,
+    titleItems: PropTypes.array
 };
 
 ActionNavbarPlugin.defaultProps = {
     items: [],
     leftMenuItems: [],
-    rightMenuItems: []
+    rightMenuItems: [],
+    titleItems: []
 };
 
 const ConnectedActionNavbarPlugin = connect(

--- a/geonode_mapstore_client/client/js/plugins/DatasetsCatalog.jsx
+++ b/geonode_mapstore_client/client/js/plugins/DatasetsCatalog.jsx
@@ -222,7 +222,8 @@ const ConnectedDatasetsCatalogPlugin = connect(
 
 const DatasetsCatalogButton = ({
     onClick,
-    size
+    size,
+    variant
 }) => {
 
     const handleClickButton = () => {
@@ -233,6 +234,7 @@ const DatasetsCatalogButton = ({
         <Button
             size={size}
             onClick={handleClickButton}
+            variant={variant}
         >
             <Message msgId="gnviewer.addLayer"/>
         </Button>

--- a/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
+++ b/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
@@ -22,7 +22,6 @@ import {
 import controls from '@mapstore/framework/reducers/controls';
 import { setControlProperty } from '@mapstore/framework/actions/controls';
 import gnresource from '@js/reducers/gnresource';
-import Message from '@mapstore/framework/components/I18N/Message';
 import {
     canEditResource,
     isNewResource,
@@ -33,79 +32,83 @@ import PropTypes from 'prop-types';
 import useDetectClickOut from '@js/hooks/useDetectClickOut';
 import OverlayContainer from '@js/components/OverlayContainer';
 import { withRouter } from 'react-router';
-import {
-    hashLocationToHref
-} from '@js/utils/SearchUtils';
+import { hashLocationToHref } from '@js/utils/SearchUtils';
+import FaIcon from '@js/components/FaIcon/FaIcon';
 
 const ConnectedDetailsPanel = connect(
-    createSelector([
-        state => state?.gnresource?.data || null,
-        state => state?.gnresource?.loading || false,
-        state => state?.gnresource?.data?.favorite || false
-    ], (resource, loading, favorite) => ({
-        resource,
-        loading,
-        favorite
-    })),
+    createSelector(
+        [
+            (state) => state?.gnresource?.data || null,
+            (state) => state?.gnresource?.loading || false,
+            (state) => state?.gnresource?.data?.favorite || false
+        ],
+        (resource, loading, favorite) => ({
+            resource,
+            loading,
+            favorite
+        })
+    ),
     {
-        closePanel: setControlProperty.bind(null, 'rightOverlay', 'enabled', false),
+        closePanel: setControlProperty.bind(
+            null,
+            'rightOverlay',
+            'enabled',
+            false
+        ),
         onFavorite: setFavoriteResource
     }
 )(DetailsPanel);
 
-const ButtonViewer = ({
-    onClick,
-    hide,
-    variant,
-    size
-}) => {
-
+const ButtonViewer = ({ onClick, hide, variant, size }) => {
     const handleClickButton = () => {
         onClick();
     };
 
-    return !hide
-        ? (<Button
+    return !hide ? (
+        <Button
             variant={variant}
             size={size}
             onClick={handleClickButton}
-        > <Message msgId="gnviewer.info"/>
-        </Button>)
-        : null
-    ;
+        >
+            <FaIcon name="info-circle" />
+        </Button>
+    ) : null;
 };
 
 const ConnectedButton = connect(
-    createSelector([
-        isNewResource,
-        getResourceId
-    ],
-    (isNew, resourcePk) => ({
+    createSelector([isNewResource, getResourceId], (isNew, resourcePk) => ({
         hide: isNew || !resourcePk
     })),
     {
-        onClick: setControlProperty.bind(null, 'rightOverlay', 'enabled', 'DetailViewer')
+        onClick: setControlProperty.bind(
+            null,
+            'rightOverlay',
+            'enabled',
+            'DetailViewer'
+        )
     }
-)((ButtonViewer));
+)(ButtonViewer);
 
-
-function DetailViewer({
-    items,
-    location,
-    enabled,
-    onEditResource,
-    onEditAbstractResource,
-    onEditThumbnail,
-    canEdit,
-    width,
-    hide,
-    user,
-    onClose
-}, context) {
-
+function DetailViewer(
+    {
+        items,
+        location,
+        enabled,
+        onEditResource,
+        onEditAbstractResource,
+        onEditThumbnail,
+        canEdit,
+        width,
+        hide,
+        user,
+        onClose
+    },
+    context
+) {
     const { loadedPlugins } = context;
     const configuredItems = usePluginItems({ items, loadedPlugins });
-    const buttonSaveThumbnailMap = configuredItems.filter(({ name }) => name === "MapThumbnail")
+    const buttonSaveThumbnailMap = configuredItems
+        .filter(({ name }) => name === 'MapThumbnail')
         .map(({ Component, name }) => <Component key={name} />);
 
     const handleTitleValue = (val) => {
@@ -167,18 +170,22 @@ DetailViewer.defaultProps = {
 };
 
 const DetailViewerPlugin = connect(
-    createSelector([
-        state => state?.controls?.rightOverlay?.enabled === 'DetailViewer',
-        canEditResource,
-        isNewResource,
-        getResourceId,
-        userSelector
-    ], (enabled, canEdit, isNew, resourcePk, user) => ({
-        enabled,
-        canEdit,
-        hide: isNew || !resourcePk,
-        user
-    })),
+    createSelector(
+        [
+            (state) =>
+                state?.controls?.rightOverlay?.enabled === 'DetailViewer',
+            canEditResource,
+            isNewResource,
+            getResourceId,
+            userSelector
+        ],
+        (enabled, canEdit, isNew, resourcePk, user) => ({
+            enabled,
+            canEdit,
+            hide: isNew || !resourcePk,
+            user
+        })
+    ),
     {
         onEditResource: editTitleResource,
         onEditAbstractResource: editAbstractResource,
@@ -186,7 +193,6 @@ const DetailViewerPlugin = connect(
         onClose: setControlProperty.bind(null, 'rightOverlay', 'enabled', false)
     }
 )(withRouter(DetailViewer));
-
 
 export default createPlugin('DetailViewer', {
     component: DetailViewerPlugin,

--- a/geonode_mapstore_client/client/js/routes/Viewer.jsx
+++ b/geonode_mapstore_client/client/js/routes/Viewer.jsx
@@ -56,6 +56,7 @@ function ViewerRoute({
 }) {
 
     const { pk } = match.params || {};
+    const { url: resourceUrl } = match;
     const pluginsConfig = isArray(propPluginsConfig)
         ? propPluginsConfig
         : propPluginsConfig && propPluginsConfig[name] || DEFAULT_PLUGINS_CONFIG;
@@ -76,6 +77,17 @@ function ViewerRoute({
             }
         }
     }, [pending, pk]);
+
+    useEffect(() => {
+        // hide the naviagtion bar is a recource is being viewed
+        if (resourceUrl?.split('/')[1] === resourceType) {
+            document.getElementById('gn-topbar')?.classList.add('hide-navigation');
+        } else {
+            document.getElementById('gn-topbar')?.classList.remove('hide-navigation');
+        }
+
+        return () => document.getElementById('gn-topbar')?.classList.remove('hide-navigation');
+    }, [resourceUrl]);
 
     const loading = loadingConfig || pending;
     const parsedPlugins = useMemo(() => ({ ...loadedPlugins, ...plugins }), [loadedPlugins]);

--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -758,7 +758,6 @@
                         {
                             "labelId": "gnviewer.save",
                             "showPendingChangesIcon": true,
-                            "variant": "primary",
                             "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "type": "dropdown",
                             "items": [
@@ -775,7 +774,6 @@
                         {
                             "labelId": "gnviewer.edit",
                             "type": "dropdown",
-                            "variant": "primary",
                             "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -800,7 +798,6 @@
                         {
                             "labelId": "gnviewer.view",
                             "type": "dropdown",
-                            "variant": "primary",
                             "disableIf": "{context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -818,12 +815,10 @@
                         },
                         {
                             "type": "plugin",
-                            "variant": "primary",
                             "name": "Share"
                         },
                         {
                             "type": "link",
-                            "variant": "primary",
                             "href": "{'#/map/new?gn-dataset=' + (state('gnResourceData') || {}).pk}",
                             "labelId": "gnviewer.createMap",
                             "disableIf": "{!(state('user') && state('user').perms && state('user').perms.includes('add_resource'))}"
@@ -834,17 +829,14 @@
                         },
                         {
                             "type": "plugin",
-                            "variant": "primary",
                             "name": "Print"
                         },
                         {
                             "type": "plugin",
-                            "variant": "primary",
                             "name": "LayerDownload"
                         },
                         {
                             "type": "plugin",
-                            "variant": "primary",
                             "name": "Measure"
                         },
                         {
@@ -856,7 +848,6 @@
                     "rightMenuItems": [
                         {
                             "type": "plugin",
-                            "variant": "primary",
                             "name": "FullScreen"
                         }
                     ]
@@ -1461,7 +1452,6 @@
                         {
                             "labelId": "gnviewer.save",
                             "showPendingChangesIcon": true,
-                            "variant": "primary",
                             "disableIf": "{!state('isNewResource') && !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "type": "dropdown",
                             "items": [
@@ -1478,7 +1468,6 @@
                         {
                             "labelId": "gnviewer.edit",
                             "type": "dropdown",
-                            "variant": "primary",
                             "disableIf": "{state('isNewResource') || !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -1491,7 +1480,6 @@
                         {
                             "labelId": "gnviewer.view",
                             "type": "dropdown",
-                            "variant": "primary",
                             "disableIf": "{state('isNewResource') || context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -1503,8 +1491,7 @@
                         },
                         {
                             "type": "plugin",
-                            "name": "Share",
-                            "variant": "primary"
+                            "name": "Share"
                         },
                         {
                             "type": "divider",
@@ -1512,23 +1499,19 @@
                         },
                         {
                             "type": "plugin",
-                            "name": "DatasetsCatalog",
-                            "variant": "primary"
+                            "name": "DatasetsCatalog"
                         },
                         {
                             "type": "plugin",
-                            "name": "Print",
-                            "variant": "primary"
+                            "name": "Print"
                         },
                         {
                             "type": "plugin",
-                            "name": "Annotations",
-                            "variant": "primary"
+                            "name": "Annotations"
                         },
                         {
                             "type": "plugin",
-                            "name": "Measure",
-                            "variant": "primary"
+                            "name": "Measure"
                         },
                         {
                             "type": "plugin",
@@ -1539,8 +1522,7 @@
                     "rightMenuItems": [
                         {
                             "type": "plugin",
-                            "name": "FullScreen",
-                            "variant": "primary"
+                            "name": "FullScreen"
                         }
                     ]
                 }
@@ -1897,7 +1879,6 @@
                         {
                             "labelId": "gnviewer.save",
                             "showPendingChangesIcon": true,
-                            "variant": "primary",
                             "disableIf": "{!state('isNewResource') && !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "type": "dropdown",
                             "items": [
@@ -1914,7 +1895,6 @@
                         {
                             "labelId": "gnviewer.edit",
                             "type": "dropdown",
-                            "variant": "primary",
                             "disableIf": "{state('isNewResource') || !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -1927,7 +1907,6 @@
                         {
                             "labelId": "gnviewer.view",
                             "type": "dropdown",
-                            "variant": "primary",
                             "disableIf": "{state('isNewResource') || context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -1939,7 +1918,6 @@
                         },
                         {
                             "type": "plugin",
-                            "variant": "primary",
                             "name": "Share"
                         },
                         {
@@ -1951,7 +1929,6 @@
                     "rightMenuItems": [
                         {
                             "type": "plugin",
-                            "variant": "primary",
                             "name": "FullScreen"
                         }
                     ]
@@ -2074,7 +2051,6 @@
                         {
                             "labelId": "gnviewer.save",
                             "type": "dropdown",
-                            "variant": "primary",
                             "showPendingChangesIcon": true,
                             "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
@@ -2091,7 +2067,6 @@
                         {
                             "labelId": "gnviewer.edit",
                             "type": "dropdown",
-                            "variant": "primary",
                             "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -2104,7 +2079,6 @@
                         {
                             "labelId": "gnviewer.view",
                             "type": "dropdown",
-                            "variant": "primary",
                             "disableIf": "{context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -2116,12 +2090,10 @@
                         },
                         {
                             "type": "plugin",
-                            "variant": "primary",
                             "name": "Share"
                         },
                         {
                             "type": "plugin",
-                            "variant": "primary",
                             "name": "DownloadResource",
                             "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'download_resourcebase')}"
                         },
@@ -2134,7 +2106,6 @@
                     "rightMenuItems": [
                         {
                             "type": "plugin",
-                            "variant": "primary",
                             "name": "FullScreen"
                         }
                     ]
@@ -2188,7 +2159,6 @@
                         {
                             "labelId": "gnviewer.save",
                             "type": "dropdown",
-                            "variant": "primary",
                             "showPendingChangesIcon": true,
                             "disableIf": "{!state('isNewResource') && !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
@@ -2205,7 +2175,6 @@
                         {
                             "labelId": "gnviewer.edit",
                             "type": "dropdown",
-                            "variant": "primary",
                             "disableIf": "{state('isNewResource') || !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -2218,7 +2187,6 @@
                         {
                             "labelId": "gnviewer.view",
                             "type": "dropdown",
-                            "variant": "primary",
                             "disableIf": "{state('isNewResource') || context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -2230,7 +2198,6 @@
                         },
                         {
                             "type": "plugin",
-                            "variant": "primary",
                             "name": "Share"
                         },
                         {
@@ -2242,7 +2209,6 @@
                     "rightMenuItems": [
                         {
                             "type": "plugin",
-                            "variant": "primary",
                             "name": "FullScreen"
                         }
                     ]

--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -748,10 +748,17 @@
                 "name": "ActionNavbar",
                 "cfg": {
                     "containerPosition": "header",
+                    "titleItems": [
+                        {
+                            "type": "plugin",
+                            "name": "DetailViewerButton"
+                        }
+                    ],
                     "leftMenuItems": [
                         {
                             "labelId": "gnviewer.save",
                             "showPendingChangesIcon": true,
+                            "variant": "primary",
                             "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "type": "dropdown",
                             "items": [
@@ -766,12 +773,9 @@
                             ]
                         },
                         {
-                            "type": "plugin",
-                            "name": "DetailViewerButton"
-                        },
-                        {
                             "labelId": "gnviewer.edit",
                             "type": "dropdown",
+                            "variant": "primary",
                             "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -796,6 +800,7 @@
                         {
                             "labelId": "gnviewer.view",
                             "type": "dropdown",
+                            "variant": "primary",
                             "disableIf": "{context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -813,10 +818,12 @@
                         },
                         {
                             "type": "plugin",
+                            "variant": "primary",
                             "name": "Share"
                         },
                         {
                             "type": "link",
+                            "variant": "primary",
                             "href": "{'#/map/new?gn-dataset=' + (state('gnResourceData') || {}).pk}",
                             "labelId": "gnviewer.createMap",
                             "disableIf": "{!(state('user') && state('user').perms && state('user').perms.includes('add_resource'))}"
@@ -827,14 +834,17 @@
                         },
                         {
                             "type": "plugin",
+                            "variant": "primary",
                             "name": "Print"
                         },
                         {
                             "type": "plugin",
+                            "variant": "primary",
                             "name": "LayerDownload"
                         },
                         {
                             "type": "plugin",
+                            "variant": "primary",
                             "name": "Measure"
                         },
                         {
@@ -846,6 +856,7 @@
                     "rightMenuItems": [
                         {
                             "type": "plugin",
+                            "variant": "primary",
                             "name": "FullScreen"
                         }
                     ]
@@ -1440,10 +1451,17 @@
                 "name": "ActionNavbar",
                 "cfg": {
                     "containerPosition": "header",
+                    "titleItems": [
+                        {
+                            "type": "plugin",
+                            "name": "DetailViewerButton"
+                        }
+                    ],
                     "leftMenuItems": [
                         {
                             "labelId": "gnviewer.save",
                             "showPendingChangesIcon": true,
+                            "variant": "primary",
                             "disableIf": "{!state('isNewResource') && !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "type": "dropdown",
                             "items": [
@@ -1458,12 +1476,9 @@
                             ]
                         },
                         {
-                            "type": "plugin",
-                            "name": "DetailViewerButton"
-                        },
-                        {
                             "labelId": "gnviewer.edit",
                             "type": "dropdown",
+                            "variant": "primary",
                             "disableIf": "{state('isNewResource') || !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -1476,6 +1491,7 @@
                         {
                             "labelId": "gnviewer.view",
                             "type": "dropdown",
+                            "variant": "primary",
                             "disableIf": "{state('isNewResource') || context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -1487,7 +1503,8 @@
                         },
                         {
                             "type": "plugin",
-                            "name": "Share"
+                            "name": "Share",
+                            "variant": "primary"
                         },
                         {
                             "type": "divider",
@@ -1495,19 +1512,23 @@
                         },
                         {
                             "type": "plugin",
-                            "name": "DatasetsCatalog"
+                            "name": "DatasetsCatalog",
+                            "variant": "primary"
                         },
                         {
                             "type": "plugin",
-                            "name": "Print"
+                            "name": "Print",
+                            "variant": "primary"
                         },
                         {
                             "type": "plugin",
-                            "name": "Annotations"
+                            "name": "Annotations",
+                            "variant": "primary"
                         },
                         {
                             "type": "plugin",
-                            "name": "Measure"
+                            "name": "Measure",
+                            "variant": "primary"
                         },
                         {
                             "type": "plugin",
@@ -1518,7 +1539,8 @@
                     "rightMenuItems": [
                         {
                             "type": "plugin",
-                            "name": "FullScreen"
+                            "name": "FullScreen",
+                            "variant": "primary"
                         }
                     ]
                 }
@@ -1865,10 +1887,17 @@
                 "name": "ActionNavbar",
                 "cfg": {
                     "containerPosition": "header",
+                    "titleItems": [
+                        {
+                            "type": "plugin",
+                            "name": "DetailViewerButton"
+                        }
+                    ],
                     "leftMenuItems": [
                         {
                             "labelId": "gnviewer.save",
                             "showPendingChangesIcon": true,
+                            "variant": "primary",
                             "disableIf": "{!state('isNewResource') && !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "type": "dropdown",
                             "items": [
@@ -1883,12 +1912,9 @@
                             ]
                         },
                         {
-                            "type": "plugin",
-                            "name": "DetailViewerButton"
-                        },
-                        {
                             "labelId": "gnviewer.edit",
                             "type": "dropdown",
+                            "variant": "primary",
                             "disableIf": "{state('isNewResource') || !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -1901,6 +1927,7 @@
                         {
                             "labelId": "gnviewer.view",
                             "type": "dropdown",
+                            "variant": "primary",
                             "disableIf": "{state('isNewResource') || context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -1912,6 +1939,7 @@
                         },
                         {
                             "type": "plugin",
+                            "variant": "primary",
                             "name": "Share"
                         },
                         {
@@ -1923,6 +1951,7 @@
                     "rightMenuItems": [
                         {
                             "type": "plugin",
+                            "variant": "primary",
                             "name": "FullScreen"
                         }
                     ]
@@ -2035,10 +2064,17 @@
                 "name": "ActionNavbar",
                 "cfg": {
                     "containerPosition": "header",
+                    "titleItems": [
+                        {
+                            "type": "plugin",
+                            "name": "DetailViewerButton"
+                        }
+                    ],
                     "leftMenuItems": [
                         {
                             "labelId": "gnviewer.save",
                             "type": "dropdown",
+                            "variant": "primary",
                             "showPendingChangesIcon": true,
                             "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
@@ -2053,12 +2089,9 @@
                             ]
                         },
                         {
-                            "type": "plugin",
-                            "name": "DetailViewerButton"
-                        },
-                        {
                             "labelId": "gnviewer.edit",
                             "type": "dropdown",
+                            "variant": "primary",
                             "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -2071,6 +2104,7 @@
                         {
                             "labelId": "gnviewer.view",
                             "type": "dropdown",
+                            "variant": "primary",
                             "disableIf": "{context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -2082,10 +2116,12 @@
                         },
                         {
                             "type": "plugin",
+                            "variant": "primary",
                             "name": "Share"
                         },
                         {
                             "type": "plugin",
+                            "variant": "primary",
                             "name": "DownloadResource",
                             "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'download_resourcebase')}"
                         },
@@ -2098,6 +2134,7 @@
                     "rightMenuItems": [
                         {
                             "type": "plugin",
+                            "variant": "primary",
                             "name": "FullScreen"
                         }
                     ]
@@ -2141,10 +2178,17 @@
                 "name": "ActionNavbar",
                 "cfg": {
                     "containerPosition": "header",
+                    "titleItems": [
+                        {
+                            "type": "plugin",
+                            "name": "DetailViewerButton"
+                        }
+                    ],
                     "leftMenuItems": [
                         {
                             "labelId": "gnviewer.save",
                             "type": "dropdown",
+                            "variant": "primary",
                             "showPendingChangesIcon": true,
                             "disableIf": "{!state('isNewResource') && !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
@@ -2159,12 +2203,9 @@
                             ]
                         },
                         {
-                            "type": "plugin",
-                            "name": "DetailViewerButton"
-                        },
-                        {
                             "labelId": "gnviewer.edit",
                             "type": "dropdown",
+                            "variant": "primary",
                             "disableIf": "{state('isNewResource') || !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -2177,6 +2218,7 @@
                         {
                             "labelId": "gnviewer.view",
                             "type": "dropdown",
+                            "variant": "primary",
                             "disableIf": "{state('isNewResource') || context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}",
                             "items": [
                                 {
@@ -2188,6 +2230,7 @@
                         },
                         {
                             "type": "plugin",
+                            "variant": "primary",
                             "name": "Share"
                         },
                         {
@@ -2199,6 +2242,7 @@
                     "rightMenuItems": [
                         {
                             "type": "plugin",
+                            "variant": "primary",
                             "name": "FullScreen"
                         }
                     ]

--- a/geonode_mapstore_client/client/themes/geonode/less/_menu.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_menu.less
@@ -235,8 +235,7 @@ nav.hide-navigation#gn-topbar {
     display: flex;
     align-items: center;
     max-width: 11rem;
-    border-color: #275a7f;
-    color: white;
+    margin-right: 0.4rem;
     padding-left: 0.5rem;
 
     button.btn {

--- a/geonode_mapstore_client/client/themes/geonode/less/_menu.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_menu.less
@@ -3,6 +3,10 @@
 // **************
 
 #gn-components-theme(@theme-vars) {
+    .gn-action-navbar-title {
+        .background-color-var(@theme-vars[info]);
+        .color-var(@theme-vars[info-contrast]);
+    }
     .gn-menu-divider {
         .background-color-var(@theme-vars[primary-contrast]);
     }
@@ -34,7 +38,6 @@
                     .background-color-var(@theme-vars[primary]);
                 }
             }
-
         }
     }
 }
@@ -62,6 +65,10 @@
 .gn-main-header-placeholder {
     position: relative;
     width: 100%;
+}
+
+nav.hide-navigation#gn-topbar {
+    display: none;
 }
 
 #gn-topbar {
@@ -100,6 +107,12 @@
             font-size: @font-size-sm;
         }
     }
+
+    &.gn-primary {
+        padding: 0.25rem 0;
+        min-height: 2rem;
+    }
+
     .dropdown-menu li button {
         width: 100%;
         text-align: left;
@@ -171,7 +184,7 @@
     .gn-menu-content-side {
         position: relative;
     }
-    >.dropdown {
+    > .dropdown {
         visibility: hidden;
     }
 
@@ -193,17 +206,17 @@
     .gn-menu-fill {
         flex: 1;
 
-        .clear-pointer{
+        .clear-pointer {
             cursor: pointer;
         }
-        .resources-found{
+        .resources-found {
             cursor: pointer;
             text-decoration: underline;
         }
-        .resources-count{
+        .resources-count {
             padding: 0em 0.2em;
         }
-        .badge{
+        .badge {
             font-weight: normal;
             background-color: transparent;
         }
@@ -217,10 +230,46 @@
 }
 
 .gn-action-navbar-title {
-    margin: 0;
     font-weight: 400;
     font-size: 1rem;
-    padding: 0 0.5rem;
+    display: flex;
+    align-items: center;
+    max-width: 11rem;
+    border-color: #275a7f;
+    color: white;
+    padding-left: 0.5rem;
+
+    button.btn {
+    background-color: transparent;
+    border: none;
+    color: inherit;
+    }
+
+    i {
+    font-size: @font-size-lg;
+    }
+}
+
+.gn-action-navbar-resource-title {
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: default;
+}
+
+
+a.gn-action-navbar-breadcrumb-link {
+    padding: 0;
+    color: inherit;
+
+    &:hover {
+        color: inherit;
+    }
+}
+
+.gn-action-navbar-breadcrumb-seperator {
+    margin: 0 0.5rem;
 }
 
 .gn-language-selector {

--- a/geonode_mapstore_client/client/themes/geonode/less/_variables.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_variables.less
@@ -29,7 +29,7 @@
 @gn-disabled-bg: #fcfcfc;
 
 @gn-primary: #397AAB;
-@gn-info: #639fcc;
+@gn-info: #275a7f;
 @gn-success: #58cf80;
 @gn-warning: #ebbc35;
 @gn-danger: #bb4940;


### PR DESCRIPTION
This PR introduces the following in editor page:
- A class added by the MapStore client to force the navigation bar hidden
- A reduction in the size of the action bar
- A compact breadcrumb with a "home" icon linking to the catalogue home
- The resource title, which is cut (with ellipsis) and a title which shows the full content moved to the left
- An "i" icon which replaces the "Info" button