### PR TITLE
[Fixes 1305] Unable to upload GEOJSON files with .json extention

### DIFF
--- a/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
+++ b/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
@@ -25,10 +25,10 @@ import UploadListContainer from '@js/routes/upload/UploadListContainer';
 import UploadContainer from '@js/routes/upload/UploadContainer';
 import { getConfigProp } from '@mapstore/framework/utils/ConfigUtils';
 import { parseUploadResponse, processUploadResponse, parseUploadFiles } from '@js/utils/ResourceUtils';
-import { getFileNameParts } from '@js/utils/FileUtils';
+import { getFileNameParts, getFileType } from '@js/utils/FileUtils';
 
 function getDatasetFileType(file, supportedTypes) {
-    const { type } = file;
+    const type = getFileType(file);
     const { ext } = getFileNameParts(file);
     const datasetFileType = supportedTypes.find((fileType) =>
         (fileType.ext || []).includes(ext)

--- a/geonode_mapstore_client/client/js/utils/FileUtils.js
+++ b/geonode_mapstore_client/client/js/utils/FileUtils.js
@@ -48,3 +48,16 @@ export const getFileNameParts = (file) => {
     const baseName = [...nameParts].splice(0, nameParts.length - 1).join('.');
     return { ext: ext.toLowerCase(), baseName };
 };
+
+/**
+ * Get file type from file.
+ * In cases where the file type is application/json (which happens when file was originally .geojson converted to .json)
+ * We return json as file type
+ */
+export const getFileType = (file) => {
+    const { type } = file;
+    if (type === 'application/json') {
+        return 'json';
+    }
+    return type;
+};


### PR DESCRIPTION
The issue was caused because when a file is changed from geojson to json, in some cases, the file type is recorded in the file metadata as `application/json` which was not recognized by the client. This PR caters for that.