### PR TITLE
Added global extensions folder

### DIFF
--- a/geonode_mapstore_client/client/package.json
+++ b/geonode_mapstore_client/client/package.json
@@ -25,7 +25,7 @@
   "author": "GeoSolutions",
   "license": "BSD-2-Clause",
   "devDependencies": {
-    "@mapstore/project": "1.0.20"
+    "@mapstore/project": "1.0.21"
   },
   "dependencies": {
     "js-cookie": "2.2.1",

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -8,6 +8,7 @@
 {{ CATALOGUE_SELECTED_SERVICE|json_script:"settings-CATALOGUE_SELECTED_SERVICE" }}
 {{ PROJECTION_DEFS|json_script:"settings-PROJECTION_DEFS" }}
 {{ PLUGINS_CONFIG_PATCH_RULES|json_script:"settings-PLUGINS_CONFIG_PATCH_RULES" }}
+{{ EXTENSIONS_FOLDER_PATH|json_script:"settings-EXTENSIONS_FOLDER_PATH" }}
 
 <script>
     {% autoescape off %}
@@ -24,6 +25,7 @@
         const catalogueSelectedService = getJSONScriptVariable('settings-CATALOGUE_SELECTED_SERVICE', '');
         const projectionDefs = getJSONScriptVariable('settings-PROJECTION_DEFS', []);
         const pluginsConfigPatchRules = getJSONScriptVariable('settings-PLUGINS_CONFIG_PATCH_RULES', []);
+        const extensionsFolder = getJSONScriptVariable('settings-EXTENSIONS_FOLDER_PATH', '/static/mapstore/extensions/')
 
         const username = '{{ user|default:"" }}' || null;
         const token = '{{ access_token|default:"" }}' || '{{ ACCESS_TOKEN|default:"" }}' || null;
@@ -46,6 +48,7 @@
                 token: token
             },
             pluginsConfigPatchRules: pluginsConfigPatchRules,
+            extensionsFolder: extensionsFolder,
             localConfig: {
                 proxyUrl: {
                     url: '{{ PROXY_URL|default:"/proxy/?url=" }}',

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -48,12 +48,12 @@
                 token: token
             },
             pluginsConfigPatchRules: pluginsConfigPatchRules,
-            extensionsFolder: extensionsFolder,
             localConfig: {
                 proxyUrl: {
                     url: '{{ PROXY_URL|default:"/proxy/?url=" }}',
                     useCORS: []
                 },
+                extensionsFolder: extensionsFolder,
                 geoNodeApi: {
                     endpointAdapter: '{{ SITEURL }}mapstore/rest',
                     endpointAutocomplete: '{{ SITEURL }}base/autocomplete_response',

--- a/mapstore2_adapter/context_processors.py
+++ b/mapstore2_adapter/context_processors.py
@@ -20,6 +20,7 @@ def resource_urls(request):
         CATALOGUE_SELECTED_SERVICE=getattr(settings, "MAPSTORE_CATALOGUE_SELECTED_SERVICE", None),
         PROJECTION_DEFS=getattr(settings, "MAPSTORE_PROJECTION_DEFS", []),
         PLUGINS_CONFIG_PATCH_RULES=getattr(settings, "MAPSTORE_PLUGINS_CONFIG_PATCH_RULES", []),
+        EXTENSIONS_FOLDER_PATH=getattr(settings, "MAPSTORE_EXTENSIONS_FOLDER_PATH", '/static/mapstore/extensions/'),
     )
 
     return defaults

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {},
   "author": "GeoSolutions",
   "license": "BSD-2-Clause",
-  "devDependencies": {},
+  "devDependencies": {
+    "@mapstore/project": "1.0.21"
+  },
   "dependencies": {
     "js-cookie": "2.2.1",
     "mapstore": "git+https://github.com/geosolutions-it/MapStore2.git#faee07b04ca5b475f2241b58fe48e59ab246de0b"

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "scripts": {},
   "author": "GeoSolutions",
   "license": "BSD-2-Clause",
-  "devDependencies": {
-    "@mapstore/project": "1.0.21"
-  },
+  "devDependencies": {},
   "dependencies": {
     "js-cookie": "2.2.1",
     "mapstore": "git+https://github.com/geosolutions-it/MapStore2.git#faee07b04ca5b475f2241b58fe48e59ab246de0b"


### PR DESCRIPTION
This PR introduces a new `'EXTENSIONS_FOLDER_PATH'` global variable to override mapstore's default extensions folder path inside of geonode mapstore client 3.3.x.

This is step in solving #889 after investigation with @allyoucanmap. The other pieces of the total fix for the issue have been added in [geonode](https://github.com/GeoNode/geonode) and [mapstore-project](https://github.com/geosolutions-it/mapstore-project) repos where they belong.