### PR TITLE
[Backport 4.x][Fixes #986] Anonymous users have an option of adding dataset and annotations to a map

### DIFF
--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -1689,11 +1689,13 @@
                         },
                         {
                             "type": "plugin",
-                            "name": "Annotations"
+                            "name": "Annotations",
+                            "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}"
                         },
                         {
                             "type": "plugin",
-                            "name": "DatasetsCatalog"
+                            "name": "DatasetsCatalog",
+                            "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}"
                         }
                     ],
                     "rightMenuItems": [


### PR DESCRIPTION
This PR sets permission for Annotation and Add Dataset plugins to only users with Edit permission

<img width="1017" alt="Screenshot 2022-05-27 at 14 46 18" src="https://user-images.githubusercontent.com/42542676/170723236-30bf044e-051f-48e3-add3-184303abb820.png">

<img width="1069" alt="Screenshot 2022-05-27 at 14 46 36" src="https://user-images.githubusercontent.com/42542676/170723221-04da26a4-5ee2-4df4-95de-813f5aa62df9.png">