### PR TITLE
Style Editor improvements

### DIFF
--- a/geonode_mapstore_client/client/js/actions/visualstyleeditor.js
+++ b/geonode_mapstore_client/client/js/actions/visualstyleeditor.js
@@ -7,29 +7,11 @@
 */
 
 export const REQUEST_DATASET_AVAILABLE_STYLES = 'GEONODE:REQUEST_DATASET_AVAILABLE_STYLES';
-export const CREATE_GEONODE_STYLE = 'GEONODE:CREATE_GEONODE_STYLE';
-export const DELETE_GEONODE_STYLE = 'GEONODE:DELETE_GEONODE_STYLE';
 
 export function requestDatasetAvailableStyles(layer, options) {
     return {
         type: REQUEST_DATASET_AVAILABLE_STYLES,
         layer,
-        options
-    };
-}
-
-export function createGeoNodeStyle(title, options) {
-    return {
-        type: CREATE_GEONODE_STYLE,
-        title,
-        options
-    };
-}
-
-export function deleteGeoNodeStyle(styleName, options) {
-    return {
-        type: DELETE_GEONODE_STYLE,
-        styleName,
         options
     };
 }

--- a/geonode_mapstore_client/client/js/plugins/visualstyleeditor/TemplateSelector.jsx
+++ b/geonode_mapstore_client/client/js/plugins/visualstyleeditor/TemplateSelector.jsx
@@ -23,7 +23,6 @@ function TemplateSelector({
     onSelect,
     selectedStyle,
     onUpdateMetadata,
-    onUpdate,
     tmpCode,
     onStoreTmpCode
 }) {
@@ -31,6 +30,7 @@ function TemplateSelector({
     const isMounted = useRef();
     const [templates, setTemplates] = useState([]);
     const [selectedTemplate, setSelectedTemplate] = useState();
+    const [open, setOpen] = useState(false);
 
     useEffect(() => {
         isMounted.current = true;
@@ -47,8 +47,11 @@ function TemplateSelector({
 
     function handleApply() {
         onStoreTmpCode(code);
-        onUpdateMetadata({ styleJSON: null });
-        onUpdate();
+        onUpdateMetadata({
+            styleJSON: null,
+            editorType: 'visual'
+        });
+        setOpen(false);
     }
 
     const storeTmpCode = useRef();
@@ -64,6 +67,7 @@ function TemplateSelector({
     };
 
     function handleOpen(isOpen) {
+        setOpen(isOpen);
         storeTmpCode.current(isOpen);
     }
 
@@ -84,14 +88,16 @@ function TemplateSelector({
         setSelectedTemplate(idx);
         const styleTitle = selectedStyle?.metadata?.title || selectedStyle?.label || selectedStyle?.title || selectedStyle?.name || '';
         getStyleParser(format)
-            .writeStyle({
-                ...templateCode,
-                name: styleTitle
-            })
-            .then((updateCode) => {
-                if (isMounted.current) {
-                    handleSelect(updateCode);
-                }
+            .then(parser => {
+                parser.writeStyle({
+                    ...templateCode,
+                    name: styleTitle
+                })
+                    .then((updateCode) => {
+                        if (isMounted.current) {
+                            handleSelect(updateCode);
+                        }
+                    });
             });
     }
 
@@ -101,7 +107,9 @@ function TemplateSelector({
 
     return (
         <Popover
+            key={open}
             placement="right"
+            open={open}
             onOpen={handleOpen}
             content={
                 <div className="gn-visual-style-editor-templates" >
@@ -124,7 +132,7 @@ function TemplateSelector({
                         })}
                     </ul>
                     <div className="gn-visual-style-editor-templates-footer">
-                        <Button size="xs" disabled={selectedTemplate === undefined} variant="primary" onClick={handleApply}><Message msgId="gnviewer.applyStyle"/></Button>
+                        <Button size="xs" disabled={selectedTemplate === undefined} variant="primary" onClick={handleApply}><Message msgId="gnviewer.copy"/></Button>
                     </div>
                 </div>
             }

--- a/geonode_mapstore_client/client/js/selectors/__tests__/resource-test.js
+++ b/geonode_mapstore_client/client/js/selectors/__tests__/resource-test.js
@@ -47,7 +47,6 @@ describe('resource selector', () => {
     it('is new resource', () => {
         expect(isNewResource(testState)).toBeTruthy();
     });
-  
     it('getGeonodeResourceDataFromGeostory', () => {
         expect(getGeonodeResourceDataFromGeostory(testState)).toEqual([{ data: { sourceId: 'geonode' }, name: 'test' }]);
     });

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -509,25 +509,6 @@ export function toMapStoreMapConfig(resource, baseConfig) {
 }
 
 /**
- * Parse metadata information from getStyleCodeByName api response
- * @param {Array} entry Array containing layer metadata information
- * @returns {Object} metadata object
- */
-export const parseMetadata = ({ entry } = {}) => {
-    const metadata = {};
-    if (!entry) {
-        return metadata;
-    }
-    entry.forEach((entryObj) => {
-        const entryArray = Object.values(entryObj);
-        if (entryArray.length > 1) {
-            metadata[entryArray[0]] = entryArray[1];
-        }
-    });
-    return metadata;
-};
-
-/**
  * Parse document response object (for image and video)
  * @param {Object} docResponse api response object
  * @param {Object} resource optional resource object

--- a/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
@@ -17,8 +17,7 @@ import {
     toGeoNodeMapConfig,
     compareBackgroundLayers,
     toMapStoreMapConfig,
-    parseStyleName,
-    parseMetadata
+    parseStyleName
 } from '../ResourceUtils';
 
 describe('Test Resource Utils', () => {
@@ -409,26 +408,5 @@ describe('Test Resource Utils', () => {
         const pasrsedStyleName = parseStyleName(styleObj);
 
         expect(pasrsedStyleName).toBe('test:testName');
-    });
-
-    it('should extract metadata information from metadata object', () => {
-        const metadata = {
-            entry: [{
-                a: 'key1',
-                b: 'test'
-            },
-            {
-                a: 'key2',
-                b: 'test2'
-            }]
-        };
-
-        const metadataObj = parseMetadata(metadata);
-
-        expect(metadataObj).toEqual({key1: 'test', key2: 'test2'});
-    });
-    it('should return empty object if entry is not defined', () => {
-        const metadataObj = parseMetadata();
-        expect(metadataObj).toEqual({});
     });
 });

--- a/geonode_mapstore_client/client/package.json
+++ b/geonode_mapstore_client/client/package.json
@@ -34,6 +34,7 @@
     "dompurify": "2.2.6",
     "font-awesome": "4.7.0",
     "mapstore": "file:MapStore2",
+    "md5": "^2.3.0",
     "react-helmet": "6.1.0"
   },
   "mapstore": {

--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -1335,10 +1335,6 @@
                             "type": "link",
                             "href": "{'#/dataset/' + (state('gnResourceData') || {}).pk}",
                             "labelId": "gnviewer.goBackTo"
-                        },
-                        {
-                            "type": "plugin",
-                            "name": "SaveStyle"
                         }
                     ],
                     "rightMenuItems": [

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
@@ -202,6 +202,7 @@
             "dismissMessage": "Diese Nachricht nicht mehr anzeigen",
             "templates": "Vorlagen",
             "copyFrom": "Kopie von",
+            "copy": "Kopie",
             "createMap": "Karte Erstellen",
             "addLayer": "Ebene hinzufügen",
             "datasetsCatalogTitle": "Ebenenkatalog",
@@ -242,7 +243,11 @@
             "resourceOrigin": {
                 "a": "eine",
                 "from": "von"
-            }
+            },
+            "styleEditorCloseTitle": "Ausstehende Änderungen",
+            "styleEditorCloseMessage": "Möchten Sie den Stileditor wirklich schließen, ohne die Änderungen zu übernehmen?",
+            "styleEditorCloseCancel": "Nein, zurück zum Stileditor",
+            "styleEditorCloseConfirm": "Ja, schließen"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
@@ -203,6 +203,7 @@
             "dismissMessage": "Don't show this message again",
             "templates": "Templates",
             "copyFrom": "Copy from",
+            "copy": "Copy",
             "createMap": "Create Map",
             "addLayer": "Add layer",
             "datasetsCatalogTitle": "Layers catalog",
@@ -243,7 +244,11 @@
             "resourceOrigin": {
                 "a": "a",
                 "from": "from"
-            }
+            },
+            "styleEditorCloseTitle": "Pending changes",
+            "styleEditorCloseMessage": "Are you sure you want to close the style editor without apply the changes?",
+            "styleEditorCloseCancel": "No, back to the style editor",
+            "styleEditorCloseConfirm": "Yes, close"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
@@ -202,6 +202,7 @@
             "dismissMessage": "No volver a mostrar este mensaje",
             "templates": "Plantillas",
             "copyFrom": "Copiado de",
+            "copy": "Copiado",
             "createMap": "Crear Mapa",
             "addLayer": "Agregar capa",
             "datasetsCatalogTitle": "Catálogo de capas",
@@ -241,7 +242,11 @@
             "resourceOrigin": {
                 "a": "una",
                 "from": "de"
-            }
+            },
+            "styleEditorCloseTitle": "Cambios pendientes",
+            "styleEditorCloseMessage": "¿Está seguro de que desea cerrar el editor de estilos sin aplicar los cambios?",
+            "styleEditorCloseCancel": "No, volver al editor de estilo",
+            "styleEditorCloseConfirm": "Sí, cerrar"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
@@ -202,6 +202,7 @@
             "dismissMessage": "Ne plus afficher ce message",
             "templates": "Modèles",
             "copyFrom": "Copier de",
+            "copy": "Copier",
             "createMap": "Créer une Carte",
             "addLayer": "Ajouter un calque",
             "datasetsCatalogTitle": "Catalogue de couches",
@@ -242,7 +243,11 @@
             "resourceOrigin": {
                 "a": "une",
                 "from": "de"
-            }
+            },
+            "styleEditorCloseTitle": "Modifications en attente",
+            "styleEditorCloseMessage": "Voulez-vous vraiment fermer l'éditeur de style sans appliquer les modifications ?",
+            "styleEditorCloseCancel": "Non, retour à l'éditeur de style",
+            "styleEditorCloseConfirm": "Oui, fermer"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
@@ -204,6 +204,7 @@
             "dismissMessage": "Non mostrare più questo messaggio",
             "templates": "Modelli",
             "copyFrom": "Copia da",
+            "copy": "Copia",
             "createMap": "Crea Mappa",
             "addLayer": "Aggiungi layer",
             "datasetsCatalogTitle": "Catalogo layers",
@@ -244,7 +245,11 @@
             "resourceOrigin": {
                 "a": "una",
                 "from": "di"
-            }
+            },
+            "styleEditorCloseTitle": "Modifiche non applicate",
+            "styleEditorCloseMessage": "Sei sicuro di voler chiudere l'editor di stile senza applicare le modifiche?",
+            "styleEditorCloseCancel": "No, torna all'editor di stile",
+            "styleEditorCloseConfirm": "Sì, chiudi"
         }
     }
 }

--- a/geonode_mapstore_client/client/themes/geonode/less/_visual-style-editor.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_visual-style-editor.less
@@ -9,7 +9,7 @@
     .ms-style-rules-editor-head {
         .background-color-var(@theme-vars[main-bg]);
     }
-    .gn-visual-style-editor-toolbar,
+    .gn-visual-style-editor-layer-info,
     .gn-visual-style-editor-styles {
         .border-bottom-color-var(@theme-vars[main-border-color]);
     }
@@ -41,15 +41,16 @@
 
 .gn-visual-style-editor-layer-info {
     display: flex;
-    padding: 4px;
+    padding: 0;
     align-items: center;
+    border-bottom-width: 1px;
+    border-bottom-style: solid;
     .gn-visual-style-editor-layer-title {
         flex: 1;
-        padding-left: 8px;
+        padding-left: 12px;
     }
 }
 
-.gn-visual-style-editor-toolbar,
 .gn-visual-style-editor-styles,
 .gn-visual-style-editor-alert {
     display: flex;
@@ -62,7 +63,7 @@
     }
 }
 
-.gn-visual-style-editor-toolbar, .gn-visual-style-editor-alert {
+.gn-visual-style-editor-alert {
     align-items: center;
 }
 
@@ -150,4 +151,8 @@
     position: sticky;
     top: 0;
     z-index: 10;
+}
+
+.ms-style-editor-toolbar-left > * + * {
+    margin-left: 4px;
 }


### PR DESCRIPTION
- [x] Align Apply / Copy from buttons with the Code editor selection, both for Maps and Datasets
- [x] Harmonize the positioning of the Copy from panel for Maps and Datasets.
- [x] Remove the spinner from the Apply button and make the Apply button only appear when the style is changed
- [x] Add some spacing between Apply and Copy from buttons
- [x] https://github.com/geosolutions-it/MapStore2/issues/7671
- [x] Remove the zoom to icon and harmonize the close button with the rest