### PR TITLE
[Fixes 1174] Error not correctly shown error (#1176)

### DIFF
--- a/geonode_mapstore_client/client/js/routes/upload/UploadCard.jsx
+++ b/geonode_mapstore_client/client/js/routes/upload/UploadCard.jsx
@@ -92,8 +92,8 @@ function UploadCard({
                         : null}
                     {(state === 'INVALID' || status === 'failed')
                         ? <>
-                            {!errorLog ? <ErrorMessageWithTooltip tooltipId={<Message msgId={`gnviewer.${getUploadErrorMessageFromCode(error?.code)}`} msgParams={{ limit: getUploadErrorMessageFromCode(error?.code) === 'fileExceeds' ? maxAllowedSize : maxParallelUploads }} />} />
-                                : <ErrorMessageWithTooltip tooltip={getUploadErrorMessageFromCode(null, errorLog)} />
+                            {!errorLog ? <ErrorMessageWithTooltip tooltipPosition="left" tooltipId={<Message msgId={`gnviewer.${getUploadErrorMessageFromCode(error?.code)}`} msgParams={{ limit: getUploadErrorMessageFromCode(error?.code) === 'fileExceeds' ? maxAllowedSize : maxParallelUploads }} />} />
+                                : <ErrorMessageWithTooltip tooltipPosition="left" tooltip={getUploadErrorMessageFromCode(null, errorLog)} />
                             }
                         </>
                         : null}

--- a/geonode_mapstore_client/client/js/utils/ErrorUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ErrorUtils.js
@@ -8,7 +8,9 @@
 
 export const getUploadErrorMessageFromCode = (code, log) => {
     if (log) {
-        return log;
+        // Make the error log more human readable
+        const errorMsg = log.replace(/[()]/g, '')?.replace(/[\[\]']+/g, '')?.split('ErrorDetailstring=')?.join(' ');
+        return errorMsg;
     }
     switch (code) {
     case 'upload_parallelism_limit_exceeded': {


### PR DESCRIPTION
The error tool-tip position is moved to the left to accommodate longer error messages without being cut out 
<img width="388" alt="Screenshot 2022-09-06 at 10 40 02" src="https://user-images.githubusercontent.com/42542676/188615136-f407c459-459f-441f-83ab-d672c2a51bd7.png">

ref #1174 