### PR TITLE
Update mobile structure and configuration

### DIFF
--- a/geonode_mapstore_client/client/js/routes/Viewer.jsx
+++ b/geonode_mapstore_client/client/js/routes/Viewer.jsx
@@ -38,6 +38,21 @@ const ConnectedPluginsContainer = connect(
 )(PluginsContainer);
 
 const DEFAULT_PLUGINS_CONFIG = [];
+
+function getPluginsConfiguration(name, pluginsConfig) {
+    if (!pluginsConfig) {
+        return DEFAULT_PLUGINS_CONFIG;
+    }
+    if (isArray(pluginsConfig)) {
+        return pluginsConfig;
+    }
+    const { isMobile } = getConfigProp('geoNodeSettings') || {};
+    if (isMobile && pluginsConfig) {
+        return pluginsConfig[`${name}_mobile`] || pluginsConfig[name] || DEFAULT_PLUGINS_CONFIG;
+    }
+    return pluginsConfig[name] || DEFAULT_PLUGINS_CONFIG
+}
+
 function ViewerRoute({
     name,
     pluginsConfig: propPluginsConfig,
@@ -56,10 +71,7 @@ function ViewerRoute({
 }) {
 
     const { pk } = match.params || {};
-    const pluginsConfig = isArray(propPluginsConfig)
-        ? propPluginsConfig
-        : propPluginsConfig && propPluginsConfig[name] || DEFAULT_PLUGINS_CONFIG;
-
+    const pluginsConfig = getPluginsConfiguration(name, propPluginsConfig);
 
     const { plugins: loadedPlugins, pending } = useLazyPlugins({
         pluginsEntries: lazyPlugins,

--- a/geonode_mapstore_client/client/js/utils/MenuUtils.js
+++ b/geonode_mapstore_client/client/js/utils/MenuUtils.js
@@ -50,6 +50,10 @@ export function buildHrefByTemplate(state, template, sep = '/') {
 
 export function filterMenuItems(state, item, parent) {
 
+    if (item.disableIf) {
+        return false;
+    }
+
     const isAuthenticated = !parent
         ? item.authenticated
         : parent.authenticated === undefined

--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -319,6 +319,7 @@
                 {
                     "labelId": "gnhome.addResource",
                     "authenticated": true,
+                    "disableIf": "{(state('settings') && state('settings').isMobile ? true : false)}",
                     "type": "dropdown",
                     "variant": "primary",
                     "perms": [
@@ -512,7 +513,66 @@
                 "name": "FitBounds"
             }
         ],
-        "map_preview": "dataset_preview",
+        "map_preview": [
+            {
+                "name": "Map",
+                "cfg": {
+                    "shouldLoadFont": false,
+                    "tools": [
+                        "popup"
+                    ],
+                    "mapOptions": {
+                        "openlayers": {
+                            "attribution": {
+                                "container": "#footer-attribution-container"
+                            },
+                            "interactions": {
+                                "pinchRotate": false,
+                                "altShiftDragRotate": false
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "name": "Identify",
+                "cfg": {
+                    "showInMapPopup": true,
+                    "viewerOptions": {
+                        "container": "{context.ReactSwipe}"
+                    }
+                }
+            },
+            {
+                "name": "Toolbar",
+                "id": "NavigationBar",
+                "cfg": {
+                    "id": "navigationBar"
+                }
+            },
+            {
+                "name": "ZoomIn",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "ZoomOut",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "MapFooter"
+            },
+            {
+                "name": "FitBounds"
+            }
+        ],
         "dataset_embed": [
             {
                 "name": "Map",
@@ -2359,6 +2419,352 @@
             },
             {
                 "name": "Notifications"
+            }
+        ],
+        "map_viewer_mobile": [
+            {
+                "name": "ActionNavbar",
+                "cfg": {
+                    "containerPosition": "header"
+                }
+            },
+            {
+                "name": "Map",
+                "cfg": {
+                    "shouldLoadFont": false,
+                    "mapOptions": {
+                        "openlayers": {
+                            "attribution": {
+                                "container": "#footer-attribution-container"
+                            },
+                            "interactions": {
+                                "pinchRotate": false,
+                                "altShiftDragRotate": false
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "name": "Search",
+                "cfg": {
+                    "withToggle": [
+                        "max-width: 768px",
+                        "min-width: 768px"
+                    ]
+                }
+            },
+            {
+                "name": "OmniBar"
+            },
+            {
+                "name": "Identify",
+                "cfg": {
+                    "showInMapPopup": true,
+                    "viewerOptions": {
+                        "container": "{context.ReactSwipe}"
+                    }
+                }
+            },
+            {
+                "name": "Toolbar",
+                "id": "NavigationBar",
+                "cfg": {
+                    "id": "navigationBar",
+                    "layout": "horizontal"
+                }
+            },
+            {
+                "name": "MapLoading",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "ZoomAll",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": false
+                    }
+                }
+            },
+            {
+                "name": "ZoomIn",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "ZoomOut",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "Expander"
+            },
+            {
+                "name": "MapFooter"
+            },
+            {
+                "name": "TOC",
+                "cfg": {
+                    "activateQueryTool": false,
+                    "activateAddLayerButton": false,
+                    "activateMetedataTool": false,
+                    "activateSettingsTool": false,
+                    "activateRemoveLayer": false,
+                    "activateRemoveGroup": false,
+                    "activateFilterLayer": false
+                }
+            },
+            {
+                "name": "DrawerMenu",
+                "cfg": {
+                    "menuOptions": {
+                        "width": 350
+                    }
+                }
+            },
+            {
+                "name": "FitBounds"
+            },
+            {
+                "name": "Locate"
+            },
+            {
+                "name": "BackgroundSelector",
+                "cfg": {
+                    "bottom": 25,
+                    "dimensions": {
+                        "side": 65,
+                        "sidePreview": 65,
+                        "frame": 3,
+                        "margin": 5,
+                        "label": false,
+                        "vertical": true
+                    }
+                }
+            }
+        ],
+        "dataset_viewer_mobile": [
+            {
+                "name": "ActionNavbar",
+                "cfg": {
+                    "containerPosition": "header"
+                }
+            },
+            {
+                "name": "Map",
+                "cfg": {
+                    "shouldLoadFont": false,
+                    "mapOptions": {
+                        "openlayers": {
+                            "attribution": {
+                                "container": "#footer-attribution-container"
+                            },
+                            "interactions": {
+                                "pinchRotate": false,
+                                "altShiftDragRotate": false
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "name": "Search",
+                "cfg": {
+                    "withToggle": [
+                        "max-width: 768px",
+                        "min-width: 768px"
+                    ]
+                }
+            },
+            {
+                "name": "OmniBar"
+            },
+            {
+                "name": "Identify",
+                "cfg": {
+                    "showInMapPopup": true,
+                    "viewerOptions": {
+                        "container": "{context.ReactSwipe}"
+                    }
+                }
+            },
+            {
+                "name": "Toolbar",
+                "id": "NavigationBar",
+                "cfg": {
+                    "id": "navigationBar",
+                    "layout": "horizontal"
+                }
+            },
+            {
+                "name": "MapLoading",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "ZoomAll",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": false
+                    }
+                }
+            },
+            {
+                "name": "ZoomIn",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "ZoomOut",
+                "override": {
+                    "Toolbar": {
+                        "alwaysVisible": true
+                    }
+                }
+            },
+            {
+                "name": "Expander"
+            },
+            {
+                "name": "MapFooter"
+            },
+            {
+                "name": "Legend",
+                "cfg": {
+                    "hideLayerTitle": true
+                }
+            },
+            {
+                "name": "FitBounds"
+            },
+            {
+                "name": "Locate"
+            },
+            {
+                "name": "BackgroundSelector",
+                "cfg": {
+                    "bottom": 25,
+                    "dimensions": {
+                        "side": 65,
+                        "sidePreview": 65,
+                        "frame": 3,
+                        "margin": 5,
+                        "label": false,
+                        "vertical": true
+                    }
+                }
+            }
+        ],
+        "geostory_viewer_mobile": [
+            {
+                "name": "ActionNavbar",
+                "cfg": {
+                    "containerPosition": "header"
+                }
+            },
+            {
+                "name": "GeoStory",
+                "cfg": {
+                    "mediaEditorSettings": {
+                        "sourceId": "geostory",
+                        "mediaTypes": {
+                            "image": {
+                                "defaultSource": "geostory",
+                                "sources": [
+                                    "geostory",
+                                    "geonode"
+                                ]
+                            },
+                            "video": {
+                                "defaultSource": "geostory",
+                                "sources": [
+                                    "geostory",
+                                    "geonode"
+                                ]
+                            },
+                            "map": {
+                                "defaultSource": "geostory",
+                                "sources": [
+                                    "geostory",
+                                    "geonode"
+                                ]
+                            }
+                        },
+                        "sources": {
+                            "geostory": {
+                                "name": "geostory.storyResources",
+                                "type": "geostory",
+                                "addMediaEnabled": {
+                                    "image": true,
+                                    "video": true
+                                },
+                                "editMediaEnabled": {
+                                    "image": true,
+                                    "video": true
+                                },
+                                "removeMediaEnabled": {
+                                    "image": true,
+                                    "video": true,
+                                    "map": true
+                                }
+                            },
+                            "geonode": {
+                                "name": "geostory.geoNode",
+                                "type": "geonode"
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "name": "GeoStoryNavigation",
+                "cfg": {
+                    "containerPosition": "header"
+                }
+            },
+            {
+                "name": "Notifications"
+            }
+        ],
+        "dashboard_viewer_mobile": [
+            {
+                "name": "ActionNavbar",
+                "cfg": {
+                    "containerPosition": "header"
+                }
+            },
+            {
+                "name": "Dashboard",
+                "cfg": {
+                    "minLayoutWidth": 768
+                }
+            }
+        ],
+        "document_viewer_mobile": [
+            {
+                "name": "ActionNavbar",
+                "cfg": {
+                    "containerPosition": "header"
+                }
+            },
+            {
+                "name": "MediaViewer"
             }
         ]
     }

--- a/geonode_mapstore_client/client/themes/geonode/less/_base.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_base.less
@@ -87,6 +87,14 @@
     text-align: left;
 }
 
+.gn-page-wrapper:not(.gn-legacy) {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 99999;
+}
 .gn-embed,
 .gn-catalogue {
     display: flex;
@@ -95,7 +103,6 @@
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 99999;
     flex-direction: column;
     .gn-footer {
         position: relative;

--- a/geonode_mapstore_client/templates/base.html
+++ b/geonode_mapstore_client/templates/base.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 
-{% block body_extra_class %}gn-legacy gn-theme gn-theme-{{ custom_theme.variant }}{% endblock %}
+{% block body_extra_class %}gn-legacy gn-theme gn-theme-{{ custom_theme.variant }} {% if request.user_agent.is_mobile %}gn-mobile{% else %}gn-desktop{% endif %}{% endblock %}
 
 {% block header %}
 {% include './geonode-mapstore-client/snippets/header.html' %}

--- a/geonode_mapstore_client/templates/documents/document_embed.html
+++ b/geonode_mapstore_client/templates/documents/document_embed.html
@@ -29,34 +29,36 @@
 
     </head>
     <body class="msgapi ms2" data-ms2-container="ms2" >
-        {% block gn_config %}
-            {% include 'geonode-mapstore-client/_geonode_config.html' with plugins_config_key='document_embed' is_embed='true' %}
-        {% endblock %}
-        <div class="gn-embed gn-theme gn-theme-{{ custom_theme.variant }}">
-            {% block container %}
-                <style>
-                    .msgapi .gn-media-viewer {
-                        top: 0;
-                        left: 0;
-                        width: 100%;
-                        height: 100%;
-                        position: absolute;
-                        margin:0;
-                    }
-                </style>
-                <div id="ms-container">
-                    <div class="gn-main-event-container">
-                        <div class="gn-main-event-content">
-                            <div class="gn-main-loader"></div>
-                            <div class="gn-main-event-text"></div>
+        <div class="gn-page-wrapper {% if request.user_agent.is_mobile %}gn-mobile{% else %}gn-desktop{% endif %}">
+            {% block gn_config %}
+                {% include 'geonode-mapstore-client/_geonode_config.html' with plugins_config_key='document_embed' is_embed='true' %}
+            {% endblock %}
+            <div class="gn-embed gn-theme gn-theme-{{ custom_theme.variant }}">
+                {% block container %}
+                    <style>
+                        .msgapi .gn-media-viewer {
+                            top: 0;
+                            left: 0;
+                            width: 100%;
+                            height: 100%;
+                            position: absolute;
+                            margin:0;
+                        }
+                    </style>
+                    <div id="ms-container">
+                        <div class="gn-main-event-container">
+                            <div class="gn-main-event-content">
+                                <div class="gn-main-loader"></div>
+                                <div class="gn-main-event-text"></div>
+                            </div>
                         </div>
                     </div>
-                </div>
-            {% endblock %}
+                {% endblock %}
 
-            {% block ms_scripts %}
-                <script id="gn-script" src="{% static 'mapstore/dist/js/gn-document.js' %}?{% client_version %}"></script>
-            {% endblock %}
+                {% block ms_scripts %}
+                    <script id="gn-script" src="{% static 'mapstore/dist/js/gn-document.js' %}?{% client_version %}"></script>
+                {% endblock %}
+            </div>
         </div>
     </body>
 </html>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -55,6 +55,7 @@
         const siteUrl = '{{ SITEURL }}' || '';
         const siteName = '{{ SITE_NAME }}' || 'Geonode';
         const geoServerPublicLocation = '{{ GEOSERVER_PUBLIC_LOCATION }}' || '';
+        const isMobile = '{{ request.user_agent.is_mobile }}' === 'True' ? true : false;
 
         window.__GEONODE_CONFIG__ = {
             languageCode: '{{ LANGUAGE_CODE }}',
@@ -86,7 +87,8 @@
                     defaultTileSize: defaultTileSize,
                     defaultLayerFormat: defaultLayerFormat,
                     timeEnabled: timeEnabled,
-                    allowedDocumentTypes: allowedDocumentTypes
+                    allowedDocumentTypes: allowedDocumentTypes,
+                    isMobile: isMobile
                 },
                 geoNodeConfiguration: {
                     cardsMenu: {

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/catalogue.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/catalogue.html
@@ -24,41 +24,43 @@
     </head>
 
     <body class="msgapi ms2" data-ms2-container="ms2" >
-        {% block gn_config %}
-            {% include './_geonode_config.html' %}
-        {% endblock %}
-        <div class="gn-catalogue gn-theme gn-theme-{{ custom_theme.variant }}">
-            {% block header %}
-                {% include './snippets/header.html' %}
+        <div class="gn-page-wrapper {% if request.user_agent.is_mobile %}gn-mobile{% else %}gn-desktop{% endif %}">
+            {% block gn_config %}
+                {% include './_geonode_config.html' %}
             {% endblock %}
+            <div class="gn-catalogue gn-theme gn-theme-{{ custom_theme.variant }}">
+                {% block header %}
+                    {% include './snippets/header.html' %}
+                {% endblock %}
 
-            {% block container %}
-                <div id="ms-container">
-                    <div class="gn-main-event-container">
-                        <div class="gn-main-event-content">
-                            <div class="gn-main-loader"></div>
-                            <div class="gn-main-event-text"></div>
+                {% block container %}
+                    <div id="ms-container">
+                        <div class="gn-main-event-container">
+                            <div class="gn-main-event-content">
+                                <div class="gn-main-loader"></div>
+                                <div class="gn-main-event-text"></div>
+                            </div>
                         </div>
                     </div>
-                </div>
-            {% endblock %}
+                {% endblock %}
 
-            {% block ms_scripts %}
-                <script id="gn-script" src="{% static 'mapstore/dist/js/gn-catalogue.js' %}?{% client_version %}"></script>
-            {% endblock %}
+                {% block ms_scripts %}
+                    <script id="gn-script" src="{% static 'mapstore/dist/js/gn-catalogue.js' %}?{% client_version %}"></script>
+                {% endblock %}
 
-            {% block footer %}
-                {% include './snippets/footer.html' %}
-            {% endblock %}
+                {% block footer %}
+                    {% include './snippets/footer.html' %}
+                {% endblock %}
 
-            {% block scripts %}
-                <script src="{% static "lib/js/jquery.min.js" %}"></script>
-                <script src="{% static "lib/js/bootstrap.min.js" %}"></script>
-                <script type="text/javascript">
-                    // enable dropdown functionalities
-                    $('.dropdown-toggle').dropdown();
-                </script>
-            {% endblock %}
+                {% block scripts %}
+                    <script src="{% static "lib/js/jquery.min.js" %}"></script>
+                    <script src="{% static "lib/js/bootstrap.min.js" %}"></script>
+                    <script type="text/javascript">
+                        // enable dropdown functionalities
+                        $('.dropdown-toggle').dropdown();
+                    </script>
+                {% endblock %}
+            </div>
         </div>
     </body>
 </html>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/dashboard_embed.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/dashboard_embed.html
@@ -24,24 +24,26 @@
     </head>
 
     <body class="msgapi ms2" data-ms2-container="ms2" >
-        {% block gn_config %}
-            {% include './_geonode_config.html' with plugins_config_key='dashboard_embed' is_embed='true' %}
-        {% endblock %}
-        <div class="gn-embed gn-theme gn-theme-{{ custom_theme.variant }}">
-            {% block container %}
-                <div id="ms-container">
-                    <div class="gn-main-event-container">
-                        <div class="gn-main-event-content">
-                            <div class="gn-main-loader"></div>
-                            <div class="gn-main-event-text"></div>
+        <div class="gn-page-wrapper {% if request.user_agent.is_mobile %}gn-mobile{% else %}gn-desktop{% endif %}">
+            {% block gn_config %}
+                {% include './_geonode_config.html' with plugins_config_key='dashboard_embed' is_embed='true' %}
+            {% endblock %}
+            <div class="gn-embed gn-theme gn-theme-{{ custom_theme.variant }}">
+                {% block container %}
+                    <div id="ms-container">
+                        <div class="gn-main-event-container">
+                            <div class="gn-main-event-content">
+                                <div class="gn-main-loader"></div>
+                                <div class="gn-main-event-text"></div>
+                            </div>
                         </div>
                     </div>
-                </div>
-            {% endblock %}
+                {% endblock %}
 
-            {% block ms_scripts %}
-                <script id="gn-script" src="{% static 'mapstore/dist/js/gn-dashboard.js' %}?{% client_version %}"></script>
-            {% endblock %}
+                {% block ms_scripts %}
+                    <script id="gn-script" src="{% static 'mapstore/dist/js/gn-dashboard.js' %}?{% client_version %}"></script>
+                {% endblock %}
+            </div>
         </div>
     </body>
 </html>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/dataset_embed.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/dataset_embed.html
@@ -29,24 +29,26 @@
 
     </head>
     <body class="msgapi ms2" data-ms2-container="ms2" >
-        {% block gn_config %}
-            {% include './_geonode_config.html' with plugins_config_key='dataset_embed' is_embed='true' %}
-        {% endblock %}
-        <div class="gn-embed gn-theme gn-theme-{{ custom_theme.variant }}">
-            {% block container %}
-                <div id="ms-container">
-                    <div class="gn-main-event-container">
-                        <div class="gn-main-event-content">
-                            <div class="gn-main-loader"></div>
-                            <div class="gn-main-event-text"></div>
+        <div class="gn-page-wrapper {% if request.user_agent.is_mobile %}gn-mobile{% else %}gn-desktop{% endif %}">
+            {% block gn_config %}
+                {% include './_geonode_config.html' with plugins_config_key='dataset_embed' is_embed='true' %}
+            {% endblock %}
+            <div class="gn-embed gn-theme gn-theme-{{ custom_theme.variant }}">
+                {% block container %}
+                    <div id="ms-container">
+                        <div class="gn-main-event-container">
+                            <div class="gn-main-event-content">
+                                <div class="gn-main-loader"></div>
+                                <div class="gn-main-event-text"></div>
+                            </div>
                         </div>
                     </div>
-                </div>
-            {% endblock %}
+                {% endblock %}
 
-            {% block ms_scripts %}
-                <script id="gn-script" src="{% static 'mapstore/dist/js/gn-map.js' %}?{% client_version %}"></script>
-            {% endblock %}
+                {% block ms_scripts %}
+                    <script id="gn-script" src="{% static 'mapstore/dist/js/gn-map.js' %}?{% client_version %}"></script>
+                {% endblock %}
+            </div>
         </div>
     </body>
 </html>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/geostory_embed.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/geostory_embed.html
@@ -24,24 +24,26 @@
     </head>
 
     <body class="msgapi ms2" data-ms2-container="ms2" >
-        {% block gn_config %}
-            {% include './_geonode_config.html' with plugins_config_key='geostory_embed' is_embed='true' %}
-        {% endblock %}
-        <div class="gn-embed gn-theme gn-theme-{{ custom_theme.variant }}">
-            {% block container %}
-                <div id="ms-container">
-                    <div class="gn-main-event-container">
-                        <div class="gn-main-event-content">
-                            <div class="gn-main-loader"></div>
-                            <div class="gn-main-event-text"></div>
+        <div class="gn-page-wrapper {% if request.user_agent.is_mobile %}gn-mobile{% else %}gn-desktop{% endif %}">
+            {% block gn_config %}
+                {% include './_geonode_config.html' with plugins_config_key='geostory_embed' is_embed='true' %}
+            {% endblock %}
+            <div class="gn-embed gn-theme gn-theme-{{ custom_theme.variant }}">
+                {% block container %}
+                    <div id="ms-container">
+                        <div class="gn-main-event-container">
+                            <div class="gn-main-event-content">
+                                <div class="gn-main-loader"></div>
+                                <div class="gn-main-event-text"></div>
+                            </div>
                         </div>
                     </div>
-                </div>
-            {% endblock %}
+                {% endblock %}
 
-            {% block ms_scripts %}
-                <script id="gn-script" src="{% static 'mapstore/dist/js/gn-geostory.js' %}?{% client_version %}"></script>
-            {% endblock %}
+                {% block ms_scripts %}
+                    <script id="gn-script" src="{% static 'mapstore/dist/js/gn-geostory.js' %}?{% client_version %}"></script>
+                {% endblock %}
+            </div>
         </div>
     </body>
 </html>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/map_embed.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/map_embed.html
@@ -23,24 +23,26 @@
 
     </head>
     <body class="msgapi ms2" data-ms2-container="ms2" >
-        {% block gn_config %}
-            {% include './_geonode_config.html' with plugins_config_key='map_embed' is_embed='true' %}
-        {% endblock %}
-        <div class="gn-embed gn-theme gn-theme-{{ custom_theme.variant }}">
-            {% block container %}
-                <div id="ms-container">
-                    <div class="gn-main-event-container">
-                        <div class="gn-main-event-content">
-                            <div class="gn-main-loader"></div>
-                            <div class="gn-main-event-text"></div>
+        <div class="gn-page-wrapper {% if request.user_agent.is_mobile %}gn-mobile{% else %}gn-desktop{% endif %}">
+            {% block gn_config %}
+                {% include './_geonode_config.html' with plugins_config_key='map_embed' is_embed='true' %}
+            {% endblock %}
+            <div class="gn-embed gn-theme gn-theme-{{ custom_theme.variant }}">
+                {% block container %}
+                    <div id="ms-container">
+                        <div class="gn-main-event-container">
+                            <div class="gn-main-event-content">
+                                <div class="gn-main-loader"></div>
+                                <div class="gn-main-event-text"></div>
+                            </div>
                         </div>
                     </div>
-                </div>
-            {% endblock %}
+                {% endblock %}
 
-            {% block ms_scripts %}
-                <script id="gn-script" src="{% static 'mapstore/dist/js/gn-map.js' %}?{% client_version %}"></script>
-            {% endblock %}
+                {% block ms_scripts %}
+                    <script id="gn-script" src="{% static 'mapstore/dist/js/gn-map.js' %}?{% client_version %}"></script>
+                {% endblock %}
+            </div>
         </div>
     </body>
 </html>

--- a/geonode_mapstore_client/templates/index.html
+++ b/geonode_mapstore_client/templates/index.html
@@ -19,49 +19,53 @@
         {% block extra_style %}
         {% endblock %}
     </head>
-    <body class="gn-theme gn-theme-{{ custom_theme.variant }} gn-homepage ms2">
-        {% include './geonode-mapstore-client/_geonode_config.html' %}
-        {% block header %}
-            {% include './geonode-mapstore-client/snippets/header.html' with show_hero=True %}
-        {% endblock %}
-
-        {% block content %}
-            {% comment %}
-            <!-- example of content extension -->
-            <div class="gn-container">
-                <div class="gn-content">
-                    <!-- My custom content -->
-                </div>
-            </div>
-            {% endcomment %}
-        {% endblock %}
-
-        {% block container %}
-            <div id="container">
-                <div class="gn-main-event-container">
-                    <div class="gn-main-event-content">
-                        <div class="gn-main-loader"></div>
-                        <div class="gn-main-event-text"></div>
+    <body class="msgapi ms2" data-ms2-container="ms2">
+        <div class="gn-page-wrapper {% if request.user_agent.is_mobile %}gn-mobile{% else %}gn-desktop{% endif %}">
+            <div class="gn-theme gn-theme-{{ custom_theme.variant }} gn-homepage">
+                {% include './geonode-mapstore-client/_geonode_config.html' %}
+                {% block header %}
+                    {% include './geonode-mapstore-client/snippets/header.html' with show_hero=True %}
+                {% endblock %}
+    
+                {% block content %}
+                    {% comment %}
+                    <!-- example of content extension -->
+                    <div class="gn-container">
+                        <div class="gn-content">
+                            <!-- My custom content -->
+                        </div>
                     </div>
-                </div>
+                    {% endcomment %}
+                {% endblock %}
+    
+                {% block container %}
+                    <div id="container">
+                        <div class="gn-main-event-container">
+                            <div class="gn-main-event-content">
+                                <div class="gn-main-loader"></div>
+                                <div class="gn-main-event-text"></div>
+                            </div>
+                        </div>
+                    </div>
+                {% endblock %}
+    
+                {% block ms_scripts %}
+                    <script id="gn-script" src="{% static 'mapstore/dist/js/gn-home.js' %}?{% client_version %}"></script>
+                {% endblock %}
+    
+                {% block footer %}
+                    {% include './geonode-mapstore-client/snippets/footer.html' %}
+                {% endblock %}
+    
+                {% block scripts %}
+                    <script src="{% static "lib/js/jquery.min.js" %}"></script>
+                    <script src="{% static "lib/js/bootstrap.min.js" %}"></script>
+                    <script type="text/javascript">
+                        // enable dropdown functionalities
+                        $('.dropdown-toggle').dropdown();
+                    </script>
+                {% endblock %}
             </div>
-        {% endblock %}
-
-        {% block ms_scripts %}
-            <script id="gn-script" src="{% static 'mapstore/dist/js/gn-home.js' %}?{% client_version %}"></script>
-        {% endblock %}
-
-        {% block footer %}
-            {% include './geonode-mapstore-client/snippets/footer.html' %}
-        {% endblock %}
-
-        {% block scripts %}
-            <script src="{% static "lib/js/jquery.min.js" %}"></script>
-            <script src="{% static "lib/js/bootstrap.min.js" %}"></script>
-            <script type="text/javascript">
-                // enable dropdown functionalities
-                $('.dropdown-toggle').dropdown();
-            </script>
-        {% endblock %}
+        </div>
     </body>
 </html>

--- a/geonode_mapstore_client/templates/page.html
+++ b/geonode_mapstore_client/templates/page.html
@@ -20,27 +20,29 @@
         {% endblock %}
     </head>
     <body class="msgapi ms2" data-ms2-container="ms2" >
-        {% include './geonode-mapstore-client/_geonode_config.html' %}
-        <div class="gn-theme gn-theme-light gn-homepage">
-            {% block header %}
-                {% include './geonode-mapstore-client/snippets/header.html' %}
-            {% endblock %}
+        <div class="gn-page-wrapper {% if request.user_agent.is_mobile %}gn-mobile{% else %}gn-desktop{% endif %}">
+            {% include './geonode-mapstore-client/_geonode_config.html' %}
+            <div class="gn-theme gn-theme-{{ custom_theme.variant }} gn-homepage">
+                {% block header %}
+                    {% include './geonode-mapstore-client/snippets/header.html' %}
+                {% endblock %}
 
-            {% block container %}
-            {% endblock %}
+                {% block container %}
+                {% endblock %}
 
-            {% block footer %}
-                {% include './geonode-mapstore-client/snippets/footer.html' %}
-            {% endblock %}
+                {% block footer %}
+                    {% include './geonode-mapstore-client/snippets/footer.html' %}
+                {% endblock %}
 
-            {% block scripts %}
-                <script src="{% static "lib/js/jquery.min.js" %}"></script>
-                <script src="{% static "lib/js/bootstrap.min.js" %}"></script>
-                <script type="text/javascript">
-                    // enable dropdown functionalities
-                    $('.dropdown-toggle').dropdown();
-                </script>
-            {% endblock %}
+                {% block scripts %}
+                    <script src="{% static "lib/js/jquery.min.js" %}"></script>
+                    <script src="{% static "lib/js/bootstrap.min.js" %}"></script>
+                    <script type="text/javascript">
+                        // enable dropdown functionalities
+                        $('.dropdown-toggle').dropdown();
+                    </script>
+                {% endblock %}
+            </div>
         </div>
     </body>
 </html>


### PR DESCRIPTION
This PR introduces following changes:

- a wrapper to the html pages that assign the gn-mobile class to allow customization
- recognize mobile device and apply specific configuration from local config
  - document_viewer_mobile
  - dataset_viewer_mobile
  - map_viewer_mobile
  - geostory_viewer_mobile
  - dashboard_viewer_mobile
- add isMobile variable to global geonode settings

This PR does not included fixes on specific style (eg: top search bar) 