### PR TITLE
[Fixes 1084] Use raw JSON body instead of ulencoded form for permissions PUT

### DIFF
--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -730,11 +730,8 @@ export const getCompactPermissionsByPk = (pk) => {
 export const updateCompactPermissionsByPk = (pk, body) => {
     return axios({
         url: parseDevHostname(`${endpoints[RESOURCES]}/${pk}/permissions`),
-        data: JSON.stringify(body),
-        method: 'put',
-        headers: {
-            'Content-Type': 'application/json'
-        }
+        data: body,
+        method: 'put'
     })
         .then(({ data }) => data);
 };


### PR DESCRIPTION
Api has been updated to use raw json body

- PR includes typo fix for `downloadResource` request headers