### PR TITLE
[Backport 4.0.x][Fixes 1147] Theme override styles from customization app needs some improvement

### DIFF
--- a/docs/customizations/theme.html
+++ b/docs/customizations/theme.html
@@ -536,7 +536,7 @@
             .then(function (text) {
                 const extraLess = document.getElementById('extra-less-functions').innerText;
                 function renderLessVariables(init) {
-                    less.render(text + extraLess + ' .gn-theme { .extract-css-variables(@gn-theme-vars); }', { modifyVars: params }, function (error, output) {
+                    less.render(text + extraLess + ' :root { .extract-css-variables(@gn-theme-vars); }', { modifyVars: params }, function (error, output) {
                         document.getElementById('gn-css-variables').innerHTML = output.css;
                         textarea.innerHTML = '/* copy this style in the "Custom CSS rules" field of the theme page to apply these new variables */\n' + output.css + '';
                         if (init) {


### PR DESCRIPTION
The theme variables are defined in the root

ref #1147 
