### PR TITLE
[Backport 4.0.x][Fixes #1305] Unable to upload GEOJSON files with .json extention (#1317)

### DIFF
--- a/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
+++ b/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
@@ -25,17 +25,10 @@ import UploadListContainer from '@js/routes/upload/UploadListContainer';
 import UploadContainer from '@js/routes/upload/UploadContainer';
 import { getConfigProp } from '@mapstore/framework/utils/ConfigUtils';
 import { parseUploadResponse, processUploadResponse, parseUploadFiles } from '@js/utils/ResourceUtils';
-
-function getFileNameParts(file) {
-    const { name } = file;
-    const nameParts = name.split('.');
-    const ext = nameParts[nameParts.length - 1];
-    const baseName = [...nameParts].splice(0, nameParts.length - 1).join('.');
-    return { ext, baseName };
-}
+import { getFileNameParts, getFileType } from '@js/utils/FileUtils';
 
 function getDatasetFileType(file, supportedTypes) {
-    const { type } = file;
+    const type = getFileType(file);
     const { ext } = getFileNameParts(file);
     const datasetFileType = supportedTypes.find((fileType) =>
         (fileType.ext || []).includes(ext)

--- a/geonode_mapstore_client/client/js/utils/FileUtils.js
+++ b/geonode_mapstore_client/client/js/utils/FileUtils.js
@@ -40,3 +40,24 @@ export const determineResourceType = extension => {
     if (pcdExtensions.includes(extension)) return 'pcd';
     return 'unsupported';
 };
+
+export const getFileNameParts = (file) => {
+    const { name } = file;
+    const nameParts = name.split('.');
+    const ext = nameParts[nameParts.length - 1];
+    const baseName = [...nameParts].splice(0, nameParts.length - 1).join('.');
+    return { ext: ext.toLowerCase(), baseName };
+};
+
+/**
+ * Get file type from file.
+ * In cases where the file type is application/json (which happens when file was originally .geojson converted to .json)
+ * We return json as file type
+ */
+export const getFileType = (file) => {
+    const { type } = file;
+    if (type === 'application/json') {
+        return 'json';
+    }
+    return type;
+};


### PR DESCRIPTION

The issue was caused because when a file is changed from geojson to json, in some cases, the file type is recorded in the file metadata as `application/json` which was not recognized by the client. This PR caters for that.