### PR TITLE
[Fixes 1210] Configure the client to receive image properties from server

### DIFF
--- a/geonode_mapstore_client/client/js/components/ContentsEditable/ThumbnailEditable.jsx
+++ b/geonode_mapstore_client/client/js/components/ContentsEditable/ThumbnailEditable.jsx
@@ -12,7 +12,9 @@ import FaIcon from '@js/components/FaIcon';
 import Button from '@js/components/Button';
 import tooltip from '@mapstore/framework/components/misc/enhancers/tooltip';
 import Message from '@mapstore/framework/components/I18N/Message';
+import { getConfigProp } from '@mapstore/framework/utils/ConfigUtils';
 const ButtonWithToolTip = tooltip(Button);
+
 
 const ThumbnailEditable = ({
     defaultImage,
@@ -24,6 +26,9 @@ const ThumbnailEditable = ({
         setThumbnail(defaultImage);
 
     }, [defaultImage]);
+
+    const { defaultThumbnailSize } = getConfigProp('geoNodeSettings');
+    const { height = 200, width = 240 } = defaultThumbnailSize;
 
     const handleDialaogWindowUpload = () => {
         thumbnailRef?.current?.nextElementSibling.click();
@@ -40,8 +45,8 @@ const ThumbnailEditable = ({
                 }}
                 thumbnailOptions={{
                     contain: false,
-                    width: 250,
-                    height: 184.8,
+                    width,
+                    height,
                     type: 'image/png'
                 }}
             />


### PR DESCRIPTION
The client now utilizes a `defaultThumbnailSize` setting provided in `geoNodeSettings`