### PR TITLE
[Backport 4.0.x][Fix #1397] Resource title is not visible inside the preview panel

### DIFF
--- a/geonode_mapstore_client/client/js/routes/Detail.jsx
+++ b/geonode_mapstore_client/client/js/routes/Detail.jsx
@@ -175,6 +175,7 @@ function Detail({
                 </div>
                 {!!resource &&
                 <ConnectedDetailsPanel
+                    key={resource?.uuid || resource?.pk}
                     enableFavorite={!!user}
                     resource={resource}
                     linkHref={hrefDetailPanel}


### PR DESCRIPTION
#1397

This PR adds the key to the detail component to remount it every time the resource change, in this way the title will update correctly