### PR TITLE
Added global extensions folder

### DIFF
--- a/geonode_mapstore_client/client/package.json
+++ b/geonode_mapstore_client/client/package.json
@@ -26,7 +26,7 @@
   "author": "GeoSolutions",
   "license": "BSD-2-Clause",
   "devDependencies": {
-    "@mapstore/project": "^1.0.21",
+    "@mapstore/project": "1.0.21",
     "dotenv": "10.0.0",
     "jsdoc-to-markdown": "7.1.0"
   },

--- a/geonode_mapstore_client/client/package.json
+++ b/geonode_mapstore_client/client/package.json
@@ -26,7 +26,7 @@
   "author": "GeoSolutions",
   "license": "BSD-2-Clause",
   "devDependencies": {
-    "@mapstore/project": "1.0.20",
+    "@mapstore/project": "^1.0.21",
     "dotenv": "10.0.0",
     "jsdoc-to-markdown": "7.1.0"
   },

--- a/geonode_mapstore_client/context_processors.py
+++ b/geonode_mapstore_client/context_processors.py
@@ -37,6 +37,7 @@ def resource_urls(request):
         'TRANSLATIONS_PATH': getattr(settings, "MAPSTORE_TRANSLATIONS_PATH", ['/static/mapstore/ms-translations', '/static/mapstore/gn-translations']),
         'PROJECTION_DEFS': getattr(settings, "MAPSTORE_PROJECTION_DEFS", []),
         'PLUGINS_CONFIG_PATCH_RULES': getattr(settings, "MAPSTORE_PLUGINS_CONFIG_PATCH_RULES", []),
+        'EXTENSIONS_FOLDER_PATH': getattr(settings, "MAPSTORE_EXTENSIONS_FOLDER_PATH", '/static/mapstore/extensions/'),
         'TIME_ENABLED': getattr(
                 settings,
                 'UPLOADER',

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -54,6 +54,7 @@
         const projectionDefs = geoNodeSettings.PROJECTION_DEFS || [];
         const pluginsConfigPatchRules  = geoNodeSettings.PLUGINS_CONFIG_PATCH_RULES || [];
         const translationsPath = geoNodeSettings.TRANSLATIONS_PATH;
+        const extensionsFolder = geoNodeSettings.EXTENSIONS_FOLDER_PATH;
 
         const isEmbed = checkBoolean('{{ is_embed }}') || false;
         const pluginsConfigKey = '{{ plugins_config_key }}';
@@ -76,6 +77,7 @@
                     url: '{{ PROXY_URL|default:"/proxy/?url=" }}',
                     useCORS: []
                 },
+                extensionsFolder: extensionsFolder,
                 printUrl: geoServerPublicLocation + 'pdf/info.json',
                 bingApiKey: '{% bing_api_key %}',
                 geoNodeApi: {


### PR DESCRIPTION
This PR introduces a new `'EXTENSIONS_FOLDER_PATH'` global variable to override mapstore's default extensions folder path inside of geonode mapstore client.

This is step in solving #889 after investigation with @allyoucanmap. The other pieces of the total fix for the issue will be added in [geonode](https://github.com/GeoNode/geonode) and [mapstore-project](https://github.com/geosolutions-it/mapstore-project) repos where they belong.