### PR TITLE
[Backport 4.x][Fixes #935] Share permissions form not showing for users in groups with manage permission

### DIFF
--- a/geonode_mapstore_client/client/js/selectors/__tests__/resource-test.js
+++ b/geonode_mapstore_client/client/js/selectors/__tests__/resource-test.js
@@ -14,7 +14,8 @@ import {
     getGeonodeResourceFromDashboard,
     getResourceThumbnail,
     updatingThumbnailResource,
-    isThumbnailChanged
+    isThumbnailChanged,
+    canEditPermissions
 } from '../resource';
 
 const testState = {
@@ -25,6 +26,9 @@ const testState = {
             thumbnailChanged: true,
             thumbnail_url: 'thumbnail.jpeg',
             updatingThumbnail: true
+        },
+        compactPermissions: {
+            groups: [{name: 'test-group', permissions: 'manage'}]
         }
     },
     geostory: {
@@ -35,6 +39,13 @@ const testState = {
     dashboard: {
         originalData: {
             widgets: [{widgetType: 'map', name: 'test widget', map: {extraParams: {pk: 1}}}, {widgetType: 'map', name: 'test widget 2', map: {pk: 1}}]
+        }
+    },
+    security: {
+        user: {
+            info: {
+                groups: ['test-group']
+            }
         }
     }
 };
@@ -64,5 +75,9 @@ describe('resource selector', () => {
 
     it('should get resource thumbnail updating status', () => {
         expect(updatingThumbnailResource(testState)).toBeTruthy();
+    });
+
+    it('should get permissions from users in groups with manage rights', () => {
+        expect(canEditPermissions(testState)).toBeTruthy();
     });
 });

--- a/geonode_mapstore_client/client/js/selectors/resource.js
+++ b/geonode_mapstore_client/client/js/selectors/resource.js
@@ -102,9 +102,13 @@ export const getPermissionsPayload = (state) => {
 export const canEditPermissions = (state) => {
     const compactPermissions = getCompactPermissions(state);
     const users = compactPermissions.users || [];
+    const groups = compactPermissions.groups || [];
+    const organizations = compactPermissions.organizations || [];
     const user = state?.security?.user;
     const { permissions } = user && users.find(({ id }) => id === user.pk) || {};
-    return ['owner', 'manage'].includes(permissions);
+    const { permissions: allowedGroups } = user && groups.find((group) => user.info.groups.includes(group.name)) || {};
+    const { permissions: allowedOrganizations } = user && organizations.find((organization) => user.info.groups.includes(organization.name)) || {};
+    return ['owner', 'manage'].includes(permissions) || ['manage'].includes(allowedGroups) || ['manage'].includes(allowedOrganizations);
 };
 
 export const getSelectedLayerPermissions = (state) => {


### PR DESCRIPTION
Share Permissions have been fixed for users belonging to groups with manage permissions for a resource.