### PR TITLE
[Backport 4.0.x][Fixes #1262] Investigate and avoid making calls to `/resources` on view page

### DIFF
--- a/geonode_mapstore_client/client/js/routes/Viewer.jsx
+++ b/geonode_mapstore_client/client/js/routes/Viewer.jsx
@@ -108,7 +108,7 @@ function ViewerRoute({
                 topbar.style.top = mainHeader.clientHeight + 'px';
             }
         }
-        // hide the naviagtion bar is a recource is being viewed
+        // hide the navigation bar if a resource is being viewed
         if (!loading) {
             document.getElementById('gn-topbar')?.classList.add('hide-navigation');
             document.getElementById('gn-brand-navbar-bottom')?.classList.add('hide-search-bar');


### PR DESCRIPTION
Calls to `/resources` on viewer pages are stopped