### PR TITLE
[Backport 4.0.x][Fixes 1291] The search box should use metadata_only=False

### DIFF
--- a/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/search_bar.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/search_bar.html
@@ -126,7 +126,8 @@
                     '?page=' + options.page +
                     '&search=' + options.value +
                     '&search_fields=title' +
-                    '&search_fields=abstract';
+                    '&search_fields=abstract' +
+                    '&filter{metadata_only}=false';
                     request = $.ajax({
                         url: url,
                         type: 'GET',


### PR DESCRIPTION
The `metadata_only=false filter` has been added for the search bar