### PR TITLE
[Backport 4.0.x][Fixes #1310] Some checkbox filter combinations fail (#1312)

### DIFF
--- a/geonode_mapstore_client/client/js/components/FiltersForm/FilterItems.jsx
+++ b/geonode_mapstore_client/client/js/components/FiltersForm/FilterItems.jsx
@@ -88,10 +88,10 @@ function FilterItems({
                     </>);
                 }
                 if (field.type === 'divider') {
-                    return <div className="gn-filter-form-divider"></div>;
+                    return <div key={field.id} className="gn-filter-form-divider"></div>;
                 }
                 if (field.type === 'link') {
-                    return <div className="gn-filter-form-link"><a href={field.href}>{field.labelId && <Message msgId={field.labelId} /> || field.label}</a></div>;
+                    return <div key={field.id} className="gn-filter-form-link"><a href={field.href}>{field.labelId && <Message msgId={field.labelId} /> || field.label}</a></div>;
                 }
                 if (field.type === 'filter') {
                     const customFilters = castArray(values.f || []);
@@ -100,6 +100,7 @@ function FilterItems({
                             const active = customFilters.find(value => value === item.id);
                             return (
                                 <Checkbox
+                                    key={item.id}
                                     className="gn-sub-filter-items"
                                     type="checkbox"
                                     checked={!!active}
@@ -108,7 +109,7 @@ function FilterItems({
                                         onChange({
                                             f: active
                                                 ? customFilters.filter(value => value !== item.id)
-                                                : [...customFilters, item.id]
+                                                : [...customFilters.filter(value => field.id !== value), item.id, field.id]
                                         });
                                     }}
                                 >
@@ -125,7 +126,7 @@ function FilterItems({
                             : [])
                     ];
                     return (
-                        <FormGroup controlId={'gn-radio-filter-' + field.id}>
+                        <FormGroup key={field.id} controlId={'gn-radio-filter-' + field.id}>
                             <Checkbox
                                 type="checkbox"
                                 checked={!!active}


### PR DESCRIPTION
This PR does the following:
1. includes parent filter when a child filter is checked
2. removes all child filters when a parent filter is unchecked since without the parent, the child filters would not work as expected

A screen recording is added below
> ![filters](https://user-images.githubusercontent.com/42542676/202744905-4a9d87ba-1498-4a08-9ea7-d01f7465c149.gif)
