### PR TITLE
[Fix #1401] @react-three/drei and @react-three/fiber dependencies are throwing warning while compiling (#1402)

### DIFF
--- a/geonode_mapstore_client/client/js/components/MediaViewer/Scene3DViewer.jsx
+++ b/geonode_mapstore_client/client/js/components/MediaViewer/Scene3DViewer.jsx
@@ -84,7 +84,9 @@ function Scene3DViewer({
         <div className="gn-media-scene-3d">
             <Suspense fallback={null}>
                 <Canvas>
-                    <Environment files={environmentFiles} />
+                    <Suspense fallback={null}>
+                        <Environment files={environmentFiles} />
+                    </Suspense>
                     <Suspense fallback={<Loader />}>
                         <Model src={src} onChange={setBoundingSphere}/>
                     </Suspense>
@@ -99,7 +101,6 @@ function Scene3DViewer({
                 </Canvas>
             </Suspense>
         </div>
-
     );
 }
 

--- a/geonode_mapstore_client/client/package.json
+++ b/geonode_mapstore_client/client/package.json
@@ -31,14 +31,15 @@
     "jsdoc-to-markdown": "7.1.0"
   },
   "dependencies": {
-    "@react-three/drei": "8.6.1",
-    "@react-three/fiber": "7.0.25",
+    "@react-three/drei": "8.20.2",
+    "@react-three/fiber": "6.0.0",
     "dompurify": "2.2.6",
     "font-awesome": "4.7.0",
     "mapstore": "file:MapStore2",
     "react-helmet": "6.1.0",
     "react-intl": "2.3.0",
-    "three": "0.136.0"
+    "three": "0.138.3",
+    "three-stdlib": "2.8.9"
   },
   "mapstore": {
     "output": "dist",


### PR DESCRIPTION
This PR updates the dependencies to avoid warning while compiling the client bundle