### PR TITLE
Keep the map state on dataset page if the resource id is the same

### DIFF
--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -1188,6 +1188,9 @@
                 "name": "QueryPanel",
                 "cfg": {
                     "activateQueryTool": true,
+                    "toolsOptions": {
+                        "hideCrossLayer": true
+                    },
                     "spatialOperations": [
                         {
                             "id": "INTERSECTS",


### PR DESCRIPTION
This PR keeps consistent the state of the map if a user switches the dataset page and the resource id is the same