### PR TITLE
Expose mapstore's setViewer to allow for custom GFI panel

### DIFF
--- a/geonode_mapstore_client/client/js/utils/AppUtils.js
+++ b/geonode_mapstore_client/client/js/utils/AppUtils.js
@@ -27,6 +27,7 @@ import isString from 'lodash/isString';
 
 import url from 'url';
 import axios from '@mapstore/framework/libs/ajax';
+import { setViewer } from '@mapstore/framework/utils/MapInfoUtils';
 
 let epicsCache = {};
 let actionListeners = {};
@@ -154,7 +155,8 @@ export function setupConfiguration({
             const listeners = (actionListeners[type] || [])
                 .filter((l) => l !== listener);
             actionListeners[type] = listeners;
-        }
+        },
+        setGetFeatureInfoViewer: setViewer
     };
     if (window.onInitMapStoreAPI) {
         window.onInitMapStoreAPI(window.MapStoreAPI, geoNodePageConfig);


### PR DESCRIPTION
Mapstore's `setViewer` is exposed as `window.MapStoreAPI.setGetFeatureInfoViewer`