### PR TITLE
[Fixes #969] Add "with_resources" GET parameter on regions and categories endpoints

### DIFF
--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -596,7 +596,8 @@ export const getCategories = ({ q, includes, page, pageSize, config, ...params }
             page,
             ...params,
             ...(includes && {'filter{identifier.in}': includes}),
-            ...(q && { 'filter{identifier.icontains}': q })
+            ...(q && { 'filter{identifier.icontains}': q }),
+            with_resources: "True"
         }
     })
         .then(({ data }) => {
@@ -629,7 +630,8 @@ export const getRegions = ({ q, includes, page, pageSize, config, ...params }, f
             page,
             ...params,
             ...(includes && {'filter{name.in}': includes}),
-            ...(q && { 'filter{name.icontains}': q })
+            ...(q && { 'filter{name.icontains}': q }),
+            with_resources: "True"
         }
     })
         .then(({ data }) => {


### PR DESCRIPTION
This PR adds a `with_resources = 'True'` param in `getCategories` and `getRegions` queries