### PR TITLE
[Fixes #961] Show an error if dataset as a ll_bbox_polygon is greater then the WGS84 max extent

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -79,7 +79,8 @@ import { CLICK_ON_MAP, resizeMap } from '@mapstore/framework/actions/map';
 import { saveError } from '@js/actions/gnsave';
 import {
     error as errorNotification,
-    success as successNotification
+    success as successNotification,
+    warning as warningNotification
 } from '@mapstore/framework/actions/notifications';
 import { getStyleProperties } from '@js/api/geonode/style';
 
@@ -161,7 +162,8 @@ const resourceTypes = {
                                 updateStatus('edit'),
                                 resizeMap()
                             ]
-                            : [])
+                            : []),
+                        newLayer?.bboxError && warningNotification({ title: "gnviewer.invalidBbox", message: "gnviewer.invalidBboxMsg" })
                     );
                 });
         }

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -33,6 +33,12 @@ function getExtentFromResource({ ll_bbox_polygon: llBboxPolygon }) {
         geometry: llBboxPolygon
     });
     const [minx, miny, maxx, maxy] = extent;
+
+    // if the extent is greater than the max extent of the WGS84 return null
+    const WGS84_MAX_EXTENT = [-180, -90, 180, 90];
+    if (minx < WGS84_MAX_EXTENT[0] || miny < WGS84_MAX_EXTENT[1] || maxx > WGS84_MAX_EXTENT[2] || maxy > WGS84_MAX_EXTENT[3]) {
+        return null;
+    }
     const bbox = {
         crs: 'EPSG:4326',
         bounds: { minx, miny, maxx, maxy }
@@ -138,7 +144,7 @@ export const resourceToLayerConfig = (resource) => {
                     url: wfsUrl
                 }
             }),
-            ...(bbox && { bbox }),
+            ...(bbox ? { bbox } : { bboxError: true }),
             ...(template && {
                 featureInfo: {
                     format: 'TEMPLATE',

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
@@ -279,8 +279,8 @@
             "parallelUploadLimit": "Die ausgewählte Anzahl von Dateien überschreitet das zulässige Limit von {limit} Dateien. Bitte entfernen Sie einige Dateien aus der Liste.",
             "parallelLimitError": "Die Anzahl aktiver paralleler Uploads überschreitet {limit}. Warten Sie, bis die ausstehenden abgeschlossen sind.",
             "thisPage": "Diese Seite",
-            "invalidBbox": "Ungültige BBox",
-            "invalidBboxMsg": "Die bereitgestellte BBox ist ungültig"
+            "invalidBbox": "Ungültige Datensatzerweiterung",
+            "invalidBboxMsg": "Die Datensatzerweiterung überschreitet die maximale WGS84-Ausdehnung [-180, -90, 180, 90]"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
@@ -278,7 +278,9 @@
             "cancelUpload": "Hochladen abbrechen",
             "parallelUploadLimit": "Die ausgewählte Anzahl von Dateien überschreitet das zulässige Limit von {limit} Dateien. Bitte entfernen Sie einige Dateien aus der Liste.",
             "parallelLimitError": "Die Anzahl aktiver paralleler Uploads überschreitet {limit}. Warten Sie, bis die ausstehenden abgeschlossen sind.",
-            "thisPage": "Diese Seite"
+            "thisPage": "Diese Seite",
+            "invalidBbox": "Ungültige BBox",
+            "invalidBboxMsg": "Die bereitgestellte BBox ist ungültig"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
@@ -278,7 +278,9 @@
             "cancelUpload": "Cancel upload",
             "parallelUploadLimit": "The selected number of files exceeds the allowed limit of {limit} files. Please remove some files from the list.",
             "parallelLimitError": "The number of active parallel uploads exceeds {limit}. Wait for the pending ones to finish.",
-            "thisPage": "This page"
+            "thisPage": "This page",
+            "invalidBbox": "Invalid BBox",
+            "invalidBboxMsg": "The provided BBox is invalid"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
@@ -279,8 +279,8 @@
             "parallelUploadLimit": "The selected number of files exceeds the allowed limit of {limit} files. Please remove some files from the list.",
             "parallelLimitError": "The number of active parallel uploads exceeds {limit}. Wait for the pending ones to finish.",
             "thisPage": "This page",
-            "invalidBbox": "Invalid BBox",
-            "invalidBboxMsg": "The provided BBox is invalid"
+            "invalidBbox": "Invalid dataset extension",
+            "invalidBboxMsg": "The dataset extension exceed the WGS84 maximum extent [-180, -90, 180, 90]"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
@@ -278,8 +278,8 @@
             "parallelUploadLimit": "El número de archivos seleccionado supera el límite permitido de {limit} archivos. Elimine algunos archivos de la lista.",
             "parallelLimitError": "El número de subidas paralelas activas supera {limit}. Espera a que terminen las pendientes.",
             "thisPage": "Esta página",
-            "invalidBbox": "BBox no válido",
-            "invalidBboxMsg": "Bl BBox proporcionado no es válido"
+            "invalidBbox": "Extensión de conjunto de datos no válida",
+            "invalidBboxMsg": "La extensión del conjunto de datos supera la extensión máxima de WGS84 [-180, -90, 180, 90]"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
@@ -277,7 +277,9 @@
             "cancelUpload": "Cancelar carga",
             "parallelUploadLimit": "El número de archivos seleccionado supera el límite permitido de {limit} archivos. Elimine algunos archivos de la lista.",
             "parallelLimitError": "El número de subidas paralelas activas supera {limit}. Espera a que terminen las pendientes.",
-            "thisPage": "Esta página"
+            "thisPage": "Esta página",
+            "invalidBbox": "BBox no válido",
+            "invalidBboxMsg": "Bl BBox proporcionado no es válido"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
@@ -279,8 +279,8 @@
             "parallelUploadLimit": "Le nombre de fichiers sélectionné dépasse la limite autorisée de {limit} fichiers. Veuillez supprimer certains fichiers de la liste.",
             "parallelLimitError": "Le nombre de téléchargements parallèles actifs dépasse {limit}. Attendez que ceux en attente se terminent.",
             "thisPage": "Cette page",
-            "invalidBbox": "BBox invalide",
-            "invalidBboxMsg": "La bBBox fournie est invalide"
+            "invalidBbox": "Extension d'ensemble de données non valide",
+            "invalidBboxMsg": "L'extension du jeu de données dépasse l'étendue maximale du WGS84 [-180, -90, 180, 90]"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
@@ -278,7 +278,9 @@
             "cancelUpload": "Annuler le téléchargement",
             "parallelUploadLimit": "Le nombre de fichiers sélectionné dépasse la limite autorisée de {limit} fichiers. Veuillez supprimer certains fichiers de la liste.",
             "parallelLimitError": "Le nombre de téléchargements parallèles actifs dépasse {limit}. Attendez que ceux en attente se terminent.",
-            "thisPage": "Cette page"
+            "thisPage": "Cette page",
+            "invalidBbox": "BBox invalide",
+            "invalidBboxMsg": "La bBBox fournie est invalide"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
@@ -281,8 +281,8 @@
             "parallelUploadLimit": "Il numero selezionato di file supera il limite consentito di {limit} file. Si prega di rimuovere alcuni file dall'elenco.",
             "parallelLimitError": "Il numero di caricamenti paralleli attivi supera {limit}. Aspetta che quelli in sospeso finiscano.",
             "thisPage": "Questa pagina",
-            "invalidBbox": "BBox non valido",
-            "invalidBboxMsg": "La BBox fornita non è valida"
+            "invalidBbox": "Estensione del dataset non valida",
+            "invalidBboxMsg": "L'estensione del dataset è maggiore del'estensione massima supportata della proiezione WGS84 [-180, -90, 180, 90]"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
@@ -280,7 +280,9 @@
             "cancelUpload": "Annulla caricamento",
             "parallelUploadLimit": "Il numero selezionato di file supera il limite consentito di {limit} file. Si prega di rimuovere alcuni file dall'elenco.",
             "parallelLimitError": "Il numero di caricamenti paralleli attivi supera {limit}. Aspetta che quelli in sospeso finiscano.",
-            "thisPage": "Questa pagina"
+            "thisPage": "Questa pagina",
+            "invalidBbox": "BBox non valido",
+            "invalidBboxMsg": "La BBox fornita non è valida"
         }
     }
 }


### PR DESCRIPTION
This PR applies the following enhancements:

- includes a check inside the getExtentFromResource function and return null if the bbox extent is greater of the max extent
- in a dataset viewer a warning notification is shown explaining that the provided bbox is invalid