### PR TITLE
Geostory editing: investigate if it's possible to maintain the origin when switching between resource type selection

### DIFF
--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -763,24 +763,21 @@
                 "name": "GeoStory",
                 "cfg": {
                     "mediaEditorSettings": {
-                        "sourceId": "geostory",
+                        "sourceId": "geonode",
                         "mediaTypes": {
                             "image": {
-                                "defaultSource": "geostory",
                                 "sources": [
                                     "geostory",
                                     "geonode"
                                 ]
                             },
                             "video": {
-                                "defaultSource": "geostory",
                                 "sources": [
                                     "geostory",
                                     "geonode"
                                 ]
                             },
                             "map": {
-                                "defaultSource": "geostory",
                                 "sources": [
                                     "geostory",
                                     "geonode"
@@ -2258,24 +2255,21 @@
                 "name": "GeoStory",
                 "cfg": {
                     "mediaEditorSettings": {
-                        "sourceId": "geostory",
+                        "sourceId": "geonode",
                         "mediaTypes": {
                             "image": {
-                                "defaultSource": "geostory",
                                 "sources": [
                                     "geostory",
                                     "geonode"
                                 ]
                             },
                             "video": {
-                                "defaultSource": "geostory",
                                 "sources": [
                                     "geostory",
                                     "geonode"
                                 ]
                             },
                             "map": {
-                                "defaultSource": "geostory",
                                 "sources": [
                                     "geostory",
                                     "geonode"
@@ -2857,24 +2851,21 @@
                 "name": "GeoStory",
                 "cfg": {
                     "mediaEditorSettings": {
-                        "sourceId": "geostory",
+                        "sourceId": "geonode",
                         "mediaTypes": {
                             "image": {
-                                "defaultSource": "geostory",
                                 "sources": [
                                     "geostory",
                                     "geonode"
                                 ]
                             },
                             "video": {
-                                "defaultSource": "geostory",
                                 "sources": [
                                     "geostory",
                                     "geonode"
                                 ]
                             },
                             "map": {
-                                "defaultSource": "geostory",
                                 "sources": [
                                     "geostory",
                                     "geonode"


### PR DESCRIPTION
PR sets Geonode as origin and maintains selected origin in geostory editing as shown below:

![origin](https://user-images.githubusercontent.com/42542676/158990883-f3beafd3-1576-4ae4-b948-6c31b45ba450.gif)
