### PR TITLE
Implement action to stop upload transfers

### DIFF
--- a/geonode_mapstore_client/client/js/routes/upload/PendingUploadCard.jsx
+++ b/geonode_mapstore_client/client/js/routes/upload/PendingUploadCard.jsx
@@ -22,7 +22,8 @@ function PendingUploadCard({
     filesExt,
     loading,
     progress,
-    size
+    size,
+    onAbort
 }) {
     return (
         <div className="gn-upload-card">
@@ -30,8 +31,10 @@ function PendingUploadCard({
                 {missingExt.length > 0 ? <div className="gn-upload-card-error"><FaIcon name="exclamation"/></div> : null}
                 <div className="gn-upload-card-title">{baseName}</div>
                 {onRemove
-                    ? <Button size="xs" onClick={onRemove}>
+                    ? (!loading || !(progress?.[baseName])) ? <Button size="xs" onClick={onRemove}>
                         <FaIcon name="trash"/>
+                    </Button> : <Button size="xs" onClick={() => onAbort(baseName)}>
+                        <FaIcon name="stop"/>
                     </Button>
                     : null}
             </div>
@@ -51,14 +54,14 @@ function PendingUploadCard({
                     })}
                 </ul>
                 {
-                    (loading && progress) ?
+                    (loading && progress && progress?.[baseName]) ?
                         <div className="gn-upload-card-progress-read">
-                            {progress?.[baseName] ? `${progress?.[baseName]}%` : <Spinner />}
+                            {progress[baseName] ? `${progress[baseName]}%` : <Spinner />}
                         </div> :
                         <div>{size}{' '}MB</div>
                 }
             </div>
-            {loading && progress && <div style={{position: 'relative'}}>
+            {loading && progress && progress?.[baseName] && <div style={{position: 'relative'}}>
                 <div
                     className="gn-upload-card-progress"
                     style={{
@@ -68,7 +71,7 @@ function PendingUploadCard({
                 >
                     <div
                         style={{
-                            width: `${progress?.[baseName]}%`,
+                            width: `${progress[baseName]}%`,
                             height: 2,
                             transition: '0.3s all'
                         }}

--- a/geonode_mapstore_client/client/js/routes/upload/UploadContainer.jsx
+++ b/geonode_mapstore_client/client/js/routes/upload/UploadContainer.jsx
@@ -40,7 +40,9 @@ function UploadContainer({
     onUpload,
     loading,
     progress,
-    type
+    type,
+    abort,
+    abortAll
 }) {
 
     const inputFile = useRef();
@@ -94,7 +96,7 @@ function UploadContainer({
                 leftColumn={
                     <div className="gn-upload-list">
                         <div className="gn-upload-list-header">
-                            <input ref={inputFile} value="" type="file" multiple onChange={handleFileDrop} style={{ display: 'none' }}/>
+                            <input disabled={loading} ref={inputFile} value="" type="file" multiple onChange={handleFileDrop} style={{ display: 'none' }}/>
                             <Button onClick={() => inputFile?.current?.click()}>
                                 <FaIcon name="plus"/>{' '}<Message msgId="gnviewer.selectFiles"/>
                             </Button>
@@ -117,6 +119,7 @@ function UploadContainer({
                                                 loading={loading}
                                                 progress={progress}
                                                 size={size}
+                                                onAbort={abort}
                                             />
                                         </li>
                                     );
@@ -146,32 +149,19 @@ function UploadContainer({
                                 <ButtonWithTooltip noTooltipWhenDisabled tooltip={<Message msgId="gnviewer.exceedingFileMsg" msgParams={{limit: maxAllowedSize }} />} >
                                     <Message msgId="gnviewer.upload" />
                                 </ButtonWithTooltip> :
-                                <Button
+                                !loading ? <Button
                                     variant="primary"
                                     disabled={disabledUpload}
                                     onClick={onUpload}
                                 >
                                     <Message msgId="gnviewer.upload"/>
+                                </Button> : <Button
+                                    variant="primary"
+                                    onClick={() => abortAll(waitingUploadNames)}
+                                >
+                                    <Message msgId="gnviewer.cancelUpload"/>
                                 </Button>}
                         </div>
-                        {loading && (
-                            <div
-                                style={{
-                                    position: 'absolute',
-                                    width: '100%',
-                                    height: '100%',
-                                    display: 'flex',
-                                    alignItems: 'flex-end',
-                                    justifyContent: 'center',
-                                    padding: '1rem',
-                                    textAlign: 'center',
-                                    backgroundColor: 'rgba(0, 0, 0, 0.2)',
-                                    paddingBottom: '3rem'
-                                }}
-                            >
-                                <Message msgId="gnviewer.transferInProgress"/>
-                            </div>
-                        )}
                     </div>
                 }
             >

--- a/geonode_mapstore_client/client/js/routes/upload/UploadListContainer.jsx
+++ b/geonode_mapstore_client/client/js/routes/upload/UploadListContainer.jsx
@@ -34,7 +34,7 @@ function UploadListContainer({
 
     return (
         <div className="gn-upload-processing">
-            {pendingUploads.length === 0
+            {pendingUploads.length === 0 || (filteredPendingUploads.every(({error}) => error === 'CANCELED'))
                 ? (
                     <div className="gn-main-event-container">
                         <div className="gn-main-event-content">
@@ -72,7 +72,7 @@ function UploadListContainer({
                                             delete_url: deleteUrl,
                                             error
                                         }) => {
-                                            return (
+                                            return (error !== 'CANCELED' &&
                                                 <li
                                                     key={id}
                                                 >

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
@@ -274,7 +274,8 @@
             "transferInProgress": "Übertragung läuft",
             "fileExceeds": "Die Dateigröße überschreitet {limit} MB. Bitte versuchen Sie es erneut mit einer kleineren Datei.",
             "exceedingFileMsg": "Algunos de sus archivos exceden el límite de carga de {limit} MB. Por favor, elimínelos de la lista.",
-            "cannotPerfomAction": "Die Aktion für diese Ressource konnte nicht ausgeführt werden."
+            "cannotPerfomAction": "Die Aktion für diese Ressource konnte nicht ausgeführt werden.",
+            "cancelUpload": "Hochladen abbrechen"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
@@ -274,7 +274,8 @@
             "transferInProgress": "Transfer in progress",
             "fileExceeds": "File size size exceeds {limit} MB. Please try again with a smaller file.",
             "exceedingFileMsg": "Some of your files exceed the upload limit of {limit} MB. Please remove them from the list.",
-            "cannotPerfomAction": "Failed to perform action on this resource."
+            "cannotPerfomAction": "Failed to perform action on this resource.",
+            "cancelUpload": "Cancel upload"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
@@ -272,7 +272,8 @@
             "transferInProgress": "Transferencia en progreso",
             "fileExceeds": "El tamaño del archivo supera los {limit} MB. Vuelva a intentarlo con un archivo más pequeño.",
             "exceedingFileMsg": "Algunos de sus archivos exceden el límite de carga de {limit} MB. Por favor, elimínelos de la lista.",
-            "cannotPerfomAction": "No se pudo realizar la acción en este recurso."
+            "cannotPerfomAction": "No se pudo realizar la acción en este recurso.",
+            "cancelUpload": "Cancelar carga"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
@@ -273,7 +273,8 @@
             "transferInProgress": "Transfert en cours",
             "fileExceeds": "La taille du fichier dépasse {Limit} Mo. Veuillez réessayer avec un fichier plus petit.",
             "exceedingFileMsg": "Certains de vos fichiers dépassent la limite de téléchargement de {limit} Mo. Veuillez les supprimer de la liste.",
-            "cannotPerfomAction": "Échec de l'exécution de l'action sur cette ressource."
+            "cannotPerfomAction": "Échec de l'exécution de l'action sur cette ressource.",
+            "cancelUpload": "Annuler le téléchargement"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
@@ -275,7 +275,8 @@
             "transferInProgress": "Trasferimento in corso",
             "fileExceeds": "La dimensione del file supera i {limit} MB. Riprova con un file più piccolo.",
             "exceedingFileMsg": "Alcuni dei tuoi file superano il limite di caricamento di {limit} MB. Si prega di rimuoverli dall'elenco.",
-            "cannotPerfomAction": "Impossibile eseguire l'azione su questa risorsa."
+            "cannotPerfomAction": "Impossibile eseguire l'azione su questa risorsa.",
+            "cancelUpload": "Annulla caricamento"
         }
     }
 }


### PR DESCRIPTION
This PR introduces a 'Cancel Upload' feature for datasets and documents to:
- stop single upload transfer
- stop all the upload transfers