### PR TITLE
[Fixes #756] Timing issues with timeline histogram initialization

### DIFF
--- a/geonode_mapstore_client/client/js/apps/gn-dashboard.js
+++ b/geonode_mapstore_client/client/js/apps/gn-dashboard.js
@@ -26,7 +26,8 @@ import {
 import {
     setupConfiguration,
     initializeApp,
-    getPluginsConfiguration
+    getPluginsConfiguration,
+    storeEpicsCache
 } from '@js/utils/AppUtils';
 import { ResourceTypes } from '@js/utils/ResourceUtils';
 import pluginsDefinition from '@js/plugins/index';
@@ -79,6 +80,14 @@ document.addEventListener('DOMContentLoaded', function() {
                         targetId = 'ms-container',
                         settings
                     }) => {
+
+                        const appEpics = {
+                            ...configEpics,
+                            ...gnresourceEpics
+                        };
+
+                        storeEpicsCache(appEpics);
+
                         import('@js/map/' + mapType + '/plugins/ArcGisMapServer')
                             .then(() => {
                                 main({
@@ -113,10 +122,7 @@ document.addEventListener('DOMContentLoaded', function() {
                                         maptype,
                                         widgets
                                     },
-                                    appEpics: {
-                                        ...configEpics,
-                                        ...gnresourceEpics
-                                    },
+                                    appEpics,
                                     onStoreInit,
                                     geoNodeConfiguration,
                                     initialActions: [

--- a/geonode_mapstore_client/client/js/apps/gn-geostory.js
+++ b/geonode_mapstore_client/client/js/apps/gn-geostory.js
@@ -28,7 +28,8 @@ import gnresourceEpics from '@js/epics/gnresource';
 import {
     setupConfiguration,
     initializeApp,
-    getPluginsConfiguration
+    getPluginsConfiguration,
+    storeEpicsCache
 } from '@js/utils/AppUtils';
 import { ResourceTypes } from '@js/utils/ResourceUtils';
 import pluginsDefinition from '@js/plugins/index';
@@ -79,6 +80,14 @@ document.addEventListener('DOMContentLoaded', function() {
                     targetId = 'ms-container',
                     settings
                 }) => {
+
+                    const appEpics = {
+                        ...configEpics,
+                        ...gnresourceEpics
+                    };
+
+                    storeEpicsCache(appEpics);
+
                     // register custom arcgis layer
                     import('@js/map/' + mapType + '/plugins/ArcGisMapServer')
                         .then(() => {
@@ -113,10 +122,7 @@ document.addEventListener('DOMContentLoaded', function() {
                                     security,
                                     maptype
                                 },
-                                appEpics: {
-                                    ...configEpics,
-                                    ...gnresourceEpics
-                                },
+                                appEpics,
                                 onStoreInit,
                                 geoNodeConfiguration,
                                 initialActions: [

--- a/geonode_mapstore_client/client/js/apps/gn-home.jsx
+++ b/geonode_mapstore_client/client/js/apps/gn-home.jsx
@@ -31,7 +31,8 @@ import {
 
 import {
     setupConfiguration,
-    initializeApp
+    initializeApp,
+    storeEpicsCache
 } from '@js/utils/AppUtils';
 
 const DEFAULT_LOCALE = {};
@@ -65,6 +66,13 @@ Promise.all([
                 securityState,
                 geoNodeConfiguration
             }) => {
+                const appEpics = {
+                    ...gnsearchEpics,
+                    ...gnsaveEpics,
+                    ...resourceServiceEpics
+                };
+
+                storeEpicsCache(appEpics);
                 // home app entry point
                 main({
                     appComponent: withRoutes(routes)(ConnectedRouter),
@@ -83,11 +91,7 @@ Promise.all([
                         security,
                         controls
                     },
-                    appEpics: {
-                        ...gnsearchEpics,
-                        ...gnsaveEpics,
-                        ...resourceServiceEpics
-                    },
+                    appEpics,
                     geoNodeConfiguration
                 });
             });

--- a/geonode_mapstore_client/client/js/apps/gn-map.js
+++ b/geonode_mapstore_client/client/js/apps/gn-map.js
@@ -46,7 +46,8 @@ import { getConfiguration, getAccountInfo } from '@js/api/geonode/v2';
 import {
     setupConfiguration,
     initializeApp,
-    getPluginsConfiguration
+    getPluginsConfiguration,
+    storeEpicsCache
 } from '@js/utils/AppUtils';
 import { ResourceTypes } from '@js/utils/ResourceUtils';
 import { requestResourceConfig } from '@js/actions/gnresource';
@@ -57,6 +58,8 @@ import {
     gnCheckSelectedDatasetPermissions,
     gnSetDatasetsPermissions
 } from '@js/epics';
+
+import timelineEpics from '@mapstore/framework/epics/timeline';
 import gnresourceEpics from '@js/epics/gnresource';
 import maplayout from '@mapstore/framework/reducers/maplayout';
 import 'react-widgets/dist/css/react-widgets.css';
@@ -116,6 +119,20 @@ document.addEventListener('DOMContentLoaded', function() {
 
                     const resourceId = geoNodePageConfig.resourceId;
 
+                    const appEpics = {
+                        ...standardEpics,
+                        ...configEpics,
+                        updateMapLayoutEpic,
+                        gnCheckSelectedDatasetPermissions,
+                        gnSetDatasetsPermissions,
+                        ...gnresourceEpics,
+                        ...pluginsDefinition.epics,
+                        // needed to initialize the correct time range
+                        ...timelineEpics
+                    };
+
+                    storeEpicsCache(appEpics);
+
                     // register custom arcgis layer
                     import('@js/map/' + mapType + '/plugins/ArcGisMapServer')
                         .then(() => {
@@ -165,15 +182,7 @@ document.addEventListener('DOMContentLoaded', function() {
                                     widgets,
                                     ...pluginsDefinition.reducers
                                 },
-                                appEpics: {
-                                    ...standardEpics,
-                                    ...configEpics,
-                                    updateMapLayoutEpic,
-                                    gnCheckSelectedDatasetPermissions,
-                                    gnSetDatasetsPermissions,
-                                    ...gnresourceEpics,
-                                    ...pluginsDefinition.epics
-                                },
+                                appEpics,
                                 geoNodeConfiguration,
                                 initialActions: [
                                     // add some settings in the global state to make them accessible in the monitor state

--- a/geonode_mapstore_client/client/js/hooks/useLazyPlugins.js
+++ b/geonode_mapstore_client/client/js/hooks/useLazyPlugins.js
@@ -11,6 +11,7 @@ import isEmpty from 'lodash/isEmpty';
 import { getPlugins, createPlugin, isMapStorePlugin } from '@mapstore/framework/utils/PluginsUtils';
 import { augmentStore } from '@mapstore/framework/utils/StateUtils';
 import join from 'lodash/join';
+import { getEpicCache, setEpicCache } from '@js/utils/AppUtils';
 
 function filterRemoved(registry, removed = []) {
     return Object.keys(registry).reduce((acc, p) => {
@@ -26,7 +27,6 @@ function filterRemoved(registry, removed = []) {
 
 let storedPlugins = {};
 const pluginsCache = {};
-const epicsCache = {};
 const reducersCache = {};
 
 function useLazyPlugins({
@@ -78,10 +78,10 @@ function useLazyPlugins({
                     // so we need to filter out the one previously added and include only new one
                     const filterOutExistingEpics = Object.keys(epics)
                         .reduce((acc, key) => {
-                            if (epicsCache[key]) {
+                            if (getEpicCache(key)) {
                                 return acc;
                             }
-                            epicsCache[key] = true;
+                            setEpicCache(key);
                             return {
                                 ...acc,
                                 [key]: epics[key]

--- a/geonode_mapstore_client/client/js/utils/AppUtils.js
+++ b/geonode_mapstore_client/client/js/utils/AppUtils.js
@@ -29,6 +29,7 @@ import url from 'url';
 import axios from '@mapstore/framework/libs/ajax';
 import { addLocaleData } from 'react-intl';
 
+let epicsCache = {};
 let actionListeners = {};
 // Target url here to fix proxy issue
 let targetURL = '';
@@ -47,6 +48,15 @@ const getTargetUrl = () => {
     targetURL = `${protocol}//${host}`;
     return targetURL;
 };
+
+export const storeEpicsCache = (epics) => {
+    Object.keys(epics).forEach((key) => {
+        epicsCache[key] = true;
+    });
+};
+
+export const getEpicCache = (name) => epicsCache[name];
+export const setEpicCache = (name) => { epicsCache[name] = true; };
 
 export function getVersion() {
     if (!__DEVTOOLS__) {


### PR DESCRIPTION
The epics stream of the timeline where not ready in time due to an asynchronous import of the timeline plugin. This PR add all the needed epics to the app initialization to ensure the correct setup of the timeline