### PR TITLE
[Fixes #946] Autoclose info panel on single click on the map

### DIFF
--- a/geonode_mapstore_client/client/js/epics/__tests__/gnresource-test.js
+++ b/geonode_mapstore_client/client/js/epics/__tests__/gnresource-test.js
@@ -10,8 +10,10 @@ import expect from 'expect';
 import MockAdapter from 'axios-mock-adapter';
 import axios from '@mapstore/framework/libs/ajax';
 import { testEpic } from '@mapstore/framework/epics/__tests__/epicTestUtils';
-import { gnViewerSetNewResourceThumbnail } from '@js/epics/gnresource';
+import { gnViewerSetNewResourceThumbnail, closeInfoPanelOnMapClick } from '@js/epics/gnresource';
 import { setResourceThumbnail, UPDATE_RESOURCE_PROPERTIES } from '@js/actions/gnresource';
+import { clickOnMap } from '@mapstore/framework/actions/map';
+import { SET_CONTROL_PROPERTY } from '@mapstore/framework/actions/controls';
 import {
     SHOW_NOTIFICATION
 } from '@mapstore/framework/actions/notifications';
@@ -63,5 +65,63 @@ describe('gnsave epics', () => {
             },
             testState
         );
+    });
+
+    it('should close share panels on map click', (done) => {
+        const NUM_ACTIONS = 1;
+        const testState = {
+            controls: {
+                rightOverlay: {
+                    enabled: 'Share'
+                }
+            }
+        };
+
+        testEpic(closeInfoPanelOnMapClick,
+            NUM_ACTIONS,
+            clickOnMap(),
+            (actions) => {
+                try {
+                    expect(actions.map(({ type }) => type))
+                        .toEqual([
+                            SET_CONTROL_PROPERTY
+                        ]);
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            },
+            testState
+        );
+
+    });
+
+    it('should close info panel on map click', (done) => {
+        const NUM_ACTIONS = 1;
+        const testState = {
+            controls: {
+                rightOverlay: {
+                    enabled: 'DetailViewer'
+                }
+            }
+        };
+
+        testEpic(closeInfoPanelOnMapClick,
+            NUM_ACTIONS,
+            clickOnMap(),
+            (actions) => {
+                try {
+                    expect(actions.map(({ type }) => type))
+                        .toEqual([
+                            SET_CONTROL_PROPERTY
+                        ]);
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            },
+            testState
+        );
+
     });
 });

--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -75,7 +75,7 @@ import { updateAdditionalLayer } from '@mapstore/framework/actions/additionallay
 import { STYLE_OWNER_NAME } from '@mapstore/framework/utils/StyleEditorUtils';
 import { styleServiceSelector } from '@mapstore/framework/selectors/styleeditor';
 import { updateStyleService } from '@mapstore/framework/api/StyleEditor';
-import { resizeMap } from '@mapstore/framework/actions/map';
+import { CLICK_ON_MAP, resizeMap } from '@mapstore/framework/actions/map';
 import { saveError } from '@js/actions/gnsave';
 import {
     error as errorNotification,
@@ -447,8 +447,13 @@ export const gnViewerSetNewResourceThumbnail = (action$, store) =>
                 });
         });
 
+export const closeInfoPanelOnMapClick = (action$, store) => action$.ofType(CLICK_ON_MAP)
+    .filter(() => store.getState().controls?.rightOverlay?.enabled === 'DetailViewer' || store.getState().controls?.rightOverlay?.enabled === 'Share')
+    .switchMap(() => Observable.of(setControlProperty('rightOverlay', 'enabled', false)));
+
 export default {
     gnViewerRequestNewResourceConfig,
     gnViewerRequestResourceConfig,
-    gnViewerSetNewResourceThumbnail
+    gnViewerSetNewResourceThumbnail,
+    closeInfoPanelOnMapClick
 };


### PR DESCRIPTION
Both info and share panels are closed (if open) on map click

![infopanel](https://user-images.githubusercontent.com/42542676/167618650-6f974a54-ead6-4726-862a-fa828d4ab910.gif)

