### PR TITLE
[Fixes #1011] Datasets with valid bbox do not open in viewer page

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -163,7 +163,9 @@ const resourceTypes = {
                                 resizeMap()
                             ]
                             : []),
-                        newLayer?.bboxError && warningNotification({ title: "gnviewer.invalidBbox", message: "gnviewer.invalidBboxMsg" })
+                        ...(newLayer?.bboxError
+                            ? [warningNotification({ title: "gnviewer.invalidBbox", message: "gnviewer.invalidBboxMsg" })]
+                            : [])
                     );
                 });
         }


### PR DESCRIPTION
Fixes https://github.com/GeoNode/geonode-mapstore-client/pull/1000#issuecomment-1147258437