### PR TITLE
[Backport 4.0.x][Fixes #1243] Show metadata page in Document view when preview is not available

### DIFF
--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -321,7 +321,11 @@ export const getDatasetByPk = (pk) => {
 };
 
 export const getDocumentByPk = (pk) => {
-    return axios.get(parseDevHostname(`${endpoints[DOCUMENTS]}/${pk}`))
+    return axios.get(parseDevHostname(`${endpoints[DOCUMENTS]}/${pk}`), {
+        params: {
+            include: ['executions']
+        }
+    })
         .then(({ data }) => data.document);
 };
 

--- a/geonode_mapstore_client/client/js/components/MediaViewer/Media.jsx
+++ b/geonode_mapstore_client/client/js/components/MediaViewer/Media.jsx
@@ -13,12 +13,13 @@ import { determineResourceType } from '@js/utils/FileUtils';
 import Loader from '@mapstore/framework/components/misc/Loader';
 import MainEventView from '@js/components/MainEventView';
 import { getResourceTypesInfo, getResourceImageSource } from '@js/utils/ResourceUtils';
+import MetadataPreview from '@js/components/MetadataPreview';
 
 const Scene3DViewer = lazy(() => import('@js/components/MediaViewer/Scene3DViewer'));
 
-function UnsupportedViewer() {
+function UnsupportedViewer({url = ''}) {
     return (
-        <MainEventView msgId={'gnhome.noPreview'} icon="file" />
+        <MetadataPreview url={url} />
     );
 }
 
@@ -52,9 +53,9 @@ const Media = ({ resource, ...props }) => {
 
     const mediaTypes = getResourceTypesInfo();
     const {
-        canPreviewed
+        hasPermission, metadataPreviewUrl = () => {}
     } = resource && (mediaTypes[resource.subtype] || mediaTypes[resource.resource_type]) || {};
-    const viewResource = resource?.pk && canPreviewed && canPreviewed(resource);
+    const viewResource = resource?.pk && hasPermission && hasPermission(resource);
 
     if (resource && viewResource) {
         const mediaType = determineResourceType(resource.extension);
@@ -68,6 +69,7 @@ const Media = ({ resource, ...props }) => {
                 id={resource.pk}
                 thumbnail={() => getResourceImageSource(resource?.thumbnail_url)}
                 src={resource.href}
+                url={resource ? metadataPreviewUrl(resource) : ''}
             />
         </Suspense>);
     }

--- a/geonode_mapstore_client/client/js/components/MetadataPreview/MetadataPreview.jsx
+++ b/geonode_mapstore_client/client/js/components/MetadataPreview/MetadataPreview.jsx
@@ -1,0 +1,32 @@
+/*
+* Copyright 2022, GeoSolutions Sas.
+* All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+
+function MetadataPreview({
+    url
+}) {
+    return (
+        <div className="gn-main-event-container">
+            <iframe
+                frameBorder="0"
+                key={url}
+                src={url}
+                style={{
+                    width: '100%',
+                    height: '100%'
+                }} />
+        </div>
+    );
+}
+
+MetadataPreview.defaultProps = {
+    url: ''
+};
+
+export default MetadataPreview;

--- a/geonode_mapstore_client/client/js/components/MetadataPreview/index.js
+++ b/geonode_mapstore_client/client/js/components/MetadataPreview/index.js
@@ -1,0 +1,1 @@
+export { default } from './MetadataPreview';

--- a/geonode_mapstore_client/client/js/epics/gnsearch.js
+++ b/geonode_mapstore_client/client/js/epics/gnsearch.js
@@ -13,6 +13,7 @@ import isNil from 'lodash/isNil';
 import {
     getResources,
     getResourceByPk,
+    getDocumentByPk,
     getFeaturedResources,
     getResourceByUuid
 } from '@js/api/geonode/v2';
@@ -228,7 +229,7 @@ export const gnsSelectResourceEpic = (action$, store) =>
             const resources = state.gnsearch?.resources || [];
             const selectedResource = resources.find(({ pk, resource_type: resourceType}) =>
                 pk === action.pk && action.ctype === resourceType);
-            return Observable.defer(() => getResourceByPk(action.pk))
+            return Observable.defer(() => action.ctype !== 'document' ? getResourceByPk(action.pk) : getDocumentByPk(action.pk))
                 .switchMap((resource) => {
                     return Observable.of(setResource({
                         ...resource,

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -15,6 +15,7 @@ import { ProcessTypes, ProcessStatus } from '@js/utils/ResourceServiceUtils';
 import { bboxToPolygon } from '@js/utils/CoordinatesUtils';
 import { uniqBy, orderBy, isString, isObject, pick, difference } from 'lodash';
 import { excludeGoogleBackground, extractTileMatrixFromSources } from '@mapstore/framework/utils/LayersUtils';
+import { determineResourceType } from '@js/utils/FileUtils';
 
 /**
 * @module utils/ResourceUtils
@@ -280,10 +281,12 @@ export const getResourceTypesInfo = () => ({
     [ResourceTypes.DOCUMENT]: {
         icon: 'file',
         name: 'Document',
-        canPreviewed: (resource) => resourceHasPermission(resource, 'download_resourcebase'),
+        canPreviewed: (resource) => resourceHasPermission(resource, 'download_resourcebase') && !!(determineResourceType(resource.extension) !== 'unsupported'),
+        hasPermission: (resource) => resourceHasPermission(resource, 'download_resourcebase'),
         formatEmbedUrl: (resource) => resource?.embed_url && parseDevHostname(resource.embed_url),
         formatDetailUrl: (resource) => resource?.detail_url && parseDevHostname(resource.detail_url),
-        formatMetadataUrl: (resource) => (`/documents/${resource.pk}/metadata`)
+        formatMetadataUrl: (resource) => (`/documents/${resource.pk}/metadata`),
+        metadataPreviewUrl: (resource) => (`/documents/${resource.pk}/metadata_detail?preview`)
     },
     [ResourceTypes.GEOSTORY]: {
         icon: 'book',

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.de-DE.json
@@ -50,7 +50,7 @@
             "viewImage": "Bild ansehen",
             "viewVideo": "Video ansehen",
             "viewDashboard": "Dashboard ansehen",
-            "viewMetadata": "Metadaten ansehen",
+            "viewMetadata": "Details anzeigen",
             "author": "Autor",
             "publication": "Veröffentlichung",
             "creation": "Erstellungsdatum",

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.en-US.json
@@ -50,7 +50,7 @@
             "viewImage": "View image",
             "viewVideo": "View video",
             "viewDashboard": "View dashboard",
-            "viewMetadata": "View metadata",
+            "viewMetadata": "View details",
             "author": "Author",
             "publication": "Publication",
             "creation": "Creation",

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.es-ES.json
@@ -50,7 +50,7 @@
             "viewImage": "Ver imágenes",
             "viewVideo": "Ver video",
             "viewDashboard": "Ver dashboard",
-            "viewMetadata": "Voir metadatos",
+            "viewMetadata": "Ver detalles",
             "author": "Autor",
             "publication": "Publicación",
             "creation": "Creación",

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.fr-FR.json
@@ -50,7 +50,7 @@
             "viewImage": "Voir images",
             "viewVideo": "Voir video",
             "viewDashboard": "Voir dashboard",
-            "viewMetadata": "Voir métadonnées",
+            "viewMetadata": "Voir les détails",
             "author": "Auteur",
             "publication": "Publication",
             "creation": "Création",

--- a/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
+++ b/geonode_mapstore_client/client/static/mapstore/translations/data.it-IT.json
@@ -50,7 +50,7 @@
             "viewImage": "Visualizza immagine",
             "viewVideo": "Visualizza video",
             "viewDashboard": "Visualizza dashboard",
-            "viewMetadata": "Visualizza metadati",
+            "viewMetadata": "Visualizza dettagli",
             "author": "Autore",
             "publication": "Pubblicazione",
             "creation": "Creazione",


### PR DESCRIPTION
The following changes have been made: 
1. When a viewer is not available for a document, a full width/height iframe is shown with a preview of the document's metadata
> ![meta](https://user-images.githubusercontent.com/42542676/196659587-2ecb488b-6d3b-438e-bf4a-1fce972aea34.gif)
2.  In the details page, the preview panel is hidden altogether in that case,
> <img width="1295" alt="Screenshot 2022-10-19 at 09 58 49" src="https://user-images.githubusercontent.com/42542676/196660444-458ecaaa-15b8-4fdc-8981-74d80367b8b9.png">
3. View Metadata button is now 'View details'
4. On the detail page, the request for details of the resource is made to the `/documents` endpoint and not `/resources`