### PR TITLE
If a request to delete an upload fails the card must be removed from the uploads list

### DIFF
--- a/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
+++ b/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
@@ -335,7 +335,7 @@ function ProcessingUploadList({
 
     function handleDelete({ id, deleteUrl }) {
         axios.get(deleteUrl)
-            .then(() => {
+            .finally(() => {
                 if (isMounted.current) {
                     setDeletedIds((ids) => [...ids, id]);
                     onChange(pendingUploads.filter(upload => upload.id !== id));


### PR DESCRIPTION
This PR implements the removal of deleted uploads from list no matter the response from the endpoint. In cases where the removal is unsuccessful due to a failure on the server, if the upload still continues to be processed, the client will put back its respective card.