### PR TITLE
Client - Layer Settings Plugin

### DIFF
--- a/geonode_mapstore_client/client/js/epics/index.js
+++ b/geonode_mapstore_client/client/js/epics/index.js
@@ -125,7 +125,7 @@ export const updateMapLayoutEpic = (action$, store) =>
             const leftPanels = head([
                 get(state, "controls.queryPanel.enabled") && { left: mapLayout.left.lg } || null,
                 get(state, "controls.widgetBuilder.enabled") && { left: mapLayout.left.md } || null,
-                get(state, "layers.settings.expanded") && { left: mapLayout.left.md } || null,
+                get(state, "layers.settings.expanded") && { left: mapLayout.left.sm } || null,
                 get(state, "controls.drawer.enabled") && { left: resizedDrawer || mapLayout.left.sm } || null
             ].filter(panel => panel)) || { left: 0 };
 

--- a/geonode_mapstore_client/client/js/plugins/LayerSettings.jsx
+++ b/geonode_mapstore_client/client/js/plugins/LayerSettings.jsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { createPlugin } from '@mapstore/framework/utils/PluginsUtils';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import isEmpty from 'lodash/isEmpty';
+import { Glyphicon } from 'react-bootstrap';
+import Button from '@js/components/Button';
+import { updateNode, hideSettings } from '@mapstore/framework/actions/layers';
+import { groupsSelector, elementSelector } from '@mapstore/framework/selectors/layers';
+import { mapSelector } from '@mapstore/framework/selectors/map';
+import { currentLocaleSelector, currentLocaleLanguageSelector } from '@mapstore/framework/selectors/locale';
+import { mapLayoutValuesSelector } from '@mapstore/framework/selectors/maplayout';
+import { getTitle } from '@mapstore/framework/utils/TOCUtils';
+import GroupSettings from '@js/plugins/layersettings/GroupSettings';
+import BaseLayerSettings from '@js/plugins/layersettings/BaseLayerSettings';
+import WMSLayerSettings from '@js/plugins/layersettings/WMSLayerSettings';
+
+const settingsForms = {
+    group: GroupSettings,
+    baseLayer: BaseLayerSettings,
+    wms: WMSLayerSettings
+};
+
+/**
+* @module plugins/LayerSettings
+*/
+
+/**
+ * Plugin for layer and groups settings
+ * @name LayerSettings
+ * @example
+ * {
+ *   "name": "LayerSettings",
+ * }
+ */
+function LayerSettings({
+    node,
+    onChange,
+    style,
+    selectedNodes,
+    onClose,
+    ...props
+}) {
+
+    if (isEmpty(node)) {
+        return null;
+    }
+
+    const isGroup = !!node?.nodes;
+
+    const Settings = isGroup
+        ? settingsForms.group
+        : settingsForms[node?.type] || settingsForms.baseLayer;
+
+    const title = node?.title && getTitle(node.title, props.currentLocale) || node.name;
+    return (
+        <div
+            className="gn-layer-settings"
+            style={style}
+        >
+            <div className="gn-layer-settings-head">
+                <div className="gn-layer-settings-title">{title}</div>
+                <Button className="square-button" onClick={() => onClose()}>
+                    <Glyphicon glyph="1-close"/>
+                </Button>
+            </div>
+            <div className="gn-layer-settings-body">
+                <Settings
+                    {...props}
+                    node={node}
+                    onChange={(properties) => onChange(node.id, isGroup ? 'groups' : 'layers', properties)}
+                />
+            </div>
+        </div>
+    );
+}
+
+const ConnectedLayerSettings = connect(
+    createSelector([
+        elementSelector,
+        mapSelector,
+        groupsSelector,
+        currentLocaleSelector,
+        currentLocaleLanguageSelector,
+        state => mapLayoutValuesSelector(state, { height: true }),
+        elementSelector
+    ], (node, map, groups, currentLocale, currentLocaleLanguage, style) => ({
+        node,
+        zoom: map?.zoom,
+        projection: map?.projection,
+        groups,
+        currentLocale,
+        currentLocaleLanguage,
+        style
+    })),
+    {
+        onChange: updateNode,
+        onClose: hideSettings
+    }
+)(LayerSettings);
+
+function LayerSettingsButton({
+    status,
+    onToolsActions,
+    selectedLayers,
+    selectedGroups
+}) {
+    if (!(status === 'LAYER' || status === 'GROUP')) {
+        return null;
+    }
+
+    function handleClick() {
+        if (status === 'LAYER' || status === 'LAYER_LOAD_ERROR') {
+            onToolsActions.onSettings( selectedLayers[0].id, 'layers', { opacity: parseFloat(selectedLayers[0].opacity !== undefined ? selectedLayers[0].opacity : 1) });
+        } else if (status === 'GROUP') {
+            onToolsActions.onSettings(selectedGroups[selectedGroups.length - 1].id, 'groups', {});
+        }
+    }
+
+    return (
+        <Button
+            variant="primary"
+            className="square-button-md"
+            onClick={handleClick}
+        >
+            <Glyphicon glyph="wrench"/>
+        </Button>
+    );
+}
+
+const ConnectedLayerSettingsButton = connect(
+    createSelector([], () => ({}))
+)(LayerSettingsButton);
+
+
+export default createPlugin('LayerSettings', {
+    component: ConnectedLayerSettings,
+    containers: {
+        TOC: {
+            target: 'toolbar',
+            Component: ConnectedLayerSettingsButton
+        }
+    },
+    epics: {},
+    reducers: {}
+});

--- a/geonode_mapstore_client/client/js/plugins/__tests__/LayerSettings-test.jsx
+++ b/geonode_mapstore_client/client/js/plugins/__tests__/LayerSettings-test.jsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import React from 'react';
+import trim from 'lodash/trim';
+import ReactDOM from 'react-dom';
+import { getPluginForTest } from '@mapstore/framework/plugins/__tests__/pluginsTestUtils';
+import LayerSettings from '../LayerSettings';
+
+describe('LayerSettings Plugin', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        window.__DEVTOOLS__ = true;
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('container'));
+        document.body.innerHTML = '';
+        window.__DEVTOOLS__ = undefined;
+        setTimeout(done);
+    });
+
+    it('should render the base layer settings', () => {
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        name: 'test',
+                        id: 'layer1',
+                        title: 'test layer',
+                        type: 'wms',
+                        url: 'https://gs-stable.geo-solutions.it/geoserver/wms'
+                    },
+                    {
+                        id: 'layer2',
+                        type: 'vector',
+                        features: []
+                    }
+                ],
+                groups: [
+                    {
+                        expanded: true,
+                        id: 'Default',
+                        name: 'Default',
+                        nodes: ['layer1', 'layer2'],
+                        title: 'Default'
+                    }
+                ],
+                selected: ['layer2'],
+                settings: {
+                    expanded: true,
+                    node: 'layer2',
+                    nodeType: 'layers'
+                }
+            }
+        };
+        const { Plugin } = getPluginForTest(LayerSettings, state);
+        ReactDOM.render(<Plugin />, document.getElementById('container'));
+        const sections = document.querySelectorAll('.gn-layer-settings-section-title');
+        expect(sections.length).toBe(2);
+        expect([...sections].map(section => trim(section.innerText))).toEqual([
+            'gnviewer.generalSettings',
+            'gnviewer.visibilitySettings'
+        ]);
+    });
+    it('should render the wms layer settings', () => {
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        name: 'test',
+                        id: 'layer1',
+                        title: 'test layer',
+                        type: 'wms',
+                        url: 'https://gs-stable.geo-solutions.it/geoserver/wms'
+                    },
+                    {
+                        id: 'layer2',
+                        type: 'vector',
+                        features: []
+                    }
+                ],
+                groups: [
+                    {
+                        expanded: true,
+                        id: 'Default',
+                        name: 'Default',
+                        nodes: ['layer1', 'layer2'],
+                        title: 'Default'
+                    }
+                ],
+                selected: ['layer1'],
+                settings: {
+                    expanded: true,
+                    node: 'layer1',
+                    nodeType: 'layers'
+                }
+            }
+        };
+        const { Plugin } = getPluginForTest(LayerSettings, state);
+        ReactDOM.render(<Plugin />, document.getElementById('container'));
+        const sections = document.querySelectorAll('.gn-layer-settings-section-title');
+        expect(sections.length).toBe(4);
+        expect([...sections].map(section => trim(section.innerText))).toEqual([
+            'gnviewer.generalSettings',
+            'gnviewer.visibilitySettings',
+            'gnviewer.styleSettings',
+            'gnviewer.tilingSettings'
+        ]);
+    });
+    it('should render the group settings', () => {
+        const state = {
+            layers: {
+                flat: [
+                    {
+                        name: 'test',
+                        id: 'layer1',
+                        title: 'test layer',
+                        type: 'wms',
+                        url: 'https://gs-stable.geo-solutions.it/geoserver/wms'
+                    },
+                    {
+                        id: 'layer2',
+                        type: 'vector',
+                        features: []
+                    }
+                ],
+                groups: [
+                    {
+                        expanded: true,
+                        id: 'Default',
+                        name: 'Default',
+                        nodes: ['layer1', 'layer2'],
+                        title: 'Default'
+                    }
+                ],
+                selected: ['Default'],
+                settings: {
+                    expanded: true,
+                    node: 'Default',
+                    nodeType: 'groups'
+                }
+            }
+        };
+        const { Plugin } = getPluginForTest(LayerSettings, state);
+        ReactDOM.render(<Plugin />, document.getElementById('container'));
+        const sections = document.querySelectorAll('.gn-layer-settings-section-title');
+        expect(sections.length).toBe(1);
+        expect([...sections].map(section => trim(section.innerText))).toEqual([
+            'gnviewer.generalSettings'
+        ]);
+    });
+});

--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -388,6 +388,10 @@ export const plugins = {
     DatasetsCatalogPlugin: toLazyPlugin(
         'DatasetsCatalog',
         () => import(/* webpackChunkName: 'plugins/dataset-catalog' */ '@js/plugins/DatasetsCatalog')
+    ),
+    LayerSettingsPlugin: toLazyPlugin(
+        'LayerSettings',
+        () => import(/* webpackChunkName: 'plugins/layer-settings' */ '@js/plugins/LayerSettings')
     )
 };
 

--- a/geonode_mapstore_client/client/js/plugins/layersettings/BaseLayerSettings.jsx
+++ b/geonode_mapstore_client/client/js/plugins/layersettings/BaseLayerSettings.jsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import GeneralSettings from '@js/plugins/layersettings/GeneralSettings';
+import VisibilitySettings from '@js/plugins/layersettings/VisibilitySettings';
+import SettingsSection from '@js/plugins/layersettings/SettingsSection';
+import useLocalStorage from '@js/hooks/useLocalStorage';
+import Message from '@mapstore/framework/components/I18N/Message';
+
+function BaseLayerSettings({
+    node = {},
+    resolutions,
+    projection,
+    onChange = () => {},
+    zoom,
+    groups = [],
+    currentLocale
+}) {
+    const [settingsSections, setSettingsSections] = useLocalStorage('settings-section', {
+        general: true,
+        visibility: false
+    });
+    function handleChangeSection(key, value) {
+        setSettingsSections({
+            ...settingsSections,
+            [key]: value
+        });
+    }
+    return (
+        <>
+            <SettingsSection
+                title={<Message msgId="gnviewer.generalSettings" />}
+                expanded={settingsSections?.general}
+                onChange={handleChangeSection.bind(null, 'general')}
+            >
+                <GeneralSettings
+                    node={node}
+                    onChange={onChange}
+                    nodeType="layer"
+                    groups={groups}
+                    currentLocale={currentLocale}
+                />
+            </SettingsSection>
+            <SettingsSection
+                title={<Message msgId="gnviewer.visibilitySettings" />}
+                expanded={settingsSections?.visibility}
+                onChange={handleChangeSection.bind(null, 'visibility')}
+            >
+                <VisibilitySettings
+                    node={node}
+                    resolutions={resolutions}
+                    projection={projection}
+                    onChange={onChange}
+                    zoom={zoom}
+                />
+            </SettingsSection>
+        </>
+    );
+}
+
+export default BaseLayerSettings;

--- a/geonode_mapstore_client/client/js/plugins/layersettings/GeneralSettings.jsx
+++ b/geonode_mapstore_client/client/js/plugins/layersettings/GeneralSettings.jsx
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import isString from 'lodash/isString';
+import isObject from 'lodash/isObject';
+import uniqBy from 'lodash/uniqBy';
+import { ControlLabel, FormControl, FormGroup } from 'react-bootstrap';
+import Message from '@mapstore/framework/components/I18N/Message';
+import Select from 'react-select';
+import { getMessageById } from '@mapstore/framework/utils/LocaleUtils';
+import { isValidNewGroupOption, flattenGroups, getLabelName as _getLabelName, getTitle as _getTitle } from '@mapstore/framework/utils/TOCUtils';
+
+function SelectGroup({
+    node,
+    allowNew = false,
+    groups: groupsProp,
+    currentLocale,
+    onChange
+}) {
+
+    const SelectCreatable = allowNew ? Select.Creatable : Select;
+    const getTitle = (label) => _getTitle(label, currentLocale);
+    const getLabelName = (label, groups) => _getLabelName(getTitle(label), groups);
+    const findGroupLabel = () => {
+        const wholeGroups = groupsProp && flattenGroups(groupsProp, 0, true);
+        const eleGroupName = node?.group || 'Default';
+        const group = wholeGroups.find(gr => gr.id === eleGroupName) || {};
+        return getTitle(group.title);
+    };
+    const groups = groupsProp && flattenGroups(groupsProp);
+    const nodeGroupLabel = findGroupLabel();
+
+    return (
+        <SelectCreatable
+            clearable={false}
+            key="group-dropdown"
+            options={
+                uniqBy([
+                    { value: 'Default', label: 'Default' },
+                    ...(groups || node?.group || []).map(item => {
+                        if (isObject(item)) {
+                            return {...item, label: getLabelName(item.label, groups)};
+                        }
+                        return { label: getLabelName(item, groups), value: item };
+                    })
+                ], 'value')
+            }
+            isValidNewOption={isValidNewGroupOption}
+            newOptionCreator={function(option) {
+                const { valueKey, label, labelKey } = option;
+                const value = label.replace(/\./g, '${dot}').replace(/\//g, '.');
+                return {
+                    [valueKey]: value,
+                    [labelKey]: label,
+                    className: 'Select-create-option-placeholder'
+                };
+            }}
+            value={{ label: getLabelName(nodeGroupLabel, groups), value: nodeGroupLabel}}
+            placeholder={getLabelName(nodeGroupLabel, groups)}
+            onChange={({ value }) => onChange({ group: value || 'Default' })}
+        />
+    );
+}
+
+function GeneralSettings({
+    node = {},
+    nodeType,
+    showTooltipOptions = true,
+    onChange = () => {},
+    groups,
+    currentLocale
+}, context) {
+
+    function  handleUpdateTranslation(key, event) {
+        const title = (key === 'default' && isString(node.title))
+            ? event.target.value
+            : {
+                ...(isObject(node.title)
+                    ? node.title
+                    : { 'default': node.title || '' }),
+                [key]: event.target.value
+            };
+        onChange({ title });
+    }
+
+    const tooltipItems = [
+        { value: "title", label: getMessageById(context.messages, "layerProperties.tooltip.title") },
+        { value: "description", label: getMessageById(context.messages, "layerProperties.tooltip.description") },
+        { value: "both", label: getMessageById(context.messages, "layerProperties.tooltip.both") },
+        { value: "none", label: getMessageById(context.messages, "layerProperties.tooltip.none") }
+    ];
+    const tooltipPlacementItems = [
+        { value: "top", label: getMessageById(context.messages, "layerProperties.tooltip.top") },
+        { value: "right", label: getMessageById(context.messages, "layerProperties.tooltip.right") },
+        { value: "bottom", label: getMessageById(context.messages, "layerProperties.tooltip.bottom") }
+    ];
+
+    const {
+        title,
+        description = '',
+        tooltipOptions = 'title',
+        tooltipPlacement = 'top'
+    } = node || {};
+
+    const currentTitle = isString(title) ? title : _getTitle(title, currentLocale) ?? title?.default ?? '';
+
+    return (
+        <>
+            <FormGroup>
+                <ControlLabel><Message msgId="layerProperties.title" /></ControlLabel>
+                <FormControl
+                    defaultValue={currentTitle}
+                    key="title"
+                    type="text"
+                    onBlur={handleUpdateTranslation.bind(null, 'default')} />
+            </FormGroup>
+            <FormGroup>
+                <ControlLabel><Message msgId="layerProperties.description" /></ControlLabel>
+                <FormControl
+                    defaultValue={description}
+                    key="description"
+                    type="text"
+                    onBlur={(event) => onChange({ description: event.target.value })}/>
+            </FormGroup>
+            {nodeType === 'layer'
+                ? <FormGroup>
+                    <ControlLabel><Message msgId="layerProperties.group" /></ControlLabel>
+                    <SelectGroup
+                        node={node}
+                        onChange={onChange}
+                        groups={groups}
+                        currentLocale={currentLocale}
+                    />
+                </FormGroup>
+                : null}
+            {showTooltipOptions &&
+            <>
+                <FormGroup>
+                    <ControlLabel><Message msgId="gnviewer.nodeTooltipContent" /></ControlLabel>
+                    <Select
+                        clearable={false}
+                        key="tooltips-dropdown"
+                        options={tooltipItems}
+                        value={tooltipItems.find(({ value }) => value === tooltipOptions)}
+                        onChange={({ value }) => onChange({ tooltipOptions: value || 'title' })}
+                    />
+                </FormGroup>
+                <FormGroup>
+                    <ControlLabel><Message msgId="gnviewer.nodeTooltipPlacement" /></ControlLabel>
+                    <Select
+                        clearable={false}
+                        key="tooltips-placement-dropdown"
+                        options={tooltipPlacementItems}
+                        value={tooltipPlacementItems.find(({ value }) => value === tooltipPlacement)}
+                        onChange={({ value }) => onChange({ tooltipPlacement: value || 'top' })}
+                    />
+                </FormGroup>
+            </>}
+
+        </>
+    );
+}
+
+GeneralSettings.contextTypes = {
+    messages: PropTypes.object
+};
+
+export default GeneralSettings;

--- a/geonode_mapstore_client/client/js/plugins/layersettings/GroupSettings.jsx
+++ b/geonode_mapstore_client/client/js/plugins/layersettings/GroupSettings.jsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import GeneralSettings from '@js/plugins/layersettings/GeneralSettings';
+import SettingsSection from '@js/plugins/layersettings/SettingsSection';
+import useLocalStorage from '@js/hooks/useLocalStorage';
+import Message from '@mapstore/framework/components/I18N/Message';
+
+function GroupSettings({
+    node,
+    onChange,
+    groups,
+    currentLocale
+}) {
+    const [settingsSections, setSettingsSections] = useLocalStorage('settings-section', {
+        general: true
+    });
+
+    function handleChangeSection(key, value) {
+        setSettingsSections({
+            ...settingsSections,
+            [key]: value
+        });
+    }
+    return (
+
+        <SettingsSection
+            title={<Message msgId="gnviewer.generalSettings" />}
+            expanded={settingsSections?.general}
+            onChange={handleChangeSection.bind(null, 'general')}
+        >
+            <GeneralSettings
+                node={node}
+                onChange={onChange}
+                nodeType="group"
+                groups={groups}
+                currentLocale={currentLocale}
+            />
+        </SettingsSection>
+    );
+}
+
+export default GroupSettings;

--- a/geonode_mapstore_client/client/js/plugins/layersettings/SettingsSection.jsx
+++ b/geonode_mapstore_client/client/js/plugins/layersettings/SettingsSection.jsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { Glyphicon } from 'react-bootstrap';
+
+function SettingsSection({
+    expanded: expandedProp,
+    title,
+    children,
+    onChange
+}) {
+    const [expanded, setExpanded] = useState(expandedProp);
+    useEffect(() => {
+        if (onChange) {
+            onChange(expanded);
+        }
+    }, [expanded]);
+    return (
+        <>
+            <div className="gn-layer-settings-section-title" onClick={() => setExpanded(!expanded)}>
+                <Glyphicon glyph={`chevron-${expanded ? 'down' : 'right'}`}/>&nbsp;
+                {title}
+            </div>
+            {expanded ? children : null}
+            <hr/>
+        </>
+    );
+}
+
+export default SettingsSection;

--- a/geonode_mapstore_client/client/js/plugins/layersettings/VisibilitySettings.jsx
+++ b/geonode_mapstore_client/client/js/plugins/layersettings/VisibilitySettings.jsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import clamp from 'lodash/clamp';
+import { FormGroup, ControlLabel } from 'react-bootstrap';
+import VisibilityLimitsForm from '@mapstore/framework/components/TOC/fragments/settings/VisibilityLimitsForm';
+import IntlNumberFormControl from '@mapstore/framework/components/I18N/IntlNumberFormControl';
+import Message from '@mapstore/framework/components/I18N/Message';
+
+function VisibilitySettings({
+    node = {},
+    resolutions,
+    projection,
+    onChange = () => {},
+    zoom
+}) {
+    const {
+        opacity = 1.0
+    } = node;
+    return (
+        <>
+            <FormGroup>
+                <ControlLabel><Message msgId="opacity"/> %</ControlLabel>
+                <IntlNumberFormControl
+                    type="number"
+                    min={0}
+                    max={100}
+                    name="opacity"
+                    value={opacity * 100}
+                    onChange={(value)=> onChange({ opacity: clamp(Math.round(value), 0, 100) / 100 })}/>
+            </FormGroup>
+            <FormGroup>
+                <VisibilityLimitsForm
+                    title={<ControlLabel><Message msgId="layerProperties.visibilityLimits.title"/></ControlLabel>}
+                    layer={node}
+                    onChange={(newProperty) => onChange(newProperty)}
+                    projection={projection}
+                    resolutions={resolutions}
+                    zoom={zoom}
+                />
+            </FormGroup>
+        </>
+    );
+}
+
+export default VisibilitySettings;

--- a/geonode_mapstore_client/client/js/plugins/layersettings/WMSLayerSettings.jsx
+++ b/geonode_mapstore_client/client/js/plugins/layersettings/WMSLayerSettings.jsx
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState, useEffect, useRef } from 'react';
+import isNumber from 'lodash/isNumber';
+import clamp from 'lodash/clamp';
+import uniqBy from 'lodash/uniqBy';
+import { Glyphicon, FormGroup, ControlLabel, Checkbox } from 'react-bootstrap';
+import Button from '@js/components/Button';
+import IntlNumberFormControl from '@mapstore/framework/components/I18N/IntlNumberFormControl';
+import Message from '@mapstore/framework/components/I18N/Message';
+import InfoPopover from '@mapstore/framework/components/widgets/widget/InfoPopover';
+import { DEFAULT_FORMAT_WMS, getSupportedFormat } from '@mapstore/framework/utils/CatalogUtils';
+import { getConfigProp } from '@mapstore/framework/utils/ConfigUtils';
+import LegendImage from '@mapstore/framework/components/TOC/fragments/legend/Legend';
+import Select from 'react-select';
+import GeneralSettings from '@js/plugins/layersettings/GeneralSettings';
+import VisibilitySettings from '@js/plugins/layersettings/VisibilitySettings';
+import SettingsSection from '@js/plugins/layersettings/SettingsSection';
+import useLocalStorage from '@js/hooks/useLocalStorage';
+
+function getStyleOptions(layer) {
+    const mapLayerStyles = layer?.extendedParams?.mapLayer?.extra_params?.styles || [];
+    const datasetStyles = layer?.extendedParams?.mapLayer?.dataset?.styles || [];
+    const defaultStyle = layer?.extendedParams?.mapLayer?.dataset?.default_style;
+    return uniqBy([
+        ...datasetStyles,
+        ...mapLayerStyles,
+        ...(defaultStyle ? [defaultStyle] : [])
+    ], 'name').map(({ name, sld_title: sldTitle, title, workspace }) => ({
+        value: workspace ? `${workspace}:${name}` : name,
+        label: sldTitle || title || name
+    }));
+}
+
+function WMSLayerSettings({
+    node = {},
+    resolutions,
+    projection,
+    onChange = () => {},
+    zoom,
+    formats,
+    isLocalizedLayerStylesEnabled,
+    currentLocaleLanguage,
+    groups = [],
+    currentLocale
+}) {
+
+    const {
+        singleTile = false,
+        tiled = true,
+        transparent = true,
+        localizedLayerStyles = false,
+        imageFormats,
+        format = getConfigProp('defaultLayerFormat') || 'image/png',
+        url,
+        legendOptions = {
+            legendWidth: 12,
+            legendHeight: 12
+        }
+    } = node;
+
+    const [formatLoading, setFormatLoading] = useState();
+    const [settingsSections, setSettingsSections] = useLocalStorage('settings-section', {
+        general: true,
+        visibility: false,
+        style: false,
+        tiling: false
+    });
+    function handleChangeSection(key, value) {
+        setSettingsSections({
+            ...settingsSections,
+            [key]: value
+        });
+    }
+
+    const isMounted = useRef();
+    useEffect(() => {
+        isMounted.current = true;
+        return () => {
+            isMounted.current = false;
+        };
+    }, []);
+
+    function handleFormatOptionsFetch(layerUrl) {
+        if (!formatLoading) {
+            setFormatLoading(true);
+            getSupportedFormat(layerUrl)
+                .then((newImageFormats)=>{
+                    if (isMounted.current) {
+                        onChange({ imageFormats: newImageFormats });
+                        setFormatLoading(false);
+                    }
+                })
+                .catch(() => {
+                    if (isMounted.current) {
+                        setFormatLoading(false);
+                    }
+                });
+        }
+    }
+
+    function isLegendOptionValid(propertyKey) {
+        if (legendOptions && legendOptions[propertyKey]) {
+            return parseInt(legendOptions[propertyKey], 10) < 12 ? 'error' : null;
+        }
+        return null;
+    }
+    function areLegendOptionsValid() {
+        return isLegendOptionValid('legendWidth') !== 'error' &&
+        isLegendOptionValid('legendHeight') !== 'error' &&
+        isNumber(legendOptions.legendHeight) &&
+        isNumber(legendOptions.legendWidth);
+    }
+    function handleLegendOptionBlur(event) {
+        const value = event.target.value && Math.round(event.target.value);
+        const name = event.target.name;
+        const defaultSize = 12;
+        onChange({
+            legendOptions: {
+                ...legendOptions,
+                [name]: value >= defaultSize ? value : ''
+            }
+        });
+    }
+
+    return (
+        <>
+            <SettingsSection
+                title={<Message msgId="gnviewer.generalSettings" />}
+                expanded={settingsSections?.general}
+                onChange={handleChangeSection.bind(null, 'general')}
+            >
+                <GeneralSettings
+                    node={node}
+                    onChange={onChange}
+                    nodeType="layer"
+                    groups={groups}
+                    currentLocale={currentLocale}
+                />
+            </SettingsSection>
+
+
+            <SettingsSection
+                title={<Message msgId="gnviewer.visibilitySettings" />}
+                expanded={settingsSections?.visibility}
+                onChange={handleChangeSection.bind(null, 'visibility')}
+            >
+                <VisibilitySettings
+                    node={node}
+                    resolutions={resolutions}
+                    projection={projection}
+                    onChange={onChange}
+                    zoom={zoom}
+                />
+            </SettingsSection>
+            <SettingsSection
+                title={<Message msgId="gnviewer.styleSettings" />}
+                expanded={settingsSections?.style}
+                onChange={handleChangeSection.bind(null, 'style')}
+            >
+                {node?.extendedParams?.mapLayer && <FormGroup>
+                    <ControlLabel><Message msgId="gnviewer.style" /></ControlLabel>
+                    <Select
+                        key="style-selector"
+                        clearable={false}
+                        options={getStyleOptions(node)}
+                        value={node.style}
+                        onChange={({ value }) => onChange({ style: value })}/>
+                </FormGroup>}
+                <FormGroup validationState={isLegendOptionValid('legendWidth')}>
+                    <ControlLabel><Message msgId="gnviewer.legendWidth" /></ControlLabel>
+                    <IntlNumberFormControl
+                        value={legendOptions.legendWidth}
+                        name="legendWidth"
+                        type="number"
+                        min={12}
+                        max={1000}
+                        onChange={(value)=> onChange({ legendOptions: { ...legendOptions, legendWidth: value && clamp(Math.round(value), 0, 1000) } })}
+                        onKeyPress={(event)=> event.key === '-' && event.preventDefault()}
+                        onBlur={handleLegendOptionBlur}
+                    />
+                </FormGroup>
+                <FormGroup
+                    validationState={isLegendOptionValid('legendHeight')}
+                >
+                    <ControlLabel><Message msgId="gnviewer.legendHeight" /></ControlLabel>
+                    <IntlNumberFormControl
+                        value={legendOptions.legendHeight}
+                        name="legendHeight"
+                        type="number"
+                        min={12}
+                        max={1000}
+                        onChange={(value)=> onChange({ legendOptions: { ...legendOptions, legendHeight: value && clamp(Math.round(value), 0, 1000) } })}
+                        onKeyPress={(event)=> event.key === '-' && event.preventDefault()}
+                        onBlur={handleLegendOptionBlur}
+                    />
+                </FormGroup>
+                <FormGroup>
+                    <ControlLabel><Message msgId="gnviewer.legendPreview" /></ControlLabel>
+                    <div style={{ width: '100%', overflow: 'auto' }}>
+                        <LegendImage
+                            style={{ maxWidth: 'none' }}
+                            layer={node}
+                            legendHeight={
+                                areLegendOptionsValid() && legendOptions.legendHeight || undefined}
+                            legendWidth={
+                                areLegendOptionsValid() && legendOptions.legendWidth || undefined}
+                            language={
+                                isLocalizedLayerStylesEnabled ? currentLocaleLanguage : undefined}
+                        />
+                    </div>
+                </FormGroup>
+            </SettingsSection>
+            <SettingsSection
+                title={<Message msgId="gnviewer.tilingSettings" />}
+                expanded={settingsSections?.tiling}
+                onChange={handleChangeSection.bind(null, 'tiling')}
+            >
+                <FormGroup>
+                    <ControlLabel><Message msgId="layerProperties.format.title" /></ControlLabel>
+                    <div className={'ms-format-container'}>
+                        <Select
+                            className={'format-select'}
+                            key="format-dropdown"
+                            clearable={false}
+                            noResultsText={<Message
+                                msgId={formatLoading
+                                    ? "layerProperties.format.loading"
+                                    : "layerProperties.format.noOption"}
+                            />}
+                            isLoading={!!formatLoading}
+                            options={formatLoading
+                                ? []
+                                : (formats?.map((value) => ({ value, label: value }))
+                                || imageFormats
+                                || DEFAULT_FORMAT_WMS)}
+                            value={format}
+                            onChange={({ value }) => onChange({ format: value })}/>
+                        <Button
+                            tooltipId="layerProperties.format.refresh"
+                            className="square-button-md no-border format-refresh"
+                            onClick={() => handleFormatOptionsFetch(url)}
+                            key="format-refresh">
+                            <Glyphicon glyph="refresh" />
+                        </Button>
+                    </div>
+                </FormGroup>
+                <FormGroup>
+                    <ControlLabel>Size</ControlLabel>
+                    <Select
+                        key="wsm-layersize-dropdown"
+                        clearable={false}
+                        options={[{ value: 256, label: 256 }, { value: 512, label: 512 }]}
+                        value={node?.tileSize || 256}
+                        onChange={({ value }) => onChange({ tileSize: value })}/>
+                </FormGroup>
+                <FormGroup>
+                    <Checkbox
+                        key="transparent"
+                        checked={transparent}
+                        onChange={(event) => onChange({ transparent: event.target.checked })}
+                    >
+                        <Message msgId="layerProperties.transparent"/>
+                    </Checkbox>
+                    <Checkbox
+                        value="tiled"
+                        key="tiled"
+                        disabled={!!singleTile}
+                        onChange={(event) => onChange({ tiled: event.target.checked })}
+                        checked={tiled} >
+                        <Message msgId="layerProperties.cached"/>
+                    </Checkbox>
+                    <Checkbox
+                        key="singleTile"
+                        value="singleTile"
+                        checked={singleTile}
+                        onChange={(event) => onChange({ singleTile: event.target.checked })}>
+                        <Message msgId="layerProperties.singleTile"/>
+                    </Checkbox>
+                    {(isLocalizedLayerStylesEnabled ? (
+                        <Checkbox
+                            key="localizedLayerStyles"
+                            value="localizedLayerStyles"
+                            data-qa="display-lacalized-layer-styles-option"
+                            checked={localizedLayerStyles}
+                            onChange={(event) => onChange({ localizedLayerStyles: event.target.checked })}>
+                            <Message msgId="layerProperties.enableLocalizedLayerStyles.label" />&nbsp;
+                            <InfoPopover text={<Message msgId="layerProperties.enableLocalizedLayerStyles.tooltip" />} />
+                        </Checkbox>) : null)}
+                </FormGroup>
+            </SettingsSection>
+        </>
+    );
+}
+
+export default WMSLayerSettings;

--- a/geonode_mapstore_client/client/js/plugins/layersettings/_tests_/BaseLayerSettings-test.jsx
+++ b/geonode_mapstore_client/client/js/plugins/layersettings/_tests_/BaseLayerSettings-test.jsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import trim from 'lodash/trim';
+import BaseLayerSettings from '../BaseLayerSettings';
+
+describe('BaseLayerSettings', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('container'));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('should render with default', () => {
+        ReactDOM.render(<BaseLayerSettings/>, document.getElementById('container'));
+        const sections = document.querySelectorAll('.gn-layer-settings-section-title');
+        expect(sections.length).toBe(2);
+        expect([...sections].map(section => trim(section.innerText))).toEqual([
+            'gnviewer.generalSettings',
+            'gnviewer.visibilitySettings'
+        ]);
+    });
+});

--- a/geonode_mapstore_client/client/js/plugins/layersettings/_tests_/GeneralSettings-test.jsx
+++ b/geonode_mapstore_client/client/js/plugins/layersettings/_tests_/GeneralSettings-test.jsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Simulate } from 'react-dom/test-utils';
+import GeneralSettings from '../GeneralSettings';
+
+describe('GeneralSettings', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('container'));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('should render with default', () => {
+        ReactDOM.render(<GeneralSettings />, document.getElementById('container'));
+        const containerChildren = document.querySelectorAll('#container > *');
+        expect(containerChildren.length).toBe(4);
+    });
+
+    it('should read title as string', () => {
+        ReactDOM.render(<GeneralSettings node={{ title: 'Title' }}/>, document.getElementById('container'));
+        const inputs = document.querySelectorAll('input');
+        expect(inputs.length).toBe(4);
+        const titleInput = inputs[0];
+        expect(titleInput.value).toBe('Title');
+    });
+
+    it('should read title as object', () => {
+        ReactDOM.render(<GeneralSettings node={{ title: { 'default': 'Title', 'en-US': 'En Title'} }} currentLocale="en-US"/>, document.getElementById('container'));
+        const inputs = document.querySelectorAll('input');
+        expect(inputs.length).toBe(4);
+        const titleInput = inputs[0];
+        expect(titleInput.value).toBe('En Title');
+    });
+    it('should use the on change callback', (done) => {
+        ReactDOM.render(<GeneralSettings
+            node={{ title: 'Title' }}
+            onChange={({ title }) => {
+                try {
+                    expect(title).toBe('New Title');
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            }}
+        />, document.getElementById('container'));
+        const inputs = document.querySelectorAll('input');
+        expect(inputs.length).toBe(4);
+        const titleInput = inputs[0];
+        expect(titleInput.value).toBe('Title');
+        Simulate.blur(titleInput, { target: { value: 'New Title' }});
+    });
+});

--- a/geonode_mapstore_client/client/js/plugins/layersettings/_tests_/GroupSettings-test.jsx
+++ b/geonode_mapstore_client/client/js/plugins/layersettings/_tests_/GroupSettings-test.jsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import GroupSettings from '../GroupSettings';
+
+describe('GroupSettings', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('container'));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('should render with default', () => {
+        ReactDOM.render(<GroupSettings/>, document.getElementById('container'));
+        const sections = document.querySelectorAll('.gn-layer-settings-section-title');
+        expect(sections.length).toBe(1);
+        expect([...sections].map(section => section.innerText)).toEqual([ ' gnviewer.generalSettings' ]);
+    });
+});

--- a/geonode_mapstore_client/client/js/plugins/layersettings/_tests_/SettingsSection-test.jsx
+++ b/geonode_mapstore_client/client/js/plugins/layersettings/_tests_/SettingsSection-test.jsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Simulate } from 'react-dom/test-utils';
+import SettingsSection from '../SettingsSection';
+
+describe('SettingsSection', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('container'));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('should render with default', () => {
+        ReactDOM.render(<SettingsSection><div className="child"></div></SettingsSection>, document.getElementById('container'));
+        const title = document.querySelector('.gn-layer-settings-section-title');
+        expect(title).toBeTruthy();
+        const child = document.querySelector('.child');
+        expect(child).toBeFalsy();
+    });
+    it('should show children after clicking on title', () => {
+        ReactDOM.render(<SettingsSection><div className="child"></div></SettingsSection>, document.getElementById('container'));
+        const title = document.querySelector('.gn-layer-settings-section-title');
+        expect(title).toBeTruthy();
+        let child = document.querySelector('.child');
+        expect(child).toBeFalsy();
+        Simulate.click(title);
+        child = document.querySelector('.child');
+        expect(child).toBeTruthy();
+    });
+});

--- a/geonode_mapstore_client/client/js/plugins/layersettings/_tests_/VisibilitySettings-test.jsx
+++ b/geonode_mapstore_client/client/js/plugins/layersettings/_tests_/VisibilitySettings-test.jsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Simulate } from 'react-dom/test-utils';
+import VisibilitySettings from '../VisibilitySettings';
+
+describe('VisibilitySettings', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('container'));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('should render with default', () => {
+        ReactDOM.render(<VisibilitySettings />, document.getElementById('container'));
+        const containerChildren = document.querySelectorAll('#container > *');
+        expect(containerChildren.length).toBe(2);
+    });
+
+    it('should set the opacity in percentage', (done) => {
+        ReactDOM.render(<VisibilitySettings
+            node={{ opacity: 0.5 }}
+            onChange={({ opacity }) => {
+                expect(opacity).toBe(0.4);
+                done();
+            }}
+        />, document.getElementById('container'));
+        const inputs = document.querySelectorAll('input');
+        expect(inputs.length).toBe(5);
+        const opacityInput = inputs[0];
+        expect(opacityInput.value).toBe('50');
+        Simulate.change(opacityInput, { target: { value: 40 }});
+    });
+});

--- a/geonode_mapstore_client/client/js/plugins/layersettings/_tests_/WMSLayerSettings-test.jsx
+++ b/geonode_mapstore_client/client/js/plugins/layersettings/_tests_/WMSLayerSettings-test.jsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import trim from 'lodash/trim';
+import WMSLayerSettings from '../WMSLayerSettings';
+
+describe('WMSLayerSettings', () => {
+    beforeEach((done) => {
+        document.body.innerHTML = '<div id="container"></div>';
+        setTimeout(done);
+    });
+
+    afterEach((done) => {
+        ReactDOM.unmountComponentAtNode(document.getElementById('container'));
+        document.body.innerHTML = '';
+        setTimeout(done);
+    });
+
+    it('should render with default', () => {
+        ReactDOM.render(<WMSLayerSettings/>, document.getElementById('container'));
+        const sections = document.querySelectorAll('.gn-layer-settings-section-title');
+        expect(sections.length).toBe(4);
+        expect([...sections].map(section => trim(section.innerText))).toEqual([
+            'gnviewer.generalSettings',
+            'gnviewer.visibilitySettings',
+            'gnviewer.styleSettings',
+            'gnviewer.tilingSettings'
+        ]);
+    });
+});

--- a/geonode_mapstore_client/client/js/utils/__tests__/APIUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/APIUtils-test.js
@@ -1,0 +1,20 @@
+import expect from 'expect';
+import { parseDevHostname } from '@js/utils/APIUtils';
+
+describe('APIUtils', () => {
+    beforeEach(done => {
+        window.__DEVTOOLS__ = true;
+        setTimeout(done);
+    });
+
+    afterEach(done => {
+        delete window.__DEVTOOLS__;
+        setTimeout(done);
+    });
+    it('should remove localhost hostname', () => {
+        expect(parseDevHostname('http://localhost:8081/path')).toBe('/path');
+    });
+    it('should keep the url if the hostname is not localhost', () => {
+        expect(parseDevHostname('https://hostname/path')).toBe('https://hostname/path');
+    });
+});

--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -28,7 +28,7 @@
     "mapLayout": {
         "preview": {
             "left": {
-                "sm": 300,
+                "sm": 350,
                 "md": 500,
                 "lg": 600
             },
@@ -41,7 +41,7 @@
         },
         "viewer": {
             "left": {
-                "sm": 300,
+                "sm": 350,
                 "md": 500,
                 "lg": 600
             },
@@ -676,7 +676,12 @@
                 }
             },
             {
-                "name": "DrawerMenu"
+                "name": "DrawerMenu",
+                "cfg": {
+                    "menuOptions": {
+                        "width": 350
+                    }
+                }
             }
         ],
         "geostory_embed": [
@@ -1375,7 +1380,12 @@
                 }
             },
             {
-                "name": "DrawerMenu"
+                "name": "DrawerMenu",
+                "cfg": {
+                    "menuOptions": {
+                        "width": 350
+                    }
+                }
             },
             {
                 "name": "MapFooter"
@@ -1579,7 +1589,12 @@
                 }
             },
             {
-                "name": "DrawerMenu"
+                "name": "DrawerMenu",
+                "cfg": {
+                    "menuOptions": {
+                        "width": 350
+                    }
+                }
             },
             {
                 "name": "OmniBar"
@@ -1814,11 +1829,7 @@
                 }
             },
             {
-                "name": "TOCItemsSettings",
-                "cfg": {
-                    "hideTitleTranslations": true,
-                    "showFeatureInfoTab": false
-                }
+                "name": "LayerSettings"
             },
             {
                 "name": "Widgets"

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
@@ -198,7 +198,17 @@
             "addLayer": "Ebene hinzufügen",
             "datasetsCatalogTitle": "Ebenenkatalog",
             "datasetsCatalogFilterPlaceholder": "Datensätze nach Titel oder Zusammenfassung filtern...",
-            "datasetsCatalogEntriesNoResults": "Keine Ergebnisse entsprechen Ihrer Suche"
+            "datasetsCatalogEntriesNoResults": "Keine Ergebnisse entsprechen Ihrer Suche",
+            "generalSettings": "Allgemeine Einstellungen",
+            "visibilitySettings": "Sichtbarkeitseinstellungen",
+            "styleSettings": "Stileinstellungen",
+            "tilingSettings": "Kacheleinstellungen",
+            "style": "Stil",
+            "legendWidth": "Symbolbreite",
+            "legendHeight": "Symbolhöhe",
+            "legendPreview": "Legendenvorschau",
+            "nodeTooltipContent": "Tooltip-Inhalt",
+            "nodeTooltipPlacement": "Tooltip-Platzierung"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
@@ -199,7 +199,17 @@
             "addLayer": "Add layer",
             "datasetsCatalogTitle": "Layers catalog",
             "datasetsCatalogFilterPlaceholder": "Filter datasets by title or abstract...",
-            "datasetsCatalogEntriesNoResults": "No results match your search"
+            "datasetsCatalogEntriesNoResults": "No results match your search",
+            "generalSettings": "General settings",
+            "visibilitySettings": "Visibility settings",
+            "styleSettings": "Style settings",
+            "tilingSettings": "Tiling settings",
+            "style": "Style",
+            "legendWidth": "Symbol width",
+            "legendHeight": "Symbol height",
+            "legendPreview": "Legend preview",
+            "nodeTooltipContent": "Tooltip content",
+            "nodeTooltipPlacement": "Tooltip placement"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
@@ -198,7 +198,17 @@
             "addLayer": "Agregar capa",
             "datasetsCatalogTitle": "Catálogo de capas",
             "datasetsCatalogFilterPlaceholder": "Filtrar conjuntos de datos por título o resumen ...",
-            "datasetsCatalogEntriesNoResults": "Ningún resultado coincide con su búsqueda"
+            "datasetsCatalogEntriesNoResults": "Ningún resultado coincide con su búsqueda",
+            "generalSettings": "Configuración general",
+            "visibilitySettings": "Configuración de visibilidad",
+            "styleSettings": "Configuración de estilo",
+            "tilingSettings": "Configuración de mosaico",
+            "style": "Estilo",
+            "legendWidth": "Ancho del símbolo",
+            "legendHeight": "Altura del símbolo",
+            "legendPreview": "Vista previa de la leyenda",
+            "nodeTooltipContent": "Contenido de la información sobre herramientas",
+            "nodeTooltipPlacement": "Ubicación de información sobre herramientas"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
@@ -198,7 +198,17 @@
             "addLayer": "Ajouter un calque",
             "datasetsCatalogTitle": "Catalogue de couches",
             "datasetsCatalogFilterPlaceholder": "Filtrer les jeux de données par titre ou résumé...",
-            "datasetsCatalogEntriesNoResults": "Aucun résultat ne correspond à votre recherche"
+            "datasetsCatalogEntriesNoResults": "Aucun résultat ne correspond à votre recherche",
+            "generalSettings": "Paramètres généraux",
+            "visibilitySettings": "Paramètres de visibilité",
+            "styleSettings": "Paramètres de style",
+            "tilingSettings": "Paramètres de mosaïque",
+            "style": "Style",
+            "legendWidth": "Largeur du symbole",
+            "legendHeight": "Hauteur du symbole",
+            "legendPreview": "Aperçu de la légende",
+            "nodeTooltipContent": "Contenu de l'info-bulle",
+            "nodeTooltipPlacement": "Placement de l'info-bulle"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
@@ -200,7 +200,17 @@
             "addLayer": "Aggiungi layer",
             "datasetsCatalogTitle": "Catalogo layers",
             "datasetsCatalogFilterPlaceholder": "Filtra set di dati per titolo o descrizione...",
-            "datasetsCatalogEntriesNoResults": "Nessun risultato corrisponde alla tua ricerca"
+            "datasetsCatalogEntriesNoResults": "Nessun risultato corrisponde alla tua ricerca",
+            "generalSettings": "Impostazioni generali",
+            "visibilitySettings": "Impostazioni visibilità",
+            "styleSettings": "Impostazioni stile",
+            "tilingSettings": "Impostazioni tiling",
+            "style": "Stile",
+            "legendWidth": "Larghezza simbolo",
+            "legendHeight": "Altezza simbolo",
+            "legendPreview": "Anteprima legenda",
+            "nodeTooltipContent": "Contenuto tooltip",
+            "nodeTooltipPlacement": "Posizionamento tooltip"
         }
     }
 }

--- a/geonode_mapstore_client/client/themes/geonode/less/_layer-settings.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_layer-settings.less
@@ -1,0 +1,68 @@
+
+// **************
+// Theme
+// **************
+
+#gn-components-theme(@theme-vars) {
+    .gn-layer-settings {
+        .color-var(@theme-vars[main-color]);
+        .background-color-var(@theme-vars[main-bg]);
+        .gn-layer-settings-section-title {
+            .background-color-var(@theme-vars[main-bg]);
+        }
+    }
+}
+
+// **************
+// Layout
+// **************
+
+.gn-layer-settings {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 2000;
+    width: 350px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    .shadow-soft();
+    .gn-layer-settings-head {
+        display: flex;
+        align-items: center;
+        .gn-layer-settings-title {
+            padding: 0 0.5rem;
+            flex: 1;
+            font-size: @font-size-lg;
+            text-overflow: ellipsis;
+            overflow: hidden;
+        }
+    }
+    .gn-layer-settings-body {
+        position: relative;
+        overflow: auto;
+        flex: 1;
+        padding: 0.5rem;
+        padding-top: 0;
+        label {
+            font-weight: normal;
+            font-size: @font-size-sm;
+        }
+        .form-group {
+            margin-bottom: 0.25rem;
+        }
+        .Select-menu-outer {
+            z-index: 200;
+        }
+        .gn-layer-settings-section-title {
+            cursor: pointer;
+            font-size: @font-size-base;
+            font-weight: bold;
+            margin: 0.5rem 0;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+        }
+    }
+    
+}

--- a/geonode_mapstore_client/client/themes/geonode/less/geonode.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/geonode.less
@@ -10,6 +10,8 @@
 @import '_filter-form.less';
 @import '_footer.less';
 @import '_hero.less';
+@import '_layer-settings.less';
+@import '_legend.less';
 @import '_loader.less';
 @import '_main-event.less';
 @import '_menu.less';
@@ -20,7 +22,6 @@
 @import '_home-container.less';
 @import '_sub-flat-menu.less';
 @import '_visual-style-editor.less';
-@import '_legend.less';
 
 @import '_mixins.less';
 @import '_bootstrap-variables.less';


### PR DESCRIPTION
This PR introduces a new custom layer settings plugin as replacement of TOCItemSettings. The main reason is to have controls on the possible input fields that we can use inside a geonode map context. 