### PR TITLE
Use the permission labels returned by the backend

### DIFF
--- a/geonode_mapstore_client/client/js/components/Permissions/PermissionsRow.jsx
+++ b/geonode_mapstore_client/client/js/components/Permissions/PermissionsRow.jsx
@@ -41,7 +41,7 @@ function PermissionsRow({
             {!hideOptions && <div className="gn-share-permissions-options">
                 <Select
                     clearable={clearable}
-                    options={options.map(({ value, labelId }) => ({ value, label: <Message msgId={labelId} /> }))}
+                    options={options.map(({ value, labelId, label }) => ({ value, label: label ? <span>{label}</span> : <Message msgId={labelId} />}))}
                     value={permissions}
                     onChange={(option) => onChange({ permissions: option?.value || '' })}
                 />

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -356,11 +356,13 @@ export const getResourcePermissions = (options) => {
         const permissions = options[key];
         let selectOptions = [];
         for (let indx = 0; indx < permissions.length; indx++) {
-            const permission = permissions[indx];
+            const permission = permissions[indx].name || permissions[indx];
+            const label = permissions[indx].label
             if (permission !== 'owner') {
                 selectOptions.push({
                     value: permission,
-                    labelId: `gnviewer.${permission}Permission`
+                    labelId: `gnviewer.${permission}Permission`,
+                    label
                 });
             }
         }

--- a/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
@@ -64,8 +64,14 @@ describe('Test Resource Utils', () => {
             allowed_perms: {
                 compact: {
                     test1: [
-                        "none",
-                        "view"
+                        {
+                            name: 'none',
+                            label: 'None'
+                        },
+                        {
+                            name: 'view',
+                            label: 'View'
+                        }
                     ]
                 }
             }
@@ -73,8 +79,8 @@ describe('Test Resource Utils', () => {
         const permissionOptions = getResourcePermissions(data[0].allowed_perms.compact);
         expect(permissionOptions).toEqual({
             test1: [
-                { value: 'none', labelId: `gnviewer.nonePermission` },
-                { value: 'view', labelId: `gnviewer.viewPermission` }
+                { value: 'none', labelId: `gnviewer.nonePermission`, label: 'None' },
+                { value: 'view', labelId: `gnviewer.viewPermission`, label: 'View' }
             ]
         });
     });


### PR DESCRIPTION
The PR adds accommodation for new permissions labels returned by backend