### PR TITLE
Set Dataset subfilter expanded by default and reduce margins

### DIFF
--- a/geonode_mapstore_client/client/js/components/FiltersForm/FilterItems.jsx
+++ b/geonode_mapstore_client/client/js/components/FiltersForm/FilterItems.jsx
@@ -100,6 +100,7 @@ function FilterItems({
                             const active = customFilters.find(value => value === item.id);
                             return (
                                 <Checkbox
+                                    className="gn-sub-filter-items"
                                     type="checkbox"
                                     checked={!!active}
                                     value={item.id}
@@ -137,7 +138,7 @@ function FilterItems({
                                     });
                                 }}>
                                 <Message msgId={field.labelId}/>
-                                {!!active && filterChild()}
+                                {filterChild()}
                             </Checkbox>
                         </FormGroup>
                     );

--- a/geonode_mapstore_client/client/js/components/FiltersMenu/FiltersMenu.jsx
+++ b/geonode_mapstore_client/client/js/components/FiltersMenu/FiltersMenu.jsx
@@ -36,6 +36,15 @@ const FiltersMenu = forwardRef(({
     function handleToggleCardLayoutStyle() {
         setCardLayoutStyle(cardLayoutStyle === 'grid' ? 'list' : 'grid');
     }
+
+    const getFilterButtonContent = () => {
+        const desktop = document.getElementsByClassName('gn-desktop');
+        if (desktop.length > 0) {
+            return 'Filter';
+        }
+        return <FaIcon name="filter" />;
+    };
+
     return (
         <div
             className="gn-filters-menu gn-menu gn-default"
@@ -50,7 +59,7 @@ const FiltersMenu = forwardRef(({
                             size="sm"
                             onClick={onClick}
                         >
-                            <FaIcon name="filter" />
+                            {getFilterButtonContent()}
                         </Button>
                         {' '}
                         <Badge>

--- a/geonode_mapstore_client/client/js/components/FiltersMenu/FiltersMenu.jsx
+++ b/geonode_mapstore_client/client/js/components/FiltersMenu/FiltersMenu.jsx
@@ -11,6 +11,7 @@ import Dropdown from '@js/components/Dropdown';
 import Button from '@js/components/Button';
 import Badge from '@js/components/Badge';
 import Message from '@mapstore/framework/components/I18N/Message';
+import { getConfigProp } from '@mapstore/framework/utils/ConfigUtils';
 import FaIcon from '@js/components/FaIcon';
 import useLocalStorage from '@js/hooks/useLocalStorage';
 import Menu from '@js/components/Menu';
@@ -31,19 +32,12 @@ const FiltersMenu = forwardRef(({
     loading
 }, ref) => {
 
+    const { isMobile } = getConfigProp('geoNodeSettings');
     const selectedSort = orderOptions.find(({ value }) => order === value);
     const [cardLayoutStyle, setCardLayoutStyle] = useLocalStorage('layoutCardsStyle', 'grid');
     function handleToggleCardLayoutStyle() {
         setCardLayoutStyle(cardLayoutStyle === 'grid' ? 'list' : 'grid');
     }
-
-    const getFilterButtonContent = () => {
-        const desktop = document.getElementsByClassName('gn-desktop');
-        if (desktop.length > 0) {
-            return 'Filter';
-        }
-        return <FaIcon name="filter" />;
-    };
 
     return (
         <div
@@ -59,7 +53,7 @@ const FiltersMenu = forwardRef(({
                             size="sm"
                             onClick={onClick}
                         >
-                            {getFilterButtonContent()}
+                            {isMobile ? <FaIcon name="filter" /> : 'Filter'}
                         </Button>
                         {' '}
                         <Badge>

--- a/geonode_mapstore_client/client/themes/geonode/less/_filter-form.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_filter-form.less
@@ -106,3 +106,14 @@
         }
     }
 }
+
+.gn-sub-filter-items.checkbox {
+    
+    &:first-of-type {
+        margin-top: 5px;
+    }
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+}


### PR DESCRIPTION
This PR expands sub filters by default and reduces their top and bottom margins.

![Screenshot 2022-02-03 at 11 15 29](https://user-images.githubusercontent.com/42542676/152332702-2243df5e-37ec-459a-a907-06e009446bcb.png)

- The filter button is also set to an icon on mobile and 'Filter' on desktop.