### PR TITLE
[Fixes 1177] Hide copy/clone option for users without permissions

### DIFF
--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -432,7 +432,17 @@
                     "action": "copy",
                     "labelId": "gnviewer.clone",
                     "icon": "copy",
-                    "authenticated": true
+                    "authenticated": true,
+                    "perms": [
+                        {
+                            "type": "user",
+                            "value": "add_resource"
+                        },
+                        {
+                            "type": "resource",
+                            "value": "download_resourcebase"
+                        }
+                    ]
                 },
                 {
                     "type": "button",
@@ -837,7 +847,7 @@
                         {
                             "labelId": "gnviewer.save",
                             "showPendingChangesIcon": true,
-                            "disableIf": "{!state('isNewResource') && !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase') && !context.canCopyResource(state('gnResourceData'), state('user'))}",
+                            "disableIf": "{!state('isNewResource') && !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase') && (!context.canCopyResource(state('gnResourceData'), state('user')) || !state('selectedLayerPermissions').includes('download_resourcebase'))}",
                             "type": "dropdown",
                             "items": [
                                 {
@@ -846,7 +856,8 @@
                                 },
                                 {
                                     "type": "plugin",
-                                    "name": "SaveAs"
+                                    "name": "SaveAs",
+                                    "disableIf": "{!state('selectedLayerPermissions').includes('download_resourcebase') || !context.resourceHasPermission(state('gnResourceData'), 'download_resourcebase')}"
                                 }
                             ]
                         },
@@ -2390,7 +2401,7 @@
                             "labelId": "gnviewer.save",
                             "type": "dropdown",
                             "showPendingChangesIcon": true,
-                            "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase') && !context.canCopyResource(state('gnResourceData'), state('user'))}",
+                            "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase') && (!context.canCopyResource(state('gnResourceData'), state('user')) || !context.resourceHasPermission(state('gnResourceData'), 'download_resourcebase'))}",
                             "items": [
                                 {
                                     "type": "plugin",
@@ -2398,7 +2409,8 @@
                                 },
                                 {
                                     "type": "plugin",
-                                    "name": "SaveAs"
+                                    "name": "SaveAs",
+                                    "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'download_resourcebase')}"
                                 }
                             ]
                         },


### PR DESCRIPTION
A User without download_resourcebase and add_resourceis no longer able to copy/clone a dataset and document.