### PR TITLE
[Fixes 1307] Manage permissions on group not respected

### DIFF
--- a/geonode_mapstore_client/client/js/selectors/resource.js
+++ b/geonode_mapstore_client/client/js/selectors/resource.js
@@ -105,9 +105,10 @@ export const canEditPermissions = (state) => {
     const groups = compactPermissions.groups || [];
     const organizations = compactPermissions.organizations || [];
     const user = state?.security?.user;
+    const userGroups = user?.info.groups.filter(group => group !== 'anonymous') || [];
     const { permissions } = user && users.find(({ id }) => id === user.pk) || {};
-    const { permissions: allowedGroups } = user && groups.find((group) => user.info.groups.includes(group.name)) || {};
-    const { permissions: allowedOrganizations } = user && organizations.find((organization) => user.info.groups.includes(organization.name)) || {};
+    const { permissions: allowedGroups } = user && groups.find((group) => userGroups.includes(group.name)) || {};
+    const { permissions: allowedOrganizations } = user && organizations.find((organization) => userGroups.includes(organization.name)) || {};
     return ['owner', 'manage'].includes(permissions) || ['manage'].includes(allowedGroups) || ['manage'].includes(allowedOrganizations);
 };
 

--- a/geonode_mapstore_client/client/js/selectors/resource.js
+++ b/geonode_mapstore_client/client/js/selectors/resource.js
@@ -99,17 +99,18 @@ export const getPermissionsPayload = (state) => {
     };
 };
 
+const inheritsPerms = (user = null, groups = []) => {
+    return user && groups.some(group => user.info.groups.some(userGroup => userGroup === group.name) && group.permissions === 'manage') || false;
+};
+
 export const canEditPermissions = (state) => {
     const compactPermissions = getCompactPermissions(state);
     const users = compactPermissions.users || [];
     const groups = compactPermissions.groups || [];
     const organizations = compactPermissions.organizations || [];
     const user = state?.security?.user;
-    const userGroups = user?.info.groups.filter(group => group !== 'anonymous') || [];
     const { permissions } = user && users.find(({ id }) => id === user.pk) || {};
-    const { permissions: allowedGroups } = user && groups.find((group) => userGroups.includes(group.name)) || {};
-    const { permissions: allowedOrganizations } = user && organizations.find((organization) => userGroups.includes(organization.name)) || {};
-    return ['owner', 'manage'].includes(permissions) || ['manage'].includes(allowedGroups) || ['manage'].includes(allowedOrganizations);
+    return ['owner', 'manage'].includes(permissions) || inheritsPerms(user, groups) || inheritsPerms(user, organizations);
 };
 
 export const getSelectedLayerPermissions = (state) => {


### PR DESCRIPTION
Registered users perms are now considered

The issue was caused by [this line](https://github.com/GeoNode/geonode-mapstore-client/blob/master/geonode_mapstore_client/client/js/selectors/resource.js#L109)
`.find` returned the permissions from the first group in `user.info.groups` (which was always 'anonymous'), and so permissions for registered users were never checked.

Since anonymous users are not relevant at this case, we can exclude that group from the checks.