### PR TITLE
[Backport 4.x][Fixes 1169] Update total when resource is removed from favorite

### DIFF
--- a/geonode_mapstore_client/client/js/actions/gnsearch.js
+++ b/geonode_mapstore_client/client/js/actions/gnsearch.js
@@ -15,6 +15,7 @@ export const UPDATE_RESOURCES_METADATA = 'GEONODE_SEARCH:UPDATE_RESOURCES_METADA
 export const SET_FEATURED_RESOURCES = 'GEONODE:SET_FEATURED_RESOURCES';
 export const UPDATE_FEATURED_RESOURCES = 'GEONODE_SEARCH:UPDATE_FEATURED_RESOURCES';
 export const REDUCE_TOTAL_COUNT = 'GEONODE_REDUCE_TOTAL_COUNT';
+export const INCREASE_TOTAL_COUNT = 'GEONODE_INCREASE_TOTAL_COUNT';
 
 /**
 * Actions for GeoNode resource featured items
@@ -87,6 +88,15 @@ export function loadFeaturedResources(action, pageSize = 4) {
 export function reduceTotalCount() {
     return {
         type: REDUCE_TOTAL_COUNT
+    };
+}
+
+/**
+ * Increase total count of resouces after deletion
+ */
+export function increaseTotalCount() {
+    return {
+        type: INCREASE_TOTAL_COUNT
     };
 }
 

--- a/geonode_mapstore_client/client/js/epics/favorite.js
+++ b/geonode_mapstore_client/client/js/epics/favorite.js
@@ -12,7 +12,9 @@ import {
     SET_FAVORITE_RESOURCE
 } from '@js/actions/gnresource';
 import {
-    updateResources
+    updateResources,
+    reduceTotalCount,
+    increaseTotalCount
 } from '@js/actions/gnsearch';
 import {
     setFavoriteResource
@@ -40,7 +42,9 @@ export const gnSaveFavoriteContent = (action$, store) =>
                 Observable.defer(() => setFavoriteResource(pk, favorite))
                     .switchMap(() => {
                         return Observable.of(
-                            updateResources(newResources, true)
+                            updateResources(newResources, true),
+                            // if on favorites filter page, we must adjust total count appropriately
+                            ...((state?.gnsearch?.params?.f?.includes('favorite') && !action.favorite) ? [reduceTotalCount()] : [increaseTotalCount()])
                         );
                     })
                     .catch((error) => {

--- a/geonode_mapstore_client/client/js/reducers/gnsearch.js
+++ b/geonode_mapstore_client/client/js/reducers/gnsearch.js
@@ -14,7 +14,8 @@ import {
     LOADING_RESOURCES,
     UPDATE_RESOURCES_METADATA,
     SET_FEATURED_RESOURCES,
-    REDUCE_TOTAL_COUNT
+    REDUCE_TOTAL_COUNT,
+    INCREASE_TOTAL_COUNT
 } from '@js/actions/gnsearch';
 
 import { UPDATE_SINGLE_RESOURCE } from '@js/actions/gnresource';
@@ -102,6 +103,12 @@ function gnsearch(state = defaultState, action) {
         return {
             ...state,
             total: state.total - 1
+        };
+    }
+    case INCREASE_TOTAL_COUNT: {
+        return {
+            ...state,
+            total: state.total + 1
         };
     }
     default:


### PR DESCRIPTION
The total count for favorite resource is adjusted appropriately 

![total fav](https://user-images.githubusercontent.com/42542676/188436379-c4950e76-323c-470a-abc3-a8fb81020a81.gif)
