### PR TITLE
[Backport 4.x][Fixes #942] Failing datasets uploads are generating double entries in the list of not processed upload

### DIFF
--- a/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
+++ b/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
@@ -19,7 +19,6 @@ import {
     getProcessedUploadsByImportId,
     uploadDataset
 } from '@js/api/geonode/v2';
-import uuidv1 from 'uuid/v1';
 import axios from '@mapstore/framework/libs/ajax';
 import UploadListContainer from '@js/routes/upload/UploadListContainer';
 import UploadContainer from '@js/routes/upload/UploadContainer';
@@ -209,6 +208,12 @@ function UploadList({
                 .then((responses) => {
                     const successfulUploads = responses.filter(({ status }) => status === 'success');
                     const errorUploads = responses.filter(({ status }) => status === 'error');
+                    if (errorUploads.length > 0) {
+                        errorUploads.forEach((upload) => {
+                            const { baseName } = upload;
+                            waitingUploads[baseName].error = true;
+                        });
+                    }
                     if (successfulUploads.length > 0) {
                         const successfulUploadsIds = successfulUploads.map(({ data }) => data?.id);
                         const successfulUploadsNames = successfulUploads.map(({ baseName }) => baseName);
@@ -223,17 +228,6 @@ function UploadList({
                             });
                     } else {
                         setLoading(false);
-                    }
-                    if (errorUploads.length > 0) {
-                        const failedUploads = errorUploads.map(({ baseName: name, error }) => ({
-                            id: uuidv1(),
-                            name,
-                            progress: 100,
-                            state: 'INVALID',
-                            create_date: Date.now(),
-                            error
-                        }));
-                        onSuccess(failedUploads);
                     }
                 })
                 .catch(() => {

--- a/geonode_mapstore_client/client/js/routes/upload/PendingUploadCard.jsx
+++ b/geonode_mapstore_client/client/js/routes/upload/PendingUploadCard.jsx
@@ -13,7 +13,13 @@ import Button from '@js/components/Button';
 import Badge from '@js/components/Badge';
 import Message from '@mapstore/framework/components/I18N/Message';
 import Spinner from '@js/components/Spinner';
+import tooltip from '@mapstore/framework/components/misc/enhancers/tooltip';
 
+function ErrorMessage(props) {
+    return (<div {...props} className="gn-failed-upload"><FaIcon name="exclamation" /></div> );
+}
+
+const ErrorMessageWithTooltip = tooltip(ErrorMessage);
 
 function PendingUploadCard({
     missingExt,
@@ -23,24 +29,28 @@ function PendingUploadCard({
     loading,
     progress,
     size,
-    onAbort
+    onAbort,
+    error
 }) {
     return (
         <div className="gn-upload-card">
             <div className="gn-upload-card-header">
-                {missingExt.length > 0 ? <div className="gn-upload-card-error"><FaIcon name="exclamation"/></div> : null}
+                {missingExt.length > 0 ? <div className="gn-upload-card-error"><FaIcon name="exclamation" /></div> : null}
                 <div className="gn-upload-card-title">{baseName}</div>
-                {onRemove
-                    ? (!loading || !(progress?.[baseName])) ? <Button size="xs" onClick={onRemove}>
-                        <FaIcon name="trash"/>
-                    </Button> : <Button size="xs" onClick={() => onAbort(baseName)}>
-                        <FaIcon name="stop"/>
-                    </Button>
-                    : null}
+                <div>
+                    {error ? <ErrorMessageWithTooltip tooltipId={<Message msgId="gnviewer.invalidUploadMessageErrorTooltip" />} /> : null}
+                    {onRemove
+                        ? (!loading || !(progress?.[baseName])) ? <Button size="xs" onClick={onRemove}>
+                            <FaIcon name="trash" />
+                        </Button> : <Button size="xs" onClick={() => onAbort(baseName)}>
+                            <FaIcon name="stop" />
+                        </Button>
+                        : null}
+                </div>
             </div>
             {missingExt.length > 0 && <div className="gn-upload-card-body">
                 <div className="text-danger">
-                    <Message msgId="gnviewer.missingFiles"/>: {missingExt.join(', ')}
+                    <Message msgId="gnviewer.missingFiles" />: {missingExt.join(', ')}
                 </div>
             </div>}
             <div className="gn-upload-card-bottom">
@@ -61,7 +71,7 @@ function PendingUploadCard({
                         <div>{size}{' '}MB</div>
                 }
             </div>
-            {loading && progress && progress?.[baseName] && <div style={{position: 'relative'}}>
+            {loading && progress && progress?.[baseName] && <div style={{ position: 'relative' }}>
                 <div
                     className="gn-upload-card-progress"
                     style={{

--- a/geonode_mapstore_client/client/js/routes/upload/UploadContainer.jsx
+++ b/geonode_mapstore_client/client/js/routes/upload/UploadContainer.jsx
@@ -106,7 +106,7 @@ function UploadContainer({
                         {waitingUploadNames.length > 0 ? (
                             <ul>
                                 {waitingUploadNames.map((baseName) => {
-                                    const { files, missingExt = [] } = waitingUploads[baseName];
+                                    const { files, missingExt = [], error } = waitingUploads[baseName];
                                     const filesExt = Object.keys(files);
                                     const size = getSize(files, filesExt);
                                     return (
@@ -122,6 +122,7 @@ function UploadContainer({
                                                 progress={progress}
                                                 size={size}
                                                 onAbort={abort}
+                                                error={error}
                                             />
                                         </li>
                                     );

--- a/geonode_mapstore_client/client/themes/geonode/less/_upload.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_upload.less
@@ -39,7 +39,7 @@
     .gn-upload-card-progress.invalid > div {
         .background-color-var(@theme-vars[danger]);
     }
-    .gn-upload-card-error {
+    .gn-upload-card-error, .gn-failed-upload .fa-exclamation {
         .color-var(@theme-vars[danger]);
     }
     .gn-upload-card-error-message {
@@ -208,4 +208,8 @@
     .btn {
         pointer-events: none;
     }
+}
+
+.gn-failed-upload {
+    display: inline-block;
 }


### PR DESCRIPTION
ref #942 

This PR fixes the double error entries and introduces an error tooltip inside `<PendingUploadCard>`
![Screenshot 2022-04-21 at 15 58 43](https://user-images.githubusercontent.com/42542676/164502144-86256990-6255-43dd-a5c6-0420f7e3457c.png)

