### PR TITLE
[Fixes #964] info icon for not approved / not published resource shouldn't take a line

### DIFF
--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -535,6 +535,7 @@ function DetailsPanel({
 
                             {
                                 <div className="gn-details-panel-tools">
+                                    <ResourceStatus resource={resource} />
                                     {
                                         enableFavorite &&
                                     <Button
@@ -576,7 +577,6 @@ function DetailsPanel({
 
 
                         </div>
-                        <ResourceStatus resource={resource} />
                         {<p className="gn-details-panel-meta-text">
                             {resource?.owner &&  <>{resource?.owner.avatar &&
                             <img src={resource?.owner.avatar} alt={getUserName(resource?.owner)} className="gn-card-author-image" />


### PR DESCRIPTION
The resource status icon has been re-positioned inside the details panel

<img width="599" alt="Screenshot 2022-05-27 at 13 20 22" src="https://user-images.githubusercontent.com/42542676/170707884-855b0436-3a5c-45bd-931f-85c588a89355.png">

