### PR TITLE
Set thumbnail through the set_thumbnail endpoint and add Apply button

### DIFF
--- a/geonode_mapstore_client/client/js/actions/gnresource.js
+++ b/geonode_mapstore_client/client/js/actions/gnresource.js
@@ -29,6 +29,7 @@ export const SET_RESOURCE_COMPACT_PERMISSIONS = 'GEONODE:SET_RESOURCE_COMPACT_PE
 export const UPDATE_RESOURCE_COMPACT_PERMISSIONS = 'GEONODE:UPDATE_RESOURCE_COMPACT_PERMISSIONS';
 export const RESET_GEO_LIMITS = 'GEONODE:RESET_GEO_LIMITS';
 export const PROCESS_RESOURCES = 'GEONODE:PROCESS_RESOURCES';
+export const SET_RESOURCE_THUMBNAIL = 'GEONODE_SET_RESOURCE_THUMBNAIL';
 
 /**
 * Actions for GeoNode resource
@@ -85,11 +86,19 @@ export function editAbstractResource(abstract) {
 * @param {string} image resource
 */
 
-export function editThumbnailResource(thumbnailUrl) {
+export function editThumbnailResource(thumbnailUrl, thumbnailChanged = 'false') {
 
     return {
         type: EDIT_THUMBNAIL_RESOURCE,
-        thumbnailUrl
+        thumbnailUrl,
+        thumbnailChanged
+    };
+}
+
+export function setResourceThumbnail() {
+
+    return {
+        type: SET_RESOURCE_THUMBNAIL
     };
 }
 

--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -272,6 +272,11 @@ export const setMapThumbnail = (pk, body) => {
         .then(({ data }) => (data));
 };
 
+export const setResourceThumbnail = (pk, body) => {
+    return axios.put(parseDevHostname(`${endpoints[RESOURCES]}/${pk}/set_thumbnail`), body)
+        .then(({ data }) => data);
+};
+
 export const setFavoriteResource = (pk, favorite) => {
     const request = favorite ? axios.post : axios.delete;
     return request(parseDevHostname(`${endpoints[RESOURCES]}/${pk}/favorite`))

--- a/geonode_mapstore_client/client/js/components/ContentsEditable/ThumbnailEditable.jsx
+++ b/geonode_mapstore_client/client/js/components/ContentsEditable/ThumbnailEditable.jsx
@@ -38,6 +38,12 @@ const ThumbnailEditable = ({
                     setThumbnail(data);
                     onEdit(data);
                 }}
+                thumbnailOptions={{
+                    contain: false,
+                    width: 250,
+                    height: 184.8,
+                    type: 'image/png'
+                }}
             />
             <ButtonWithToolTip
                 variant="default"

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -60,11 +60,14 @@ const EditAbstract = ({ abstract, onEdit, tagName, disabled }) => (
 );
 
 
-const EditThumbnail = ({ image, onEdit }) => (
+const EditThumbnail = ({ image, onEdit, thumbnailUpdating }) => (
     <div className="editContainer imagepreview">
         <ThumbnailEditable onEdit={onEdit} defaultImage={image} />
+        {thumbnailUpdating && <div className="gn-details-thumbnail-loader">
+            <Loader size={50} />
+        </div>
+        }
     </div>
-
 );
 
 
@@ -190,14 +193,7 @@ const MapThumbnailView = ({ layers, featuresProp = [], onMapThumbnail, onClose, 
                     ]}
                 >
                 </Map>
-                {savingThumbnailMap && <div
-                    style={{
-                        position: 'absolute', width: '100%',
-                        height: '100%', backgroundColor: 'rgba(255, 255, 255, 0.75)',
-                        top: '0px', zIndex: 2000, display: 'flex',
-                        alignItems: 'center', justifyContent: 'center', right: '0px'
-                    }}>
-
+                {savingThumbnailMap && <div className="gn-details-thumbnail-loader">
                     <Loader size={150} />
                 </div>
                 }
@@ -235,7 +231,10 @@ function DetailsPanel({
     enableFavorite,
     onMapThumbnail,
     savingThumbnailMap,
-    layers
+    layers,
+    isThumbnailChanged,
+    onResourceThumbnail,
+    resourceThumbnailUpdating
 }) {
     const detailsContainerNode = useRef();
     const isMounted = useRef();
@@ -262,6 +261,10 @@ function DetailsPanel({
 
     const handleFavorite = () => {
         onFavorite(!favorite);
+    };
+
+    const handleResourceThumbnailUpdate = () => {
+        onResourceThumbnail();
     };
 
     const types = getTypesInfo();
@@ -521,19 +524,24 @@ function DetailsPanel({
                             {!enableMapViewer ? <> <EditThumbnail
                                 onEdit={editThumbnail}
                                 image={resource?.thumbnail_url}
+                                thumbnailUpdating={resourceThumbnailUpdating}
                             />
                             {
                                 (resource.resource_type === ResourceTypes.MAP || resource.resource_type === ResourceTypes.DATASET) &&
-                                ( <MapThumbnailButtonToolTip
+                                ( <><MapThumbnailButtonToolTip
                                     variant="default"
                                     onClick={handleMapViewer}
-                                    className={"map-thumbnail"}
+                                    className="map-thumbnail"
                                     tooltip={<Message msgId="gnviewer.saveMapThumbnail" />}
                                     tooltipPosition={"top"}
                                 >
                                     <FaIcon name="map" />
-                                </MapThumbnailButtonToolTip>)
+                                </MapThumbnailButtonToolTip>
+                                </>)
                             }
+                            {isThumbnailChanged && <Button style={{
+                                left: (resource.resource_type === ResourceTypes.MAP || resource.resource_type === ResourceTypes.DATASET) ? '85px' : '50px'
+                            }} variant="primary" className="map-thumbnail apply-button" onClick={handleResourceThumbnailUpdate}>Apply</Button>}
                             </>
                                 : <MapThumbnailView
                                     layers={layers}
@@ -632,8 +640,10 @@ DetailsPanel.defaultProps = {
     onClose: () => { },
     formatHref: () => '#',
     linkHref: () => '#',
+    onResourceThumbnail: () => '#',
     width: 696,
-    getTypesInfo: getResourceTypesInfo
+    getTypesInfo: getResourceTypesInfo,
+    isThumbnailChanged: false
 };
 
 export default DetailsPanel;

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -541,7 +541,7 @@ function DetailsPanel({
                             }
                             {isThumbnailChanged && <Button style={{
                                 left: (resource.resource_type === ResourceTypes.MAP || resource.resource_type === ResourceTypes.DATASET) ? '85px' : '50px'
-                            }} variant="primary" className="map-thumbnail apply-button" onClick={handleResourceThumbnailUpdate}>Apply</Button>}
+                            }} variant="primary" className="map-thumbnail apply-button" onClick={handleResourceThumbnailUpdate}><Message msgId={"gnhome.apply"} /></Button>}
                             </>
                                 : <MapThumbnailView
                                     layers={layers}

--- a/geonode_mapstore_client/client/js/epics/__tests__/gnresource-test.js
+++ b/geonode_mapstore_client/client/js/epics/__tests__/gnresource-test.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import expect from 'expect';
+import MockAdapter from 'axios-mock-adapter';
+import axios from '@mapstore/framework/libs/ajax';
+import { testEpic } from '@mapstore/framework/epics/__tests__/epicTestUtils';
+import { gnViewerSetNewResourceThumbnail } from '@js/epics/gnresource';
+import { setResourceThumbnail, UPDATE_RESOURCE_PROPERTIES } from '@js/actions/gnresource';
+import {
+    SHOW_NOTIFICATION
+} from '@mapstore/framework/actions/notifications';
+
+let mockAxios;
+
+describe('gnsave epics', () => {
+    beforeEach(done => {
+        global.__DEVTOOLS__ = true;
+        mockAxios = new MockAdapter(axios);
+        setTimeout(done);
+    });
+    afterEach(done => {
+        delete global.__DEVTOOLS__;
+        mockAxios.restore();
+        setTimeout(done);
+    });
+
+    it('should apply new resource thumbnail', (done) => {
+        const NUM_ACTIONS = 2;
+        const pk = 1;
+        const testState = {
+            gnresource: {
+                id: pk,
+                data: {
+                    'title': 'Map',
+                    'thumbnail_url': 'thumbnail.jpeg'
+                }
+            }
+        };
+        mockAxios.onPut(new RegExp(`resources/${pk}/set_thumbnail`))
+            .reply(() => [200, { thumbnail_url: 'test_url' }]);
+
+        testEpic(
+            gnViewerSetNewResourceThumbnail,
+            NUM_ACTIONS,
+            setResourceThumbnail(),
+            (actions) => {
+                try {
+                    expect(actions.map(({ type }) => type))
+                        .toEqual([
+                            UPDATE_RESOURCE_PROPERTIES,
+                            SHOW_NOTIFICATION
+                        ]);
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            },
+            testState
+        );
+    });
+});

--- a/geonode_mapstore_client/client/js/epics/gnsave.js
+++ b/geonode_mapstore_client/client/js/epics/gnsave.js
@@ -53,8 +53,7 @@ import {
     getResourceData,
     getResourceId,
     getDataPayload,
-    getCompactPermissions,
-    getResourceThumbnail
+    getCompactPermissions
 } from '@js/selectors/resource';
 
 import {
@@ -129,7 +128,6 @@ export const gnSaveContent = (action$, store) =>
             const data = getDataPayload(state, contentType);
             const body = {
                 'title': action.metadata.name,
-                ...(action.metadata.thumbnail && { 'thumbnail_url': action.metadata.thumbnail }),
                 ...(action.metadata.description && { 'abstract': action.metadata.description }),
                 ...(data && { 'data': JSON.parse(JSON.stringify(data)) })
             };
@@ -189,19 +187,18 @@ export const gnSetMapThumbnail = (action$, store) =>
             return Observable.defer(() => setMapThumbnail(resourceIDThumbnail, body, contentType))
                 .switchMap((res) => {
                     return Observable.of(
-                        updateResourceProperties({...currentResource, thumbnail_url: `${res.thumbnail_url}?${Math.random()}`}),
+                        updateResourceProperties({ ...currentResource, thumbnail_url: `${res.thumbnail_url}?${Math.random()}` }),
                         clearSave(),
-                        ...([successNotification({title: "gnviewer.thumbnailsaved", message: "gnviewer.thumbnailsaved"})])
+                        ...([successNotification({ title: "gnviewer.thumbnailsaved", message: "gnviewer.thumbnailsaved" })])
 
                     );
                 })
                 .catch((error) => {
                     return Observable.of(
                         saveError(error.data),
-                        errorNotification({title: "gnviewer.thumbnailnotsaved", message: "gnviewer.thumbnailnotsaved"})
+                        errorNotification({ title: "gnviewer.thumbnailnotsaved", message: "gnviewer.thumbnailnotsaved" })
                     );
-                })
-                .startWith();
+                });
         });
 export const gnSaveDirectContent = (action$, store) =>
     action$.ofType(SAVE_DIRECT_CONTENT)
@@ -228,11 +225,9 @@ export const gnSaveDirectContent = (action$, store) =>
                     const geoLimitsErrors = geoLimitsResponses.filter(({ error }) => error);
                     const name = getResourceName(state);
                     const description = getResourceDescription(state);
-                    const thumbnail = getResourceThumbnail(state);
                     const metadata = {
                         name: (name) ? name : resource?.title,
                         description: (description) ? description : resource?.abstract,
-                        ...(thumbnail && { thumbnail }),
                         extension: resource?.extension,
                         href: resource?.href
                     };

--- a/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
+++ b/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
@@ -17,7 +17,8 @@ import {
     editAbstractResource,
     editThumbnailResource,
     setFavoriteResource,
-    setMapThumbnail
+    setMapThumbnail,
+    setResourceThumbnail
 } from '@js/actions/gnresource';
 import FaIcon from '@js/components/FaIcon/FaIcon';
 import controls from '@mapstore/framework/reducers/controls';
@@ -26,7 +27,9 @@ import gnresource from '@js/reducers/gnresource';
 import {
     canEditResource,
     isNewResource,
-    getResourceId
+    getResourceId,
+    isThumbnailChanged,
+    updatingThumbnailResource
 } from '@js/selectors/resource';
 import Button from '@js/components/Button';
 import PropTypes from 'prop-types';
@@ -43,18 +46,23 @@ const ConnectedDetailsPanel = connect(
         state => state?.gnresource?.loading || false,
         state => state?.gnresource?.data?.favorite || false,
         state => state?.gnsave?.savingThumbnailMap || false,
-        layersSelector
-    ], (resource, loading, favorite, savingThumbnailMap, layers) => ({
+        layersSelector,
+        isThumbnailChanged,
+        updatingThumbnailResource
+    ], (resource, loading, favorite, savingThumbnailMap, layers, thumbnailChanged, resourceThumbnailUpdating) => ({
         layers: layers,
         resource,
         loading,
         savingThumbnailMap,
-        favorite
+        favorite,
+        isThumbnailChanged: thumbnailChanged,
+        resourceThumbnailUpdating
     })),
     {
         closePanel: setControlProperty.bind(null, 'rightOverlay', 'enabled', false),
         onFavorite: setFavoriteResource,
-        onMapThumbnail: setMapThumbnail
+        onMapThumbnail: setMapThumbnail,
+        onResourceThumbnail: setResourceThumbnail
     }
 )(DetailsPanel);
 
@@ -111,7 +119,7 @@ function DetailViewer({
         onEditAbstractResource(val);
     };
     const handleEditThumbnail = (val) => {
-        onEditThumbnail(val);
+        onEditThumbnail(val, true);
     };
 
     const node = useDetectClickOut({

--- a/geonode_mapstore_client/client/js/reducers/__tests__/gnresource-test.js
+++ b/geonode_mapstore_client/client/js/reducers/__tests__/gnresource-test.js
@@ -16,7 +16,9 @@ import {
     setResourceType,
     setNewResource,
     setResourceId,
-    setResourcePermissions
+    setResourcePermissions,
+    editThumbnailResource,
+    setResourceThumbnail
 } from '@js/actions/gnresource';
 
 describe('gnresource reducer', () => {
@@ -102,6 +104,27 @@ describe('gnresource reducer', () => {
         const state = gnresource({}, setResourcePermissions(permissions));
         expect(state).toEqual({
             permissions
+        });
+    });
+
+    it('should test editThumbnailResource', () => {
+        const state = gnresource({}, editThumbnailResource('test.url', true));
+
+        expect(state).toEqual({
+            data: {
+                thumbnail_url: 'test.url',
+                thumbnailChanged: true
+            }
+        });
+    });
+
+    it('should test setResourceThumbnail', () => {
+        const state = gnresource({}, setResourceThumbnail());
+
+        expect(state).toEqual({
+            data: {
+                updatingThumbnail: true
+            }
         });
     });
 });

--- a/geonode_mapstore_client/client/js/reducers/gnresource.js
+++ b/geonode_mapstore_client/client/js/reducers/gnresource.js
@@ -19,6 +19,7 @@ import {
     EDIT_TITLE_RESOURCE,
     EDIT_ABSTRACT_RESOURCE,
     EDIT_THUMBNAIL_RESOURCE,
+    SET_RESOURCE_THUMBNAIL,
     SET_SELECTED_DATASET_PERMISSIONS,
     RESET_RESOURCE_STATE,
     LOADING_RESOURCE_CONFIG,
@@ -144,7 +145,18 @@ function gnresource(state = defaultState, action) {
             ...state,
             data: {
                 ...state?.data,
-                thumbnail_url: action?.thumbnailUrl
+                thumbnail_url: action?.thumbnailUrl,
+                thumbnailChanged: action?.thumbnailChanged
+            }
+        };
+    }
+
+    case SET_RESOURCE_THUMBNAIL: {
+        return {
+            ...state,
+            data: {
+                ...state?.data,
+                updatingThumbnail: true
             }
         };
     }

--- a/geonode_mapstore_client/client/js/selectors/__tests__/resource-test.js
+++ b/geonode_mapstore_client/client/js/selectors/__tests__/resource-test.js
@@ -9,13 +9,21 @@
 import expect from 'expect';
 import {
     getViewedResourceType,
-    isNewResource
+    isNewResource,
+    getResourceThumbnail,
+    updatingThumbnailResource,
+    isThumbnailChanged
 } from '../resource';
 
 const testState = {
     gnresource: {
         type: 'testResource',
-        isNew: true
+        isNew: true,
+        data: {
+            thumbnailChanged: true,
+            thumbnail_url: 'thumbnail.jpeg',
+            updatingThumbnail: true
+        }
     }
 };
 
@@ -26,5 +34,17 @@ describe('resource selector', () => {
 
     it('is new resource', () => {
         expect(isNewResource(testState)).toBeTruthy();
+    });
+
+    it('should get thumbnail change status', () => {
+        expect(isThumbnailChanged(testState)).toBeTruthy();
+    });
+
+    it('should get resource thumbnail', () => {
+        expect(getResourceThumbnail(testState)).toBe('thumbnail.jpeg');
+    });
+
+    it('should get resource thumbnail updating status', () => {
+        expect(updatingThumbnailResource(testState)).toBeTruthy();
     });
 });

--- a/geonode_mapstore_client/client/js/selectors/resource.js
+++ b/geonode_mapstore_client/client/js/selectors/resource.js
@@ -45,6 +45,14 @@ export const getResourceThumbnail = (state) => {
     return state?.gnresource?.data?.thumbnail_url || false;
 };
 
+export const updatingThumbnailResource = (state) => {
+    return state?.gnresource?.data?.updatingThumbnail || false;
+};
+
+export const isThumbnailChanged = (state) => {
+    return state?.gnresource?.data?.thumbnailChanged || false;
+};
+
 export const getViewedResourceType = (state) => {
     const viewedResourceType = state?.gnresource?.type || false;
     return viewedResourceType;
@@ -185,11 +193,13 @@ export const getResourceDirtyState = (state) => {
         return null;
     }
     const resourceType = state?.gnresource?.type;
-    const metadataKeys = ['title', 'abstract', 'thumbnail_url', 'data'];
+    const metadataKeys = ['title', 'abstract', 'data'];
     const { data: initialData = {}, ...resource } = pick(state?.gnresource?.initialResource || {}, metadataKeys);
     const { compactPermissions, geoLimits } = getPermissionsPayload(state);
     const currentData = JSON.parse(JSON.stringify(getDataPayload(state) || {})); // JSON stringify is needed to remove undefined values
-    const newMetadata = state?.gnresource?.data || {};
+    // omitting data on thumbnail
+    const thumbnailData = ['thumbnail_url', 'thumbnailChanged', 'updatingThumbnail'];
+    const newMetadata = omit(state?.gnresource?.data, thumbnailData) || {};
     const newResource = pick(newMetadata, metadataKeys);
     const isDataChanged = !isResourceDataEqual(state, initialData, currentData);
     const isMetadataChanged = !!(!isEmpty(newResource) && !isEmpty(resource) && !isEqual(newResource, resource));

--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -113,7 +113,7 @@
             }
         }
 
-        &:last-of-type {
+        &:last-of-type:not(.imagepreview) {
             padding-top: 0.3rem;
             font-size: 0.9rem;
         }
@@ -214,6 +214,10 @@
             opacity: 0.5;
             border-radius: 50%;
 
+            &.apply-button {
+                opacity: 1;
+                border-radius: 3px; 
+            }
         }
         .gn-detail-extent {
             position: relative;
@@ -352,4 +356,17 @@
             z-index: 100;
         }
     }
+}
+
+.gn-details-thumbnail-loader {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(255, 255, 255, 0.75);
+    top: 0px;
+    z-index: 2000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    right: 0px;
 }


### PR DESCRIPTION
This PR updates the client to adopt the new set_thumbnail api. It also implements a contextual Apply button that will be visible only when the thumbnail has been changed.

![Screenshot 2022-01-18 at 12 42 24](https://user-images.githubusercontent.com/42542676/149939446-8b0b6b4b-f3f0-438c-8dbb-c06a4f9ecff3.png)