### PR TITLE
[Fixes 1136] The client should only depend on the new favorite field in resource object

### DIFF
--- a/geonode_mapstore_client/client/js/actions/gnresource.js
+++ b/geonode_mapstore_client/client/js/actions/gnresource.js
@@ -34,8 +34,6 @@ export const ENABLE_MAP_THUMBNAIL_VIEWER = 'GEONODE_ENABLE_MAP_THUMBNAIL_VIEWER'
 export const DOWNLOAD_RESOURCE = 'GEONODE_DOWNLOAD_RESOURCE';
 export const DOWNLOAD_COMPLETE = 'GEONODE_DOWNLOAD_COMPLETE';
 export const UPDATE_SINGLE_RESOURCE = 'GEONODE_UPDATE_SINGLE_RESOURCE';
-export const SET_FAVORITE_RESOURCES = 'GEONODE_SET_FAVORITE_RESOURCES';
-export const REMOVE_FAVORITE_RESOURCE = 'GEONODE_REMOVE_FAVORITE_RESOURCE';
 
 
 /**
@@ -309,19 +307,5 @@ export function downloadComplete(resource) {
     return {
         type: DOWNLOAD_COMPLETE,
         resource
-    };
-}
-
-export function setFavoriteResources(favorites) {
-    return {
-        type: SET_FAVORITE_RESOURCES,
-        favorites
-    };
-}
-
-export function removeFavoriteResource(pk) {
-    return {
-        type: REMOVE_FAVORITE_RESOURCE,
-        pk
     };
 }

--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -297,11 +297,6 @@ export const setFavoriteResource = (pk, favorite) => {
         .then(({ data }) => data );
 };
 
-export const getUserFavoriteResources = () => {
-    return axios.get(parseDevHostname(`${endpoints[RESOURCES]}/favorites`))
-        .then(({ data }) => data.favorites.map(({ pk }) => pk));
-};
-
 export const getResourceByPk = (pk) => {
     return axios.get(parseDevHostname(`${endpoints[RESOURCES]}/${pk}`), {
         params: {

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -29,7 +29,6 @@ import Loader from '@mapstore/framework/components/misc/Loader';
 import { getUserName } from '@js/utils/SearchUtils';
 import ZoomTo from '@js/components/ZoomTo';
 import { boundsToExtentString } from '@js/utils/CoordinatesUtils';
-import { getUserFavoriteResources } from '@js/api/geonode/v2';
 
 const Map = mapTypeHOC(BaseMap);
 Map.displayName = 'Map';
@@ -207,9 +206,7 @@ function DetailsPanel({
     onClose,
     onAction,
     canDownload,
-    setFavorites,
-    removeFavorite,
-    resourceId
+    onUpdateFavorite
 }) {
     const detailsContainerNode = useRef();
     const isMounted = useRef();
@@ -222,10 +219,6 @@ function DetailsPanel({
             isMounted.current = false;
         };
     }, []);
-
-    useEffect(() => {
-        getUserFavoriteResources().then(favorites => setFavorites(favorites));
-    }, [resourceId]);
 
     if (!resource && !loading) {
         return null;
@@ -240,9 +233,14 @@ function DetailsPanel({
         }, 700);
     };
 
-    const handleFavorite = () => {
-        favorite ? removeFavorite(resourceId) : setFavorites(resourceId);
-        onFavorite(!favorite);
+    const handleFavorite = (fav) => {
+        fav ? onUpdateFavorite({
+            'favorite': false
+        })
+            : onUpdateFavorite({
+                'favorite': true
+            });
+        onFavorite(!fav);
     };
 
     const handleResourceThumbnailUpdate = () => {
@@ -549,7 +547,7 @@ function DetailsPanel({
                                         enableFavorite &&
                                     <Button
                                         variant="default"
-                                        onClick={debounce(handleFavorite, 500)}>
+                                        onClick={debounce(() => handleFavorite(favorite), 500)}>
                                         <FaIcon name={favorite ? 'star' : 'star-o'} />
                                     </Button>
                                     }

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -205,8 +205,7 @@ function DetailsPanel({
     enableMapViewer,
     onClose,
     onAction,
-    canDownload,
-    onUpdateFavorite
+    canDownload
 }) {
     const detailsContainerNode = useRef();
     const isMounted = useRef();
@@ -234,12 +233,6 @@ function DetailsPanel({
     };
 
     const handleFavorite = (fav) => {
-        fav ? onUpdateFavorite({
-            'favorite': false
-        })
-            : onUpdateFavorite({
-                'favorite': true
-            });
         onFavorite(!fav);
     };
 

--- a/geonode_mapstore_client/client/js/epics/favorite.js
+++ b/geonode_mapstore_client/client/js/epics/favorite.js
@@ -35,22 +35,24 @@ export const gnSaveFavoriteContent = (action$, store) =>
                 : [...resources, resource]) : resources;
 
 
-            return Observable
-                .defer(() => setFavoriteResource(pk, favorite))
-                .switchMap(() => {
-                    return Observable.of(
-                        updateResources(newResources, true)
-                    );
-                })
-                .catch((error) => {
-                    return Observable.of(
-                        action.favorite ? updateResourceProperties({
-                            'favorite': false
-                        }) : updateResourceProperties({
-                            'favorite': true
-                        }),
-                        errorNotification({ title: "gnviewer.cannotPerfomAction", message: error?.data?.message || error?.data?.detail || error?.originalError?.message || "gnviewer.syncErrorDefault" }));
-                });
+            return Observable.concat(
+                Observable.of(updateResourceProperties({'favorite': favorite})),
+                Observable.defer(() => setFavoriteResource(pk, favorite))
+                    .switchMap(() => {
+                        return Observable.of(
+                            updateResources(newResources, true)
+                        );
+                    })
+                    .catch((error) => {
+                        return Observable.of(
+                            action.favorite ? updateResourceProperties({
+                                'favorite': false
+                            }) : updateResourceProperties({
+                                'favorite': true
+                            }),
+                            errorNotification({ title: "gnviewer.cannotPerfomAction", message: error?.data?.message || error?.data?.detail || error?.originalError?.message || "gnviewer.syncErrorDefault" }));
+                    })
+            );
 
         });
 

--- a/geonode_mapstore_client/client/js/epics/favorite.js
+++ b/geonode_mapstore_client/client/js/epics/favorite.js
@@ -9,9 +9,7 @@
 import { Observable } from 'rxjs';
 import {
     updateResourceProperties,
-    SET_FAVORITE_RESOURCE,
-    removeFavoriteResource,
-    setFavoriteResources
+    SET_FAVORITE_RESOURCE
 } from '@js/actions/gnresource';
 import {
     updateResources
@@ -41,15 +39,16 @@ export const gnSaveFavoriteContent = (action$, store) =>
                 .defer(() => setFavoriteResource(pk, favorite))
                 .switchMap(() => {
                     return Observable.of(
-                        updateResourceProperties({
-                            'favorite': favorite
-                        }),
                         updateResources(newResources, true)
                     );
                 })
                 .catch((error) => {
                     return Observable.of(
-                        action.favorite ? removeFavoriteResource(pk) : setFavoriteResources(pk),
+                        action.favorite ? updateResourceProperties({
+                            'favorite': false
+                        }) : updateResourceProperties({
+                            'favorite': true
+                        }),
                         errorNotification({ title: "gnviewer.cannotPerfomAction", message: error?.data?.message || error?.data?.detail || error?.originalError?.message || "gnviewer.syncErrorDefault" }));
                 });
 

--- a/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
+++ b/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
@@ -20,8 +20,7 @@ import {
     setMapThumbnail,
     setResourceThumbnail,
     enableMapThumbnailViewer,
-    downloadResource,
-    updateResourceProperties
+    downloadResource
 } from '@js/actions/gnresource';
 import { processingDownload } from '@js/selectors/resourceservice';
 import FaIcon from '@js/components/FaIcon/FaIcon';
@@ -77,8 +76,7 @@ const ConnectedDetailsPanel = connect(
         onMapThumbnail: setMapThumbnail,
         onResourceThumbnail: setResourceThumbnail,
         onClose: enableMapThumbnailViewer,
-        onAction: downloadResource,
-        onUpdateFavorite: updateResourceProperties
+        onAction: downloadResource
     }
 )(DetailsPanel);
 

--- a/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
+++ b/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
@@ -21,8 +21,7 @@ import {
     setResourceThumbnail,
     enableMapThumbnailViewer,
     downloadResource,
-    setFavoriteResources,
-    removeFavoriteResource
+    updateResourceProperties
 } from '@js/actions/gnresource';
 import { processingDownload } from '@js/selectors/resourceservice';
 import FaIcon from '@js/components/FaIcon/FaIcon';
@@ -57,14 +56,13 @@ const ConnectedDetailsPanel = connect(
         updatingThumbnailResource,
         mapSelector,
         state => state?.gnresource?.showMapThumbnail || false,
-        processingDownload,
-        state => state?.gnresource?.favoriteResources || []
-    ], (resource, loading, favorite, savingThumbnailMap, layers, thumbnailChanged, resourceThumbnailUpdating, mapData, showMapThumbnail, downloading, favorites) => ({
+        processingDownload
+    ], (resource, loading, favorite, savingThumbnailMap, layers, thumbnailChanged, resourceThumbnailUpdating, mapData, showMapThumbnail, downloading) => ({
         layers: layers,
         resource,
         loading,
         savingThumbnailMap,
-        favorite: favorite || favorites.includes(resource?.pk),
+        favorite: favorite,
         isThumbnailChanged: thumbnailChanged,
         resourceThumbnailUpdating,
         initialBbox: mapData?.bbox,
@@ -80,8 +78,7 @@ const ConnectedDetailsPanel = connect(
         onResourceThumbnail: setResourceThumbnail,
         onClose: enableMapThumbnailViewer,
         onAction: downloadResource,
-        setFavorites: setFavoriteResources,
-        removeFavorite: removeFavoriteResource
+        onUpdateFavorite: updateResourceProperties
     }
 )(DetailsPanel);
 

--- a/geonode_mapstore_client/client/js/reducers/__tests__/gnresource-test.js
+++ b/geonode_mapstore_client/client/js/reducers/__tests__/gnresource-test.js
@@ -14,7 +14,6 @@ import {
     resourceError,
     updateResourceProperties,
     setResourceType,
-    setNewResource,
     setResourceId,
     setResourcePermissions,
     editThumbnailResource,
@@ -79,16 +78,6 @@ describe('gnresource reducer', () => {
         const state = gnresource({}, setResourceType(resourceType));
         expect(state).toEqual({
             type: resourceType
-        });
-    });
-    it('should test setNewResource', () => {
-        const state = gnresource({}, setNewResource());
-        expect(state).toEqual({
-            selectedLayerPermissions: [],
-            data: {},
-            permissions: [],
-            favoriteResources: [],
-            isNew: true
         });
     });
     it('should test setResourceId', () => {

--- a/geonode_mapstore_client/client/js/reducers/gnresource.js
+++ b/geonode_mapstore_client/client/js/reducers/gnresource.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-import {isEqual, uniq} from 'lodash';
+import {isEqual } from 'lodash';
 import {
     RESOURCE_LOADING,
     SET_RESOURCE,
@@ -27,9 +27,7 @@ import {
     SET_RESOURCE_COMPACT_PERMISSIONS,
     UPDATE_RESOURCE_COMPACT_PERMISSIONS,
     RESET_GEO_LIMITS,
-    ENABLE_MAP_THUMBNAIL_VIEWER,
-    SET_FAVORITE_RESOURCES,
-    REMOVE_FAVORITE_RESOURCE
+    ENABLE_MAP_THUMBNAIL_VIEWER
 } from '@js/actions/gnresource';
 
 import {
@@ -40,8 +38,7 @@ import {
 const defaultState = {
     selectedLayerPermissions: [],
     data: {},
-    permissions: [],
-    favoriteResources: []
+    permissions: []
 };
 
 function gnresource(state = defaultState, action) {
@@ -211,20 +208,6 @@ function gnresource(state = defaultState, action) {
             };
         }
         return state;
-    case SET_FAVORITE_RESOURCES: {
-        const favoriteResources = Array.isArray(action.favorites) ? action.favorites : uniq([...state.favoriteResources, action.favorites]);
-        return {
-            ...state,
-            favoriteResources: [...favoriteResources]
-        };
-    }
-    case REMOVE_FAVORITE_RESOURCE: {
-        const newFavorites = state.favoriteResources?.filter(fav => fav !== action.pk);
-        return {
-            ...state,
-            favoriteResources: [...newFavorites]
-        };
-    }
     default:
         return state;
     }

--- a/geonode_mapstore_client/client/js/routes/Detail.jsx
+++ b/geonode_mapstore_client/client/js/routes/Detail.jsx
@@ -24,7 +24,7 @@ import {
     loadFeaturedResources
 } from '@js/actions/gnsearch';
 
-import { downloadResource, setFavoriteResource, setFavoriteResources, removeFavoriteResource } from '@js/actions/gnresource';
+import { downloadResource, setFavoriteResource, updateResourceProperties } from '@js/actions/gnresource';
 import {
     hashLocationToHref,
     clearQueryParams,
@@ -51,11 +51,10 @@ const ConnectedDetailsPanel = connect(
         state => state?.gnresource?.loading || false,
         state => state?.gnresource?.data?.favorite || false,
         processingDownload,
-        state => state?.gnresource?.data || null,
-        state => state?.gnresource?.favoriteResources || []
-    ], (loading, favorite, downloading, resource, favorites) => ({
+        state => state?.gnresource?.data || null
+    ], (loading, favorite, downloading, resource) => ({
         loading,
-        favorite: favorite || favorites.includes(resource?.pk),
+        favorite: favorite,
         downloading,
         canDownload: resourceHasPermission(resource, 'download_resourcebase'),
         resourceId: resource.pk
@@ -63,8 +62,7 @@ const ConnectedDetailsPanel = connect(
     {
         onFavorite: setFavoriteResource,
         onAction: downloadResource,
-        setFavorites: setFavoriteResources,
-        removeFavorite: removeFavoriteResource
+        onUpdateFavorite: updateResourceProperties
     }
 )(DetailsPanel);
 function Detail({

--- a/geonode_mapstore_client/client/js/routes/Detail.jsx
+++ b/geonode_mapstore_client/client/js/routes/Detail.jsx
@@ -24,7 +24,7 @@ import {
     loadFeaturedResources
 } from '@js/actions/gnsearch';
 
-import { downloadResource, setFavoriteResource, updateResourceProperties } from '@js/actions/gnresource';
+import { downloadResource, setFavoriteResource } from '@js/actions/gnresource';
 import {
     hashLocationToHref,
     clearQueryParams,
@@ -61,8 +61,7 @@ const ConnectedDetailsPanel = connect(
     })),
     {
         onFavorite: setFavoriteResource,
-        onAction: downloadResource,
-        onUpdateFavorite: updateResourceProperties
+        onAction: downloadResource
     }
 )(DetailsPanel);
 function Detail({


### PR DESCRIPTION
The client adopts the field in displaying which resources have been favorited in the detail panel.