### PR TITLE
Implement a check for default upload parallelism limit on making uploads

### DIFF
--- a/geonode_mapstore_client/client/js/routes/UploadDocument.jsx
+++ b/geonode_mapstore_client/client/js/routes/UploadDocument.jsx
@@ -149,6 +149,8 @@ function UploadList({
         return files.forEach((file) => sources[file].cancel());
     }, []);
 
+    const { maxParallelUploads } = getConfigProp('geoNodeSettings');
+
     return (
         <UploadContainer
             waitingUploads={waitingUploads}
@@ -157,6 +159,7 @@ function UploadList({
             onRemove={(baseName) => removeFile(waitingUploads, baseName)}
             unsupported={unsupported}
             disabledUpload={Object.keys(waitingUploads).length === 0}
+            disableOnParallelLmit={Object.keys(waitingUploads).length > maxParallelUploads}
             onUpload={handleUploadProcess}
             loading={loading}
             progress={uploadContainerProgress}

--- a/geonode_mapstore_client/client/js/routes/upload/UploadCard.jsx
+++ b/geonode_mapstore_client/client/js/routes/upload/UploadCard.jsx
@@ -38,7 +38,7 @@ function UploadCard({
     type
 }) {
 
-    const { datasetMaxUploadSize, documentMaxUploadSize } = getConfigProp('geoNodeSettings');
+    const { datasetMaxUploadSize, documentMaxUploadSize, maxParallelUploads } = getConfigProp('geoNodeSettings');
     const maxAllowedBytes = type !== 'document' ? datasetMaxUploadSize : documentMaxUploadSize;
     const maxAllowedSize = Math.floor(maxAllowedBytes / (1024 * 1024));
 
@@ -49,6 +49,16 @@ function UploadCard({
             fileExceeds = true;
         }
         return fileExceeds;
+    };
+
+    const errorToolTip = ({ code }) => {
+        switch (code) {
+        case "upload_parallelism_limit_exceeded": {
+            return "gnviewer.parallelLimitError";
+        }
+        default:
+            return "gnviewer.invalidUploadMessageErrorTooltip";
+        }
     };
 
     return (
@@ -97,7 +107,7 @@ function UploadCard({
                         </Button>
                         : null}
                     {state === 'INVALID'
-                        ? exceedingSizeError(error) ? <ErrorMessageWithTooltip tooltip={<Message msgId="gnviewer.fileExceeds" msgParams={{limit: maxAllowedSize }} />} /> : <ErrorMessageWithTooltip tooltipId="gnviewer.invalidUploadMessageErrorTooltip" />
+                        ? exceedingSizeError(error) ? <ErrorMessageWithTooltip tooltip={<Message msgId="gnviewer.fileExceeds" msgParams={{limit: maxAllowedSize }} />} /> : <ErrorMessageWithTooltip tooltipId={<Message msgId={errorToolTip(error)} msgParams={{ limit: maxParallelUploads }} />} />
                         : null}
                 </div>
             </div>

--- a/geonode_mapstore_client/client/js/routes/upload/UploadContainer.jsx
+++ b/geonode_mapstore_client/client/js/routes/upload/UploadContainer.jsx
@@ -37,6 +37,7 @@ function UploadContainer({
     onRemove,
     unsupported,
     disabledUpload,
+    disableOnParallelLmit,
     onUpload,
     loading,
     progress,
@@ -62,7 +63,7 @@ function UploadContainer({
         return Math.ceil(bytes / (1024 * 1024));
     };
 
-    const { datasetMaxUploadSize, documentMaxUploadSize } = getConfigProp('geoNodeSettings');
+    const { datasetMaxUploadSize, documentMaxUploadSize, maxParallelUploads } = getConfigProp('geoNodeSettings');
     const maxAllowedBytes = type === 'dataset' ? datasetMaxUploadSize : documentMaxUploadSize;
     const maxAllowedSize = Math.floor(maxAllowedBytes / (1024 * 1024));
 
@@ -91,14 +92,15 @@ function UploadContainer({
             activeClassName="gn-dropzone-active"
             rejectClassName="gn-dropzone-reject"
             disableClick
+            maxFiles={maxParallelUploads}
         >
             <ViewerLayout
                 leftColumn={
                     <div className="gn-upload-list">
                         <div className="gn-upload-list-header">
-                            <input disabled={loading} ref={inputFile} value="" type="file" multiple onChange={handleFileDrop} style={{ display: 'none' }}/>
+                            <input disabled={loading} ref={inputFile} value="" type="file" multiple onChange={handleFileDrop} style={{ display: 'none' }} />
                             <Button onClick={() => inputFile?.current?.click()}>
-                                <FaIcon name="plus"/>{' '}<Message msgId="gnviewer.selectFiles"/>
+                                <FaIcon name="plus" />{' '}<Message msgId="gnviewer.selectFiles" />
                             </Button>
                         </div>
                         {waitingUploadNames.length > 0 ? (
@@ -138,29 +140,34 @@ function UploadContainer({
                                     textAlign: 'center'
                                 }}
                             >
-                                <div><Message msgId="gnviewer.supportedFiles"/>: {supportedLabels}</div>
+                                <div><Message msgId="gnviewer.supportedFiles" />: {supportedLabels}</div>
                             </div>
                         )}
                         <div className="gn-upload-list-footer">
                             {unsupported.length > 0 ? <Alert bsStyle="danger">
-                                <Message msgId="gnviewer.unsupportedFiles"/>: {unsupported.map(({ file }) => file?.name).join(', ')}
+                                <Message msgId="gnviewer.unsupportedFiles" />: {unsupported.map(({ file }) => file?.name).join(', ')}
                             </Alert> : null}
                             {(waitingUploadNames.length > 0 && getExceedingFileSize(waitingUploadNames, maxAllowedSize)) ?
-                                <ButtonWithTooltip noTooltipWhenDisabled tooltip={<Message msgId="gnviewer.exceedingFileMsg" msgParams={{limit: maxAllowedSize }} />} >
+                                <ButtonWithTooltip noTooltipWhenDisabled tooltip={<Message msgId="gnviewer.exceedingFileMsg" msgParams={{ limit: maxAllowedSize }} />} >
                                     <Message msgId="gnviewer.upload" />
-                                </ButtonWithTooltip> :
-                                !loading ? <Button
-                                    variant="primary"
-                                    disabled={disabledUpload}
-                                    onClick={onUpload}
-                                >
-                                    <Message msgId="gnviewer.upload"/>
-                                </Button> : <Button
-                                    variant="primary"
-                                    onClick={() => abortAll(waitingUploadNames)}
-                                >
-                                    <Message msgId="gnviewer.cancelUpload"/>
-                                </Button>}
+                                </ButtonWithTooltip>
+                                : disableOnParallelLmit ?
+                                    <ButtonWithTooltip noTooltipWhenDisabled tooltip={<Message msgId="gnviewer.parallelUploadLimit" msgParams={{ limit: maxParallelUploads }} />} >
+                                        <Message msgId="gnviewer.upload" />
+                                    </ButtonWithTooltip>
+                                    :
+                                    !loading ? <Button
+                                        variant="primary"
+                                        disabled={disabledUpload}
+                                        onClick={onUpload}
+                                    >
+                                        <Message msgId="gnviewer.upload" />
+                                    </Button> : <Button
+                                        variant="primary"
+                                        onClick={() => abortAll(waitingUploadNames)}
+                                    >
+                                        <Message msgId="gnviewer.cancelUpload" />
+                                    </Button>}
                         </div>
                     </div>
                 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
@@ -275,7 +275,9 @@
             "fileExceeds": "Die Dateigröße überschreitet {limit} MB. Bitte versuchen Sie es erneut mit einer kleineren Datei.",
             "exceedingFileMsg": "Algunos de sus archivos exceden el límite de carga de {limit} MB. Por favor, elimínelos de la lista.",
             "cannotPerfomAction": "Die Aktion für diese Ressource konnte nicht ausgeführt werden.",
-            "cancelUpload": "Hochladen abbrechen"
+            "cancelUpload": "Hochladen abbrechen",
+            "parallelUploadLimit": "Die ausgewählte Anzahl von Dateien überschreitet das zulässige Limit von {limit} Dateien. Bitte entfernen Sie einige Dateien aus der Liste.",
+            "parallelLimitError": "Die Anzahl aktiver paralleler Uploads überschreitet {limit}. Warten Sie, bis die ausstehenden abgeschlossen sind."
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
@@ -275,7 +275,9 @@
             "fileExceeds": "File size size exceeds {limit} MB. Please try again with a smaller file.",
             "exceedingFileMsg": "Some of your files exceed the upload limit of {limit} MB. Please remove them from the list.",
             "cannotPerfomAction": "Failed to perform action on this resource.",
-            "cancelUpload": "Cancel upload"
+            "cancelUpload": "Cancel upload",
+            "parallelUploadLimit": "The selected number of files exceeds the allowed limit of {limit} files. Please remove some files from the list.",
+            "parallelLimitError": "The number of active parallel uploads exceeds {limit}. Wait for the pending ones to finish."
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
@@ -273,7 +273,9 @@
             "fileExceeds": "El tamaño del archivo supera los {limit} MB. Vuelva a intentarlo con un archivo más pequeño.",
             "exceedingFileMsg": "Algunos de sus archivos exceden el límite de carga de {limit} MB. Por favor, elimínelos de la lista.",
             "cannotPerfomAction": "No se pudo realizar la acción en este recurso.",
-            "cancelUpload": "Cancelar carga"
+            "cancelUpload": "Cancelar carga",
+            "parallelUploadLimit": "El número de archivos seleccionado supera el límite permitido de {limit} archivos. Elimine algunos archivos de la lista.",
+            "parallelLimitError": "El número de subidas paralelas activas supera {limit}. Espera a que terminen las pendientes."
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
@@ -274,7 +274,9 @@
             "fileExceeds": "La taille du fichier dépasse {Limit} Mo. Veuillez réessayer avec un fichier plus petit.",
             "exceedingFileMsg": "Certains de vos fichiers dépassent la limite de téléchargement de {limit} Mo. Veuillez les supprimer de la liste.",
             "cannotPerfomAction": "Échec de l'exécution de l'action sur cette ressource.",
-            "cancelUpload": "Annuler le téléchargement"
+            "cancelUpload": "Annuler le téléchargement",
+            "parallelUploadLimit": "Le nombre de fichiers sélectionné dépasse la limite autorisée de {limit} fichiers. Veuillez supprimer certains fichiers de la liste.",
+            "parallelLimitError": "Le nombre de téléchargements parallèles actifs dépasse {limit}. Attendez que ceux en attente se terminent."
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
@@ -276,7 +276,9 @@
             "fileExceeds": "La dimensione del file supera i {limit} MB. Riprova con un file più piccolo.",
             "exceedingFileMsg": "Alcuni dei tuoi file superano il limite di caricamento di {limit} MB. Si prega di rimuoverli dall'elenco.",
             "cannotPerfomAction": "Impossibile eseguire l'azione su questa risorsa.",
-            "cancelUpload": "Annulla caricamento"
+            "cancelUpload": "Annulla caricamento",
+            "parallelUploadLimit": "Il numero selezionato di file supera il limite consentito di {limit} file. Si prega di rimuovere alcuni file dall'elenco.",
+            "parallelLimitError": "Il numero di caricamenti paralleli attivi supera {limit}. Aspetta che quelli in sospeso finiscano."
         }
     }
 }


### PR DESCRIPTION
This PR implements parallel upload limit to prevent users from uploading more than the allows number of files at once. A user receives relevant error messages on exceeding the `maxParallelUploads`