### PR TITLE
The UploadDatasetForm should POST "store_spatial_files=true" when uploading

### DIFF
--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -785,6 +785,7 @@ export const uploadDataset = ({
     const formData = new FormData();
     formData.append('base_file', file);
     formData.append('charset', charset);
+    formData.append('store_spatial_files', true);
     const { timeEnabled } = getConfigProp('geoNodeSettings') || {};
     if (timeEnabled) {
         formData.append('time', ['csv', 'shp'].includes(ext) ? true : false);


### PR DESCRIPTION
This PR introduces a `'store_spatial_files=true`' tag in dataset uploads.

![Screenshot 2022-04-06 at 08 14 51](https://user-images.githubusercontent.com/42542676/161929702-56c01514-e2e3-4d79-bceb-fb034c443b75.png)

