### PR TITLE
[Backport 4.x][Fixes #1085] Spinner is missing during the upload phase

### DIFF
--- a/geonode_mapstore_client/client/js/routes/upload/UploadCard.jsx
+++ b/geonode_mapstore_client/client/js/routes/upload/UploadCard.jsx
@@ -58,7 +58,7 @@ function UploadCard({
                         </a>
                         : name}
                 </div>
-                {(state === 'PENDING' || state === 'COMPLETE') && progress < 100 ? <Spinner /> : null}
+                {progress < 100 ? <Spinner /> : null}
                 {onRemove
                     ? <Button size="xs" onClick={onRemove}>
                         <FaIcon name="trash"/>


### PR DESCRIPTION
Spinner only keeps track of progress