### PR TITLE
[Fixes 1028] The DatasetCatalog plugin but be enabled for a new map

### DIFF
--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -1697,12 +1697,12 @@
                         {
                             "type": "plugin",
                             "name": "Annotations",
-                            "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}"
+                            "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase') && !state('isNewResource')}"
                         },
                         {
                             "type": "plugin",
                             "name": "DatasetsCatalog",
-                            "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase')}"
+                            "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase') && !state('isNewResource')}"
                         }
                     ],
                     "rightMenuItems": [


### PR DESCRIPTION
The conditional check to include Dataset and Annotations pluhgin has been extended to take into account if the resource is a new map.