### PR TITLE
[Fixes #1308] Clone option in the list view is missing on Maps for non admin users

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/SaveAs.jsx
+++ b/geonode_mapstore_client/client/js/plugins/SaveAs.jsx
@@ -12,9 +12,8 @@ import { createSelector } from 'reselect';
 import { createPlugin } from '@mapstore/framework/utils/PluginsUtils';
 import { setControlProperty } from '@mapstore/framework/actions/controls';
 import Message from '@mapstore/framework/components/I18N/Message';
-import { Glyphicon } from 'react-bootstrap';
 import { mapInfoSelector } from '@mapstore/framework/selectors/map';
-import { isLoggedIn } from '@mapstore/framework/selectors/security';
+import { userSelector } from '@mapstore/framework/selectors/security';
 import Button from '@js/components/Button';
 import {
     saveContent,
@@ -33,6 +32,7 @@ import {
     getResourceDirtyState
 } from '@js/selectors/resource';
 import { ProcessTypes } from '@js/utils/ResourceServiceUtils';
+import { canCopyResource } from '@js/utils/ResourceUtils';
 import { processResources } from '@js/actions/gnresource';
 import { getCurrentResourceCopyLoading } from '@js/selectors/resourceservice';
 import Dropdown from '@js/components/Dropdown';
@@ -135,15 +135,28 @@ function SaveAsButton({
     ;
 }
 
+const canCopyResourceFunction = (state) => {
+    return (resource) => {
+        const user = userSelector(state);
+        if (!user) {
+            return false;
+        }
+        const isResourceNew = isNewResource(state);
+        const canAdd = canAddResource(state);
+        if (isResourceNew && canAdd) {
+            return true;
+        }
+        return canCopyResource(resource, user);
+    };
+};
+
 const ConnectedSaveAsButton = connect(
     createSelector(
-        isLoggedIn,
-        canAddResource,
         getResourceData,
         getResourceDirtyState,
-        isNewResource,
-        (loggedIn, userCanAddResource, resource, dirtyState, isResourceNew) => ({
-            enabled: loggedIn && userCanAddResource && (resource?.is_copyable || isResourceNew),
+        canCopyResourceFunction,
+        (resource, dirtyState, canCopy) => ({
+            enabled: !!canCopy(resource),
             resource,
             disabled: !!dirtyState
         })
@@ -155,15 +168,10 @@ const ConnectedSaveAsButton = connect(
 
 function CopyMenuItem({
     resource,
-    authenticated,
-    onCopy,
-    userCanAddResource
+    canCopy,
+    onCopy
 }) {
-    if (!(authenticated
-        && userCanAddResource
-        && resource?.is_copyable
-        && resource?.perms?.includes('download_resourcebase'))
-    ) {
+    if (!canCopy(resource)) {
         return null;
     }
     return (
@@ -179,7 +187,11 @@ function CopyMenuItem({
 }
 
 const ConnectedMenuItem = connect(
-    createSelector([isLoggedIn, canAddResource], (authenticated, userCanAddResource) => ({ authenticated, userCanAddResource })),
+    createSelector([
+        canCopyResourceFunction
+    ], (canCopy) => ({
+        canCopy
+    })),
     {
         onCopy: setControlProperty.bind(null, ProcessTypes.COPY_RESOURCE, 'value')
     }
@@ -188,20 +200,6 @@ const ConnectedMenuItem = connect(
 export default createPlugin('SaveAs', {
     component: SaveAsPlugin,
     containers: {
-        BurgerMenu: {
-            name: 'saveAs',
-            position: 30,
-            text: <Message msgId="saveAs"/>,
-            icon: <Glyphicon glyph="floppy-open"/>,
-            action: setControlProperty.bind(null, 'saveAs', null),
-            selector: createSelector(
-                isLoggedIn,
-                canAddResource,
-                (loggedIn, userCanAddResource) => ({
-                    style: (loggedIn && userCanAddResource) ? {} : { display: 'none' }
-                })
-            )
-        },
         ActionNavbar: {
             name: 'SaveAs',
             Component: ConnectedSaveAsButton

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -585,13 +585,19 @@ export const parseMapConfig = (mapResponse, resource = {}) => {
     };
 };
 
-/**
-* Util to check if resosurce can be cloned (Save As)
+/*
+* Util to check if resource can be cloned (Save As)
 * Requirements for copying are 'add_resource' permission and is_copyable property on resource
+* the dataset and document need also the download_resourcebase permission
 */
 export const canCopyResource = (resource, user) => {
     const canAdd = user?.perms?.includes('add_resource');
     const canCopy = resource?.is_copyable;
+    const resourceType = resource?.resource_type;
+    if ([ResourceTypes.DATASET, ResourceTypes.DOCUMENT].includes(resourceType)) {
+        const canDownload = !!resource?.perms?.includes('download_resourcebase');
+        return (canAdd && canCopy && canDownload) ? true : false;
+    }
     return (canAdd && canCopy) ? true : false;
 };
 

--- a/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
@@ -422,11 +422,19 @@ describe('Test Resource Utils', () => {
         expect(pasrsedStyleName).toBe('test:testName');
     });
 
-    it('should test canCopyResource', () => {
-        const resource = { is_copyable: true };
+    it('should test canCopyResource with different resource type', () => {
         const user = { perms: ['add_resource'] };
+        expect(canCopyResource({ resource_type: 'dataset', perms: ['download_resourcebase'], is_copyable: true }, user)).toBe(true);
+        expect(canCopyResource({ resource_type: 'document', perms: ['download_resourcebase'], is_copyable: true }, user)).toBe(true);
+        expect(canCopyResource({ resource_type: 'map', perms: [], is_copyable: true }, user)).toBe(true);
+        expect(canCopyResource({ resource_type: 'geostory', perms: [], is_copyable: true }, user)).toBe(true);
+        expect(canCopyResource({ resource_type: 'dashboard', perms: [], is_copyable: true }, user)).toBe(true);
 
-        expect(canCopyResource(resource, user)).toEqual(true);
+        expect(canCopyResource({ resource_type: 'dataset', perms: [], is_copyable: true }, user)).toBe(false);
+        expect(canCopyResource({ resource_type: 'document', perms: [], is_copyable: true }, user)).toBe(false);
+        expect(canCopyResource({ resource_type: 'map', perms: [] }, user)).toBe(false);
+        expect(canCopyResource({ resource_type: 'geostory', perms: [] }, user)).toBe(false);
+        expect(canCopyResource({ resource_type: 'dashboard', perms: [] }, user)).toBe(false);
     });
 
     it('should test excludeDeletedResources', () => {


### PR DESCRIPTION
This PR improves the checks for clone and save as actions