### PR TITLE
[Backport 4.x][Fixes #967] Drop support for GeoJSON upload

### DIFF
--- a/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
+++ b/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
@@ -48,12 +48,6 @@ const supportedDatasetTypes = [
         mimeType: ['text/csv']
     },
     {
-        id: 'geojson',
-        label: 'GeoJSON',
-        format: 'vector',
-        ext: ['geojson']
-    },
-    {
         id: 'zip',
         label: 'Zip Archive',
         format: 'archive',


### PR DESCRIPTION
This PR drops support for geojson in Dataset uploads