### PR TITLE
[Fixes #1065] Extend configs to include new timeline setting for Mapstore's Timeline plugin

### DIFF
--- a/.github/workflows/3.3.x-build.yml
+++ b/.github/workflows/3.3.x-build.yml
@@ -1,0 +1,85 @@
+# This is a basic workflow to help you get started with Actions
+
+name: GeoNode Client 3.3.x CI (build)
+
+concurrency: 
+  group: "client_build_3.3.x"
+  cancel-in-progress: true
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push events but only for the 3.3.x branch
+  push:
+    branches: [ 3.3.x ]
+    paths: 
+      - "geonode_mapstore_client/client/**"
+      - "!geonode_mapstore_client/client/version.txt"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build_and_commit:
+    env:
+      working-directory: ./geonode_mapstore_client/client
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checking out"
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+
+      ###########
+      # SET UP 
+      #########
+      - name: "Setting up npm"
+        uses: actions/setup-node@v2
+        with:
+            node-version: '12.x'
+
+      ############
+      # CACHING
+      ##########
+      - name: "Cache node modules"
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      ###############
+      # NPM BUILD
+      #############
+      - name: "Run npm install"
+        run: npm install
+        working-directory: ${{env.working-directory}}
+
+      - name: "Run npm compile"
+        run: npm run compile
+        working-directory: ${{env.working-directory}}
+
+      ###############
+      # COMMIT
+      #############
+      - name: "Stage files"
+        run: git add --all
+        
+      - name: "Generate temp GitHub token"
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.TOKEN_APP_ID }}
+          private_key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
+        
+      - name: "Create Pull Request"
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          base: "3.3.x"
+          title: "[3.3.x] new client build"
+          body: "Automated client build from GeoNode Client 3.3.x CI"
+          branch: "3.3.x-create-pull-request/patch"

--- a/.github/workflows/3.3.x-test.yml
+++ b/.github/workflows/3.3.x-test.yml
@@ -1,0 +1,60 @@
+# This is a basic workflow to help you get started with Actions
+
+name: GeoNode Client 3.3.x CI (tests)
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow pull request events but only for the 3.3.x branch
+  pull_request:
+    branches: [ 3.3.x ]
+    paths: 
+      - "geonode_mapstore_client/client/**"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  test-front-end:
+    env:
+      working-directory: ./geonode_mapstore_client/client
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checking out"
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+
+      - name: "Setting up npm"
+        uses: actions/setup-node@v2
+        with:
+            node-version: '12.x'
+
+      ############
+      # CACHING
+      ##########
+      - name: "Cache node modules"
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      ###############
+      # NPM CHECKS
+      #############
+      - name: "Run npm install"
+        run: npm install
+        working-directory: ${{env.working-directory}}
+
+      - name: "Run ESlint"
+        run: npm run lint
+        working-directory: ${{env.working-directory}}
+
+      - name: "Run Unit Tests"
+        run: npm test
+        working-directory: ${{env.working-directory}}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "geonode_mapstore_client/client/MapStore2"]
 	path = geonode_mapstore_client/client/MapStore2
 	url = https://github.com/geosolutions-it/MapStore2.git
-	branch = 2022.01.xx
+	branch = geonode-3.3.x

--- a/geonode_mapstore_client/client/package.json
+++ b/geonode_mapstore_client/client/package.json
@@ -25,7 +25,7 @@
   "author": "GeoSolutions",
   "license": "BSD-2-Clause",
   "devDependencies": {
-    "@mapstore/project": "1.0.21"
+    "@mapstore/project": "1.0.24"
   },
   "dependencies": {
     "js-cookie": "2.2.1",

--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -577,7 +577,8 @@
                         "marginLeft": 80,
                         "marginRight": 45
                     },
-                    "compact": true
+                    "compact": true,
+                    "expandedPanel": "{state('settings') && state('settings').timelineExpandedPanel ? true : false}"
                 }
             },
             {
@@ -785,7 +786,10 @@
                 }
             },
             {
-                "name": "Timeline"
+                "name": "Timeline",
+                "cfg": {
+                    "expandedPanel": "{state('settings') && state('settings').timelineExpandedPanel ? true : false}"
+                }
             },
             {
                 "name": "Playback"
@@ -1235,7 +1239,10 @@
                 }
             },
             {
-                "name": "Timeline"
+                "name": "Timeline",
+                "cfg": {
+                    "expandedPanel": "{state('settings') && state('settings').timelineExpandedPanel ? true : false}"
+                }
             },
             {
                 "name": "Playback"
@@ -1682,7 +1689,10 @@
                 }
             },
             {
-                "name": "Timeline"
+                "name": "Timeline",
+                "cfg": {
+                    "expandedPanel": "{state('settings') && state('settings').timelineExpandedPanel ? true : false}"
+                }
             },
             {
                 "name": "Playback"
@@ -2109,7 +2119,10 @@
                 }
             },
             {
-                "name": "Timeline"
+                "name": "Timeline",
+                "cfg": {
+                    "expandedPanel": "{state('settings') && state('settings').timelineExpandedPanel ? true : false}"
+                }
             },
             {
                 "name": "Playback"
@@ -2554,7 +2567,10 @@
                 }
             },
             {
-                "name": "Timeline"
+                "name": "Timeline",
+                "cfg": {
+                    "expandedPanel": "{state('settings') && state('settings').timelineExpandedPanel ? true : false}"
+                }
             },
             {
                 "name": "Playback"
@@ -3037,7 +3053,10 @@
                 }
             },
             {
-                "name": "Timeline"
+                "name": "Timeline",
+                "cfg": {
+                    "expandedPanel": "{state('settings') && state('settings').timelineExpandedPanel ? true : false}"
+                }
             },
             {
                 "name": "Playback"

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -26,7 +26,7 @@
         const projectionDefs = getJSONScriptVariable('settings-PROJECTION_DEFS', []);
         const pluginsConfigPatchRules = getJSONScriptVariable('settings-PLUGINS_CONFIG_PATCH_RULES', []);
         const extensionsFolder = getJSONScriptVariable('settings-EXTENSIONS_FOLDER_PATH', '/static/mapstore/extensions/')
-        const expandedPanel = getJSONScriptVariable('settings-TIMELINE_EXPANDED', False)
+        const timelineExpandedPanel = getJSONScriptVariable('settings-TIMELINE_EXPANDED', false)
 
         const username = '{{ user|default:"" }}' || null;
         const token = '{{ access_token|default:"" }}' || '{{ ACCESS_TOKEN|default:"" }}' || null;
@@ -72,7 +72,7 @@
                     initialCatalog: catalogueServices[catalogueSelectedService] || {},
                     geonodeUrl: '{{ SITEURL }}',
                     geoserverUrl: '{{ OGC_SERVER.default.PUBLIC_LOCATION|default:"" }}',
-                    expandedPanel: expandedPanel
+                    timelineExpandedPanel: timelineExpandedPanel
                 }
             }
         };

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -26,6 +26,7 @@
         const projectionDefs = getJSONScriptVariable('settings-PROJECTION_DEFS', []);
         const pluginsConfigPatchRules = getJSONScriptVariable('settings-PLUGINS_CONFIG_PATCH_RULES', []);
         const extensionsFolder = getJSONScriptVariable('settings-EXTENSIONS_FOLDER_PATH', '/static/mapstore/extensions/')
+        const expandedPanel = getJSONScriptVariable('settings-TIMELINE_EXPANDED', False)
 
         const username = '{{ user|default:"" }}' || null;
         const token = '{{ access_token|default:"" }}' || '{{ ACCESS_TOKEN|default:"" }}' || null;
@@ -70,7 +71,8 @@
                     catalogueServices: catalogueServices,
                     initialCatalog: catalogueServices[catalogueSelectedService] || {},
                     geonodeUrl: '{{ SITEURL }}',
-                    geoserverUrl: '{{ OGC_SERVER.default.PUBLIC_LOCATION|default:"" }}'
+                    geoserverUrl: '{{ OGC_SERVER.default.PUBLIC_LOCATION|default:"" }}',
+                    expandedPanel: expandedPanel
                 }
             }
         };

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -9,6 +9,7 @@
 {{ PROJECTION_DEFS|json_script:"settings-PROJECTION_DEFS" }}
 {{ PLUGINS_CONFIG_PATCH_RULES|json_script:"settings-PLUGINS_CONFIG_PATCH_RULES" }}
 {{ EXTENSIONS_FOLDER_PATH|json_script:"settings-EXTENSIONS_FOLDER_PATH" }}
+{{ TIMELINE_EXPANDED|json_script:"settings-TIMELINE_EXPANDED" }}
 
 <script>
     {% autoescape off %}

--- a/mapstore2_adapter/context_processors.py
+++ b/mapstore2_adapter/context_processors.py
@@ -21,6 +21,7 @@ def resource_urls(request):
         PROJECTION_DEFS=getattr(settings, "MAPSTORE_PROJECTION_DEFS", []),
         PLUGINS_CONFIG_PATCH_RULES=getattr(settings, "MAPSTORE_PLUGINS_CONFIG_PATCH_RULES", []),
         EXTENSIONS_FOLDER_PATH=getattr(settings, "MAPSTORE_EXTENSIONS_FOLDER_PATH", '/static/mapstore/extensions/'),
+        TIMELINE_EXPANDED=getattr(settings, "MAPSTORE_TIMELINE_EXPANDED", False)
     )
 
     return defaults


### PR DESCRIPTION
The following improvements have been made:
- extend the [content processors](https://github.com/GeoNode/geonode-mapstore-client/blob/8b371a98515782ea21da6e6b8d04e6e901721cbe/mapstore2_adapter/context_processors.py) to include the new settings.py variable (eg MAPSTORE_TIMELINE_EXPANDED to be decided in development phase)
- extend the [geoNodeSettings](https://github.com/GeoNode/geonode-mapstore-client/blob/8b371a98515782ea21da6e6b8d04e6e901721cbe/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html#L68-L74) to make this new variable available at the localConfig level to be applied as follow