### PR TITLE
Truncate abstract inside the metadata table inside the info box

### DIFF
--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -210,6 +210,8 @@ function DetailsPanel({
     const detailsContainerNode = useRef();
     const isMounted = useRef();
     const [copiedResourceLink, setCopiedResourceLink] = useState(false);
+    const [readMore, setReadMore] = useState(false);
+
     useEffect(() => {
         isMounted.current = true;
         return () => {
@@ -269,6 +271,13 @@ function DetailsPanel({
         return dataType;
     };
 
+    // To be used when user clicks 'Read more' for long abstracts
+    const extraContent = readMore && (<span className="extra-content">
+        {validateDataType(resource?.raw_abstract)?.substring(100, resource?.raw_abstract?.length - 1)}
+    </span>);
+
+    const linkName = readMore ? 'Read Less' : 'Read More';
+
     const infoField = [
         {
             "label": "Title",
@@ -276,7 +285,7 @@ function DetailsPanel({
         },
         {
             "label": "Abstract",
-            "value": validateDataType(resource?.raw_abstract)
+            "value": validateDataType(resource?.raw_abstract)?.length > 100 ? <div>{validateDataType(resource?.raw_abstract)?.substring(0, 100)}{extraContent}{' '}<a className="read-more-link" onClick={() => setReadMore(!readMore) }>{linkName}</a></div> : validateDataType(resource?.raw_abstract)
         },
         {
             "label": "Owner",

--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -457,3 +457,8 @@
         width: 100vw;
     }
 }
+
+.read-more-link {
+    text-decoration: underline;
+    cursor: pointer;
+}


### PR DESCRIPTION
This PR truncates abstracts inside the details panel info box after 100 characters and appends a 'Read more' link.

<img width="770" alt="Screenshot 2022-04-20 at 08 58 06" src="https://user-images.githubusercontent.com/42542676/164191622-ecb937db-ec5c-4e80-9e32-a2218c02c033.png">

