### PR TITLE
[Fixes 1336] Deleting resources removes applied filters

### DIFF
--- a/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/client/static/mapstore/configs/localConfig.json
@@ -2654,7 +2654,10 @@
                 }
             },
             {
-                "name": "DeleteResource"
+                "name": "DeleteResource",
+                "cfg": {
+                    "redirectTo": false
+                }
             },
             {
                 "name": "DownloadResource"


### PR DESCRIPTION
The bug was caused by a default `redirectTo` prop which triggered a location change action to `'/'`