### PR TITLE
[Fixes #979] Expose mapstore's setViewer to allow for custom GFI panel

### DIFF
--- a/geonode_mapstore_client/client/js/utils/AppUtils.js
+++ b/geonode_mapstore_client/client/js/utils/AppUtils.js
@@ -28,6 +28,7 @@ import isString from 'lodash/isString';
 import url from 'url';
 import axios from '@mapstore/framework/libs/ajax';
 import { addLocaleData } from 'react-intl';
+import { setViewer } from '@mapstore/framework/utils/MapInfoUtils';
 
 let epicsCache = {};
 let actionListeners = {};
@@ -217,7 +218,8 @@ export function setupConfiguration({
             const listeners = (actionListeners[type] || [])
                 .filter((l) => l !== listener);
             actionListeners[type] = listeners;
-        }
+        },
+        setGetFeatureInfoViewer: setViewer
     };
     if (window.onInitMapStoreAPI) {
         window.onInitMapStoreAPI(window.MapStoreAPI, geoNodePageConfig);


### PR DESCRIPTION
Mapstore's `setViewer` is exposed as `window.MapStoreAPI.setGetFeatureInfoViewer`