### PR TITLE
[Backport 4.1.x][Fixes #1386] Export service selection should be hidden

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -950,6 +950,8 @@
                 "name": "LayerDownload",
                 "cfg": {
                     "disablePluginIf": "{!state('selectedLayerPermissions').includes('download_resourcebase')}",
+                    "hideServiceSelector": true,
+                    "defaultSelectedService": "wps",
                     "formats": [
                         {
                             "name": "application/json",
@@ -1793,6 +1795,8 @@
                 "name": "LayerDownload",
                 "cfg": {
                     "disablePluginIf": "{!state('selectedLayerPermissions').includes('download_resourcebase')}",
+                    "hideServiceSelector": true,
+                    "defaultSelectedService": "wps",
                     "formats": [
                         {
                             "name": "application/json",


### PR DESCRIPTION
#1386

This PR includes following changes:
- update MapStore2 submodule to latest 2022.02.xx commits
- add configuration to localConfig.json to hide the service selector in layer download