### PR TITLE
[Backport 4.x][Fixes #1020] Show invalid bbox warning on the overview of the dataset

### DIFF
--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -507,6 +507,9 @@
             },
             {
                 "name": "FitBounds"
+            },
+            {
+                "name": "Notifications"
             }
         ],
         "map_preview": [
@@ -644,6 +647,9 @@
             },
             {
                 "name": "FitBounds"
+            },
+            {
+                "name": "Notifications"
             }
         ],
         "map_embed": [
@@ -2832,6 +2838,9 @@
                         "vertical": true
                     }
                 }
+            },
+            {
+                "name": "Notifications"
             }
         ],
         "geostory_viewer_mobile": [


### PR DESCRIPTION
<img width="1310" alt="Screenshot 2022-06-07 at 08 48 51" src="https://user-images.githubusercontent.com/42542676/172339886-482b7c85-fbb1-440d-9157-02878028cca3.png">
