### PR TITLE
[Backport 4.x][Fixes #1072] Dataset legend must show the dataset's title instead of Geoserver's layername

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/Legend.jsx
+++ b/geonode_mapstore_client/client/js/plugins/Legend.jsx
@@ -15,6 +15,7 @@ import { layersSelector } from '@mapstore/framework/selectors/layers';
 import OpacitySlider from '@mapstore/framework/components/TOC/fragments/OpacitySlider';
 import { updateNode } from '@mapstore/framework/actions/layers';
 import VisibilityCheck from '@mapstore/framework/components/TOC/fragments/VisibilityCheck';
+import Message from '@mapstore/framework/components/I18N/HTML';
 
 function Legend({
     layers,
@@ -30,14 +31,14 @@ function Legend({
     return layers.length > 0 && <div className="shadow gn-legend-wrapper" style={{width: expandLegend ? 'auto' : '80px'}}>
         <div onClick={expand} className="gn-legend-head">
             <span role="button" className={`identify-icon glyphicon glyphicon-chevron-${expandLegend ? 'down' : 'right'}`} title="Expand layer legend" />
-            <span className="gn-legend-list-item">Legend</span>
+            <span className="gn-legend-list-item"><Message msgId="gnviewer.legend" /></span>
         </div>
         <ul className="gn-legend-list" style={{display: expandLegend ? 'inline-block' : 'none'}}>
             {layers.map((layer, ind) => <Fragment key={ind}>
                 <li className="gn-legend-list-item"><VisibilityCheck key="visibilitycheck"
                     tooltip={layer.loadingError === 'Warning' ? 'toc.toggleLayerVisibilityWarning' : 'toc.toggleLayerVisibility'}
                     node={layer}
-                    propertiesChangeHandler={(id, options) => onUpdateNode(id, 'layers', options)} /><p>{layer.name || layer.title}</p></li>
+                    propertiesChangeHandler={(id, options) => onUpdateNode(id, 'layers', options)} /><p>{layer.title}</p></li>
                 <li className="gn-legend-bottom">
                     <OpacitySlider
                         opacity={layer.opacity}

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
@@ -220,6 +220,7 @@
             "legendWidth": "Legendensymbolbreite",
             "legendHeight": "Höhe des Legendensymbols",
             "legendPreview": "Legendenvorschau",
+            "legend": "Legende",
             "nodeTooltipContent": "Tooltip-Inhalt",
             "nodeTooltipPlacement": "Tooltip-Platzierung",
 

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
@@ -220,6 +220,7 @@
             "legendWidth": "Legend symbol width",
             "legendHeight": "Legend symbol height",
             "legendPreview": "Legend preview",
+            "legend": "Legend",
             "nodeTooltipContent": "Tooltip content",
             "nodeTooltipPlacement": "Tooltip placement",
 

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
@@ -220,6 +220,7 @@
             "legendWidth": "Ancho del símbolo de leyenda",
             "legendHeight": "Altura del símbolo de leyenda",
             "legendPreview": "Vista previa de la leyenda",
+            "legend": "Leyenda",
             "nodeTooltipContent": "Contenido de la información sobre herramientas",
             "nodeTooltipPlacement": "Ubicación de información sobre herramientas",
             "zoomToLayer": "Zoom a la extensión de la capa",

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
@@ -220,6 +220,7 @@
             "legendWidth": "Largeur du symbole de la légende",
             "legendHeight": "Hauteur du symbole de la légende",
             "legendPreview": "Aperçu de la légende",
+            "legend": "Légende",
             "nodeTooltipContent": "Contenu de l'info-bulle",
             "nodeTooltipPlacement": "Placement de l'info-bulle",
 

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
@@ -222,6 +222,7 @@
             "legendWidth": "Larghezza simbolo legenda",
             "legendHeight": "Altezza simbolo legenda",
             "legendPreview": "Anteprima legenda",
+            "legend": "Legenda",
             "nodeTooltipContent": "Contenuto tooltip",
             "nodeTooltipPlacement": "Posizionamento tooltip",
 


### PR DESCRIPTION
![Screenshot 2022-07-07 at 10 16 21](https://user-images.githubusercontent.com/42542676/177750665-50acd9a6-aa8f-4817-acb1-855ea8ceb71b.png)

ref #1072 