### PR TITLE
[Fixes #828] Flickering of map widgets while using the get feature info

### DIFF
--- a/geonode_mapstore_client/client/js/epics/datasetscatalog.js
+++ b/geonode_mapstore_client/client/js/epics/datasetscatalog.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { SET_CONTROL_PROPERTY } from '@mapstore/framework/actions/controls';
+import { updateMapLayout, UPDATE_MAP_LAYOUT } from '@mapstore/framework/actions/maplayout';
+import { mapLayoutSelector } from '@mapstore/framework/selectors/maplayout';
+import { getConfigProp } from "@mapstore/framework/utils/ConfigUtils";
+
+/**
+* @module epics/datasetcatalog
+*/
+
+/**
+ * Override the layout to get the correct right offset when the data catalog is open
+ */
+export const gnUpdateDatasetsCatalogMapLayout = (action$, store) =>
+    action$.ofType(UPDATE_MAP_LAYOUT, SET_CONTROL_PROPERTY)
+        .filter(() => store.getState()?.controls?.datasetsCatalog?.enabled)
+        .filter(({ source }) => {
+            return source !== 'DatasetsCatalog';
+        })
+        .map(({ layout }) => {
+            const mapLayout = getConfigProp('mapLayout') || { left: { sm: 300, md: 500, lg: 600 }, right: { md: 658 }, bottom: { sm: 30 } };
+            const action = updateMapLayout({
+                ...mapLayoutSelector(store.getState()),
+                ...layout,
+                right: mapLayout.right.md,
+                boundingMapRect: {
+                    ...(layout?.boundingMapRect || {}),
+                    right: mapLayout.right.md
+                }
+            });
+            return { ...action, source: 'DatasetsCatalog' }; // add an argument to avoid infinite loop.
+        });
+
+export default {
+    gnUpdateDatasetsCatalogMapLayout
+};

--- a/geonode_mapstore_client/client/js/epics/index.js
+++ b/geonode_mapstore_client/client/js/epics/index.js
@@ -15,22 +15,13 @@ import { setEditPermissionStyleEditor, INIT_STYLE_SERVICE } from "@mapstore/fram
 import { getSelectedLayer, layersSelector } from "@mapstore/framework/selectors/layers";
 import { getConfigProp } from "@mapstore/framework/utils/ConfigUtils";
 import { getDatasetByName, getDatasetsByName } from '@js/api/geonode/v2';
-import { updateMapLayout } from '@mapstore/framework/actions/maplayout';
-import { TOGGLE_CONTROL, SET_CONTROL_PROPERTY, SET_CONTROL_PROPERTIES } from '@mapstore/framework/actions/controls';
 import { MAP_CONFIG_LOADED } from '@mapstore/framework/actions/config';
-import { SIZE_CHANGE, CLOSE_FEATURE_GRID, OPEN_FEATURE_GRID, setPermission } from '@mapstore/framework/actions/featuregrid';
-import { CLOSE_IDENTIFY, ERROR_FEATURE_INFO, TOGGLE_MAPINFO_STATE, LOAD_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO, PURGE_MAPINFO_RESULTS } from '@mapstore/framework/actions/mapInfo';
-import { SHOW_SETTINGS, HIDE_SETTINGS, SELECT_NODE, updateNode, ADD_LAYER } from '@mapstore/framework/actions/layers';
-import { isMapInfoOpen } from '@mapstore/framework/selectors/mapInfo';
+import { setPermission } from '@mapstore/framework/actions/featuregrid';
+import { SELECT_NODE, updateNode, ADD_LAYER } from '@mapstore/framework/actions/layers';
 import { setSelectedDatasetPermissions } from '@js/actions/gnresource';
-import { isFeatureGridOpen, getDockSize } from '@mapstore/framework/selectors/featuregrid';
-import head from 'lodash/head';
-import get from 'lodash/get';
-
+import { updateMapLayoutEpic as msUpdateMapLayoutEpic } from '@mapstore/framework/epics/maplayout';
 
 // We need to include missing epics. The plugins that normally include this epic is not used.
-
-import { showCoordinateEditorSelector } from '@mapstore/framework/selectors/controls';
 
 /**
 * @module epics/index
@@ -88,78 +79,8 @@ export const gnSetDatasetsPermissions = (actions$, { getState = () => {}} = {}) 
                 });
         });
 
-// Modified to accept map-layout from Config diff less NO_QUERYABLE_LAYERS, SET_CONTROL_PROPERTIES more action$.ofType(PURGE_MAPINFO_RESULTS)
-export const updateMapLayoutEpic = (action$, store) =>
+export const updateMapLayoutEpic = msUpdateMapLayoutEpic;
 
-    action$.ofType(MAP_CONFIG_LOADED, SIZE_CHANGE, SET_CONTROL_PROPERTIES, CLOSE_FEATURE_GRID, OPEN_FEATURE_GRID, CLOSE_IDENTIFY, TOGGLE_MAPINFO_STATE, LOAD_FEATURE_INFO, EXCEPTIONS_FEATURE_INFO, TOGGLE_CONTROL, SET_CONTROL_PROPERTY, SHOW_SETTINGS, HIDE_SETTINGS, ERROR_FEATURE_INFO, PURGE_MAPINFO_RESULTS)
-        .switchMap(() => {
-            const state = store.getState();
-
-            if (get(state, "browser.mobile")) {
-                const bottom = isMapInfoOpen(state) ? { bottom: '50%' } : { bottom: undefined };
-
-                const boundingMapRect = {
-                    ...bottom
-                };
-                return Rx.Observable.of(updateMapLayout({
-                    boundingMapRect
-                }));
-            }
-
-            const mapLayout = getConfigProp("mapLayout") || { left: { sm: 300, md: 500, lg: 600 }, right: { md: 658 }, bottom: { sm: 30 } };
-
-            if (get(state, "mode") === 'embedded') {
-                const height = { height: 'calc(100% - ' + mapLayout.bottom.sm + 'px)' };
-                const bottom = isMapInfoOpen(state) ? { bottom: '50%' } : { bottom: undefined };
-                const boundingMapRect = {
-                    ...bottom
-                };
-                return Rx.Observable.of(updateMapLayout({
-                    ...height,
-                    boundingMapRect
-                }));
-            }
-
-            const resizedDrawer = get(state, "controls.drawer.resizedWidth");
-
-            const leftPanels = head([
-                get(state, "controls.queryPanel.enabled") && { left: mapLayout.left.lg } || null,
-                get(state, "controls.widgetBuilder.enabled") && { left: mapLayout.left.md } || null,
-                get(state, "controls.visualStyleEditor.enabled") && { left: mapLayout.left.md } || null,
-                get(state, "layers.settings.expanded") && { left: mapLayout.left.sm } || null,
-                get(state, "controls.drawer.enabled") && { left: resizedDrawer || mapLayout.left.sm } || null
-            ].filter(panel => panel)) || { left: 0 };
-
-            const rightPanels = head([
-                get(state, "controls.details.enabled") && { right: mapLayout.right.md } || null,
-                get(state, "controls.annotations.enabled") && { right: mapLayout.right.md / 2 } || null,
-                get(state, "controls.metadataexplorer.enabled") && { right: mapLayout.right.md } || null,
-                get(state, "controls.datasetsCatalog.enabled") && { right: mapLayout.right.md } || null,
-                get(state, "controls.measure.enabled") && showCoordinateEditorSelector(state) && { right: mapLayout.right.md } || null,
-                get(state, "mapInfo.enabled") && isMapInfoOpen(state) && { right: mapLayout.right.md } || null
-            ].filter(panel => panel)) || { right: 0 };
-
-            const dockSize = getDockSize(state) * 100;
-            const bottom = isFeatureGridOpen(state) && { bottom: dockSize + '%', dockSize } || { bottom: mapLayout.bottom.sm };
-
-            const transform = isFeatureGridOpen(state) && { transform: 'translate(0, -' + mapLayout.bottom.sm + 'px)' } || { transform: 'none' };
-            const height = { height: 'calc(100% - ' + mapLayout.bottom.sm + 'px)' };
-
-            const boundingMapRect = {
-                ...bottom,
-                ...leftPanels,
-                ...rightPanels
-            };
-
-            return Rx.Observable.of(updateMapLayout({
-                ...leftPanels,
-                ...rightPanels,
-                ...bottom,
-                ...transform,
-                ...height,
-                boundingMapRect
-            }));
-        });
 export default {
     gnCheckSelectedDatasetPermissions,
     updateMapLayoutEpic,

--- a/geonode_mapstore_client/client/js/epics/layersettings.js
+++ b/geonode_mapstore_client/client/js/epics/layersettings.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { updateMapLayout, UPDATE_MAP_LAYOUT } from '@mapstore/framework/actions/maplayout';
+import { mapLayoutSelector } from '@mapstore/framework/selectors/maplayout';
+import { getConfigProp } from "@mapstore/framework/utils/ConfigUtils";
+import { SHOW_SETTINGS } from '@mapstore/framework/actions/layers';
+/**
+* @module epics/layersetting
+*/
+
+/**
+ * Override the layout to get the correct left offset when the layer settings panel is open
+ */
+export const gnUpdateLayerSettingsMapLayout = (action$, store) =>
+    action$.ofType(UPDATE_MAP_LAYOUT, SHOW_SETTINGS)
+        .filter(() => store.getState()?.layers?.settings?.expanded)
+        .filter(({ source }) => {
+            return source !== 'LayerSettings';
+        })
+        .map(({ layout }) => {
+            const mapLayout = getConfigProp('mapLayout') || { left: { sm: 300, md: 500, lg: 600 }, right: { md: 658 }, bottom: { sm: 30 } };
+            const action = updateMapLayout({
+                ...mapLayoutSelector(store.getState()),
+                ...layout,
+                left: mapLayout.left.sm,
+                boundingMapRect: {
+                    ...(layout?.boundingMapRect || {}),
+                    left: mapLayout.left.sm
+                }
+            });
+            return { ...action, source: 'LayerSettings' }; // add an argument to avoid infinite loop.
+        });
+
+export default {
+    gnUpdateLayerSettingsMapLayout
+};

--- a/geonode_mapstore_client/client/js/plugins/DatasetsCatalog.jsx
+++ b/geonode_mapstore_client/client/js/plugins/DatasetsCatalog.jsx
@@ -24,6 +24,7 @@ import { addLayer } from '@mapstore/framework/actions/layers';
 import { zoomToExtent } from '@mapstore/framework/actions/map';
 import { setControlProperty } from '@mapstore/framework/actions/controls';
 import Loader from '@mapstore/framework/components/misc/Loader';
+import datasetscatalogEpics from '@js/epics/datasetscatalog';
 import withDebounceOnCallback from '@mapstore/framework/components/misc/enhancers/withDebounceOnCallback';
 import { mapLayoutValuesSelector } from '@mapstore/framework/selectors/maplayout';
 import localizedProps from '@mapstore/framework/components/misc/enhancers/localizedProps';
@@ -258,6 +259,6 @@ export default createPlugin('DatasetsCatalog', {
             Component: ConnectedDatasetsCatalogButton
         }
     },
-    epics: {},
+    epics: datasetscatalogEpics,
     reducers: {}
 });

--- a/geonode_mapstore_client/client/js/plugins/LayerSettings.jsx
+++ b/geonode_mapstore_client/client/js/plugins/LayerSettings.jsx
@@ -24,6 +24,7 @@ import BaseLayerSettings from '@js/plugins/layersettings/BaseLayerSettings';
 import WMSLayerSettings from '@js/plugins/layersettings/WMSLayerSettings';
 import GeoNodeStyleSelector from '@js/plugins/layersettings/GeoNodeStyleSelector';
 import usePluginItems from '@js/hooks/usePluginItems';
+import layersettingsEpics from '@js/epics/layersettings';
 
 const settingsForms = {
     group: GroupSettings,
@@ -172,6 +173,8 @@ export default createPlugin('LayerSettings', {
             Component: ConnectedLayerSettingsButton
         }
     },
-    epics: {},
+    epics: {
+        ...layersettingsEpics
+    },
     reducers: {}
 });


### PR DESCRIPTION
This PR remove the custom map layout manager to make the layout behaviour aligned with the one from MapStore core framework