### PR TITLE
[Fixes 1144] Disable / hide the charts button if a user doesn't have enough perms on the dataset

### DIFF
--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -2137,7 +2137,10 @@
                 "name": "Locate"
             },
             {
-                "name": "WidgetsBuilder"
+                "name": "WidgetsBuilder",
+                "cfg": {
+                    "disablePluginIf": "{!state('selectedLayerPermissions').includes('download_resourcebase')}"
+                }
             },
             {
                 "name": "Save",


### PR DESCRIPTION
Widgets are disabled when user does not have download perms