### PR TITLE
[Backport 4.x][Fixes #968] Adjustments to links inside Share Panel

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/Share.jsx
+++ b/geonode_mapstore_client/client/js/plugins/Share.jsx
@@ -94,7 +94,8 @@ function Share({
     canEdit,
     permissionsLoading,
     resourceType,
-    embedUrl
+    embedUrl,
+    downloadUrl
 }) {
 
     const [permissionsObject, setPermissionsObject] = useState({});
@@ -130,7 +131,8 @@ function Share({
                 </div>
                 <div className="gn-share-panel-body">
                     <SharePageLink url={pageUrl} label={<Message msgId="gnviewer.thisPage" />} />
-                    <SharePageLink url={embedUrl} label={<Message msgId={`gnhome.${resourceType}`} />} />
+                    <SharePageLink url={embedUrl} label={<Message msgId={`gnviewer.embed${resourceType}`} />} />
+                    {(resourceType === 'document' && !!downloadUrl) && <SharePageLink url={downloadUrl} label={<Message msgId={`gnviewer.directLink`} />} />}
                     {canEdit && <>
                         <Permissions
                             compactPermissions={compactPermissions}
@@ -179,7 +181,8 @@ const SharePlugin = connect(
         canEdit,
         permissionsLoading,
         embedUrl: resource?.embed_url,
-        resourceType: type
+        resourceType: type,
+        downloadUrl: resource?.download_url
     })),
     {
         onClose: setControlProperty.bind(null, 'rightOverlay', 'enabled', false),

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
@@ -278,7 +278,16 @@
             "cancelUpload": "Hochladen abbrechen",
             "parallelUploadLimit": "Die ausgewählte Anzahl von Dateien überschreitet das zulässige Limit von {limit} Dateien. Bitte entfernen Sie einige Dateien aus der Liste.",
             "parallelLimitError": "Die Anzahl aktiver paralleler Uploads überschreitet {limit}. Warten Sie, bis die ausstehenden abgeschlossen sind.",
-            "thisPage": "Diese Seite"
+            "thisPage": "Diese Seite",
+            "addMainFiles": "Hauptdatei hinzufügen",
+            "invalidBbox": "Ungültige Datensatzerweiterung",
+            "invalidBboxMsg": "Die Datensatzerweiterung überschreitet die maximale WGS84-Ausdehnung [-180, -90, 180, 90]",
+            "embedmap": "Diese Karte einbetten",
+            "embeddataset": "Betten Sie diesen Datensatz ein",
+            "embedgeostory": "Betten Sie diese Geostory ein",
+            "embeddocument": "Betten Sie dieses Dokument ein",
+            "embeddashboard": "Betten Sie dieses Dashboard ein",
+            "directLink": "Direkte Verbindung"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
@@ -278,7 +278,16 @@
             "cancelUpload": "Cancel upload",
             "parallelUploadLimit": "The selected number of files exceeds the allowed limit of {limit} files. Please remove some files from the list.",
             "parallelLimitError": "The number of active parallel uploads exceeds {limit}. Wait for the pending ones to finish.",
-            "thisPage": "This page"
+            "thisPage": "This page",
+            "addMainFiles": "Add main file",
+            "invalidBbox": "Invalid dataset extension",
+            "invalidBboxMsg": "The dataset extension exceed the WGS84 maximum extent [-180, -90, 180, 90]",
+            "embedmap": "Embed this Map",
+            "embeddataset": "Embed this Dataset",
+            "embedgeostory": "Embed this Geostory",
+            "embeddocument": "Embed this Document",
+            "embeddashboard": "Embed this Dashboard",
+            "directLink": "Direct Link"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
@@ -277,7 +277,16 @@
             "cancelUpload": "Cancelar carga",
             "parallelUploadLimit": "El número de archivos seleccionado supera el límite permitido de {limit} archivos. Elimine algunos archivos de la lista.",
             "parallelLimitError": "El número de subidas paralelas activas supera {limit}. Espera a que terminen las pendientes.",
-            "thisPage": "Esta página"
+            "thisPage": "Esta página",
+            "addMainFiles": "Agregar archivo principal",
+            "invalidBbox": "Extensión de conjunto de datos no válida",
+            "invalidBboxMsg": "La extensión del conjunto de datos supera la extensión máxima de WGS84 [-180, -90, 180, 90]",
+            "embedmap": "Insertar este mapa",
+            "embeddataset": "Incrustar este conjunto de datos",
+            "embedgeostory": "Insertar esta Geohistoria",
+            "embeddocument": "Inserta éste Documento",
+            "embeddashboard": "Insertar este Panel",
+            "directLink": "Enlace Directo"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
@@ -278,7 +278,16 @@
             "cancelUpload": "Annuler le téléchargement",
             "parallelUploadLimit": "Le nombre de fichiers sélectionné dépasse la limite autorisée de {limit} fichiers. Veuillez supprimer certains fichiers de la liste.",
             "parallelLimitError": "Le nombre de téléchargements parallèles actifs dépasse {limit}. Attendez que ceux en attente se terminent.",
-            "thisPage": "Cette page"
+            "thisPage": "Cette page",
+            "addMainFiles": "Ajouter le fichier principal",
+            "invalidBbox": "Extension d'ensemble de données non valide",
+            "invalidBboxMsg": "L'extension du jeu de données dépasse l'étendue maximale du WGS84 [-180, -90, 180, 90]",
+            "embedmap": "Intégrer cette carte",
+            "embeddataset": "Intégrer cet ensemble de données",
+            "embedgeostory": "Intégrer cette Geostory",
+            "embeddocument": "Intégrer ce document",
+            "embeddashboard": "Intégrer ce Tableau de bord",
+            "directLink": "BLien direct"
         }
     }
 }

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
@@ -280,7 +280,16 @@
             "cancelUpload": "Annulla caricamento",
             "parallelUploadLimit": "Il numero selezionato di file supera il limite consentito di {limit} file. Si prega di rimuovere alcuni file dall'elenco.",
             "parallelLimitError": "Il numero di caricamenti paralleli attivi supera {limit}. Aspetta che quelli in sospeso finiscano.",
-            "thisPage": "Questa pagina"
+            "thisPage": "Questa pagina",
+            "addMainFiles": "Aggiungi file principale",
+            "invalidBbox": "Estensione del dataset non valida",
+            "invalidBboxMsg": "L'estensione del dataset è maggiore del'estensione massima supportata della proiezione WGS84 [-180, -90, 180, 90]",
+            "embedmap": "Incorpora questa Mappa",
+            "embeddataset": "Incorpora questo Set di dati",
+            "embedgeostory": "Incorpora questa Geostoria",
+            "embeddocument": "Incorpora questo Documento",
+            "embeddashboard": "Incorpora questo Dashboard",
+            "directLink": "Collegamento Diretto"
         }
     }
 }

--- a/geonode_mapstore_client/client/themes/geonode/less/_share.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_share.less
@@ -295,7 +295,7 @@
 }
 
 .gn-share-link-pad {
-    padding: 10px;
+    padding: 5px 10px;
 
     .gn-share-link {
         display: flex;
@@ -314,14 +314,16 @@
             border: none;
             font-family: @font-family-monospace;
         }
-    
-        .gn-share-title {
-            width: 6rem;
-            text-transform: capitalize;
-        }
+
     }
     
     .gn-share-page-link {
         padding: 0.2rem 0.5rem;
+
+        .gn-share-title {
+            margin-bottom: 0;
+            font-size: 0.8rem;
+            text-transform: capitalize;
+        }
     }
 }


### PR DESCRIPTION
Share links have been adjusted according to https://github.com/GeoNode/geonode-mapstore-client/issues/968#issue-1232475692

<img width="794" alt="Screenshot 2022-06-08 at 14 09 47" src="https://user-images.githubusercontent.com/42542676/172638098-dfa21124-21e8-40c8-8190-0395d251adfc.png">

<img width="798" alt="Screenshot 2022-06-08 at 14 10 02" src="https://user-images.githubusercontent.com/42542676/172638153-5d2aeaaf-67d4-473d-8fb0-ab34e28f4a0b.png">

ref #968 