### PR TITLE
Enable KML format for WPS export of vector layers

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -882,6 +882,14 @@
                             "validServices": [
                                 "wps"
                             ]
+                        },
+                        {
+                            "name": "application/vnd.google-earth.kml+xml",
+                            "label": "KML",
+                            "type": "vector",
+                            "validServices": [
+                                "wps"
+                            ]
                         }
                     ]
                 }
@@ -1324,6 +1332,14 @@
                             "validServices": [
                                 "wps"
                             ]
+                        },
+                        {
+                            "name": "application/vnd.google-earth.kml+xml",
+                            "label": "KML",
+                            "type": "vector",
+                            "validServices": [
+                                "wps"
+                            ]
                         }
                     ]
                 }
@@ -1763,6 +1779,14 @@
                             "validServices": [
                                 "wps"
                             ]
+                        },
+                        {
+                            "name": "application/vnd.google-earth.kml+xml",
+                            "label": "KML",
+                            "type": "vector",
+                            "validServices": [
+                                "wps"
+                            ]
                         }
                     ]
                 }
@@ -2179,6 +2203,14 @@
                             "name": "application/geopackage+sqlite3",
                             "label": "GeoPackage",
                             "type": "raster",
+                            "validServices": [
+                                "wps"
+                            ]
+                        },
+                        {
+                            "name": "application/vnd.google-earth.kml+xml",
+                            "label": "KML",
+                            "type": "vector",
                             "validServices": [
                                 "wps"
                             ]
@@ -2616,6 +2648,14 @@
                             "name": "application/geopackage+sqlite3",
                             "label": "GeoPackage",
                             "type": "raster",
+                            "validServices": [
+                                "wps"
+                            ]
+                        },
+                        {
+                            "name": "application/vnd.google-earth.kml+xml",
+                            "label": "KML",
+                            "type": "vector",
                             "validServices": [
                                 "wps"
                             ]
@@ -3091,6 +3131,14 @@
                             "name": "application/geopackage+sqlite3",
                             "label": "GeoPackage",
                             "type": "raster",
+                            "validServices": [
+                                "wps"
+                            ]
+                        },
+                        {
+                            "name": "application/vnd.google-earth.kml+xml",
+                            "label": "KML",
+                            "type": "vector",
                             "validServices": [
                                 "wps"
                             ]


### PR DESCRIPTION
This PR adds KML format to layer download options in 3.3.x