### PR TITLE
Bring back the attribute table to the DetailsViewer

### DIFF
--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsAttributeTable.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsAttributeTable.jsx
@@ -37,9 +37,7 @@ const parseAttributeData = (fields) => {
 };
 
 
-const DetailsAttributeTable = ({
-    fields
-}) => {
+const DetailsAttributeTable = ({ fields }) => {
     const attributeData = parseAttributeData(fields);
     return (
         <div className="gn-details-info-table">
@@ -49,11 +47,11 @@ const DetailsAttributeTable = ({
 };
 
 DetailsAttributeTable.propTypes = {
-    resource: PropTypes.object
+    fields: PropTypes.array,
 };
 
 DetailsAttributeTable.defaultProps = {
-    resource: {}
+    fields: []
 };
 
 export default DetailsAttributeTable;

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsAttributeTable.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsAttributeTable.jsx
@@ -5,19 +5,14 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-
-import {
-    getDatasetByPk
-} from '@js/api/geonode/v2'
-
 import Table from '@js/components/Table';
 
 
-const parseAttributeData = (dataset) => {
-    if (dataset?.attribute_set) {
+const parseAttributeData = (fields) => {
+    if (fields) {
         const header = [{
             value: "Name",
             key: "name"
@@ -27,13 +22,12 @@ const parseAttributeData = (dataset) => {
         }, {
             value: "Description",
             key: "description"
-        }]
-
-        const na = <FormattedMessage id="gnhome.na" defaultMessage="N/A" />
-        const rows = dataset.attribute_set.map(attribute => ({
+        }];
+        const na = <FormattedMessage id="gnhome.na" defaultMessage="N/A" />;
+        const rows = fields.map(attribute => ({
             name: attribute.attribute,
             label: attribute.attribute_label || na,
-            description: attribute.description || na,
+            description: attribute.description || na
         }));
 
         return { header, rows };
@@ -44,24 +38,15 @@ const parseAttributeData = (dataset) => {
 
 
 const DetailsAttributeTable = ({
-    resource,
+    fields
 }) => {
-    const [attributeData, setAttributeData] = useState({ header: [], rows: [] });
-    useEffect(() => {
-        const getAttributes = async () => {
-            if (resource.resource_type === "dataset") {
-                const dataset = await getDatasetByPk(resource.pk);
-                setAttributeData(parseAttributeData(dataset));
-            }
-        }
-        getAttributes();
-    }, [])
+    const attributeData = parseAttributeData(fields);
     return (
         <div className="gn-details-info-table">
             <Table head={attributeData.header} body={attributeData.rows} />
         </div>
-    )
-}
+    );
+};
 
 DetailsAttributeTable.propTypes = {
     resource: PropTypes.object

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsAttributeTable.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsAttributeTable.jsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+import {
+    getDatasetByPk
+} from '@js/api/geonode/v2'
+
+import Table from '@js/components/Table';
+
+
+const parseAttributeData = (dataset) => {
+    if (dataset?.attribute_set) {
+        const header = [{
+            value: "Name",
+            key: "name"
+        }, {
+            value: "Label",
+            key: "label"
+        }, {
+            value: "Description",
+            key: "description"
+        }]
+
+        const rows = dataset.attribute_set.map(attribute => ({
+            name: attribute.attribute,
+            label: attribute.attribute_label || "",
+            description: attribute.description || "",
+        }));
+
+        return { header, rows };
+    }
+
+    return { header: [], rows: [] };
+};
+
+
+const DetailsAttributeTable = ({
+    resource,
+}) => {
+    const [attributeData, setAttributeData] = useState({ header: [], rows: [] });
+    useEffect(() => {
+        const getAttributes = async () => {
+            if (resource.resource_type === "dataset") {
+                const dataset = await getDatasetByPk(resource.pk);
+                setAttributeData(parseAttributeData(dataset));
+            }
+        }
+        getAttributes();
+    }, [])
+    return (
+        <div className="gn-details-info-table">
+            <Table head={attributeData.header} body={attributeData.rows} />
+        </div>
+    )
+}
+
+DetailsAttributeTable.propTypes = {
+    resource: PropTypes.object
+};
+
+DetailsAttributeTable.defaultProps = {
+    resource: {}
+};
+
+export default DetailsAttributeTable;

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsAttributeTable.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsAttributeTable.jsx
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import React, { useState, useEffect } from 'react';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import {
@@ -28,10 +29,11 @@ const parseAttributeData = (dataset) => {
             key: "description"
         }]
 
+        const na = <FormattedMessage id="gnhome.na" defaultMessage="N/A" />
         const rows = dataset.attribute_set.map(attribute => ({
             name: attribute.attribute,
-            label: attribute.attribute_label || "",
-            description: attribute.description || "",
+            label: attribute.attribute_label || na,
+            description: attribute.description || na,
         }));
 
         return { header, rows };

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx
@@ -146,6 +146,10 @@ const parseTabItems = (items) => {
 };
 const isDefaultTabType = (type) => type === 'tab';
 
+const canShowAttributeTab = ({resource, tab}) => {
+    return resource?.resource_type === 'dataset' && tab?.type === 'attribute-table'
+}
+
 function DetailsInfo({
     tabs = [],
     resource,
@@ -160,7 +164,7 @@ function DetailsInfo({
                 Component: tabTypes[tab.type] || tabTypes.tab
             }))
         // ensure tab has items .. attribute table loads them dynamically
-        .filter(tab => tab?.items?.length > 0 || tab.type === 'attribute-table' );
+        .filter(tab => tab?.items?.length > 0 || canShowAttributeTab({resource, tab}) );
     const selectedTabId = filteredTabs?.[0]?.id;
     return (
         <Tabs

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx
@@ -11,6 +11,7 @@ import moment from 'moment';
 import { Tabs, Tab } from "react-bootstrap";
 
 import Button from '@js/components/Button';
+import DetailsAttributeTable from '@js/components/DetailsPanel/DetailsAttributeTable';
 import DetailsLinkedResources from '@js/components/DetailsPanel/DetailsLinkedResources';
 import Message from '@mapstore/framework/components/I18N/Message';
 
@@ -55,7 +56,7 @@ function DetailsHTML({ value, placeholder }) {
         return (
             <div className={`gn-details-info-html${expand ? '' : ' collapsed'}`}>
                 {expand
-                    ? <div className="gn-details-info-html-value" dangerouslySetInnerHTML={{ __html: value }}/>
+                    ? <div className="gn-details-info-html-value" dangerouslySetInnerHTML={{ __html: value }} />
                     : <div className="gn-details-info-html-value">{placeholder}</div>}
                 <Button onClick={() => setExpand(!expand)}>
                     <Message msgId={expand ? 'gnviewer.readLess' : 'gnviewer.readMore'} />
@@ -63,7 +64,7 @@ function DetailsHTML({ value, placeholder }) {
             </div>);
     }
     return (
-        <div dangerouslySetInnerHTML={{ __html: value }}/>
+        <div dangerouslySetInnerHTML={{ __html: value }} />
     );
 }
 
@@ -110,7 +111,7 @@ function DetailsInfoFields({ fields, formatHref }) {
                 return (
                     <DetailsInfoField key={filedIndex} field={field}>
                         {(values) => values.map((value, idx) => (
-                            <DetailsHTML key={idx} value={value} placeholder={field.placeholder}/>
+                            <DetailsHTML key={idx} value={value} placeholder={field.placeholder} />
                         ))}
                     </DetailsInfoField>
                 );
@@ -130,6 +131,7 @@ function DetailsInfoFields({ fields, formatHref }) {
 }
 
 const tabTypes = {
+    'attribute-table': DetailsAttributeTable,
     'linked-resources': DetailsLinkedResources,
     'tab': DetailsInfoFields
 };
@@ -146,6 +148,7 @@ const isDefaultTabType = (type) => type === 'tab';
 
 function DetailsInfo({
     tabs = [],
+    resource,
     formatHref,
     resourceTypesInfo
 }) {
@@ -156,7 +159,8 @@ function DetailsInfo({
                 items: isDefaultTabType(tab.type) ? parseTabItems(tab?.items) : tab?.items,
                 Component: tabTypes[tab.type] || tabTypes.tab
             }))
-        .filter(tab => tab?.items?.length > 0 );
+        // ensure tab has items .. attribute table loads them dynamically
+        .filter(tab => tab?.items?.length > 0 || tab.type === 'attribute-table' );
     const selectedTabId = filteredTabs?.[0]?.id;
     return (
         <Tabs
@@ -166,7 +170,11 @@ function DetailsInfo({
         >
             {filteredTabs.map(({Component, ...tab}, idx) => (
                 <Tab key={idx} eventKey={tab?.id} title={<DetailInfoFieldLabel field={tab} />}>
-                    <Component fields={tab?.items} formatHref={formatHref} resourceTypesInfo={resourceTypesInfo} />
+                    <Component 
+                        fields={tab?.items}
+                        resource={resource}
+                        formatHref={formatHref}
+                        resourceTypesInfo={resourceTypesInfo} />
                 </Tab>
             ))}
         </Tabs>

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx
@@ -146,25 +146,20 @@ const parseTabItems = (items) => {
 };
 const isDefaultTabType = (type) => type === 'tab';
 
-const canShowAttributeTab = ({resource, tab}) => {
-    return resource?.resource_type === 'dataset' && tab?.type === 'attribute-table'
-}
-
 function DetailsInfo({
     tabs = [],
-    resource,
     formatHref,
     resourceTypesInfo
 }) {
     const filteredTabs = tabs
+        .filter((tab) => !tab?.disableIf)
         .map((tab) =>
             ({
                 ...tab,
                 items: isDefaultTabType(tab.type) ? parseTabItems(tab?.items) : tab?.items,
                 Component: tabTypes[tab.type] || tabTypes.tab
             }))
-        // ensure tab has items .. attribute table loads them dynamically
-        .filter(tab => tab?.items?.length > 0 || canShowAttributeTab({resource, tab}) );
+        .filter(tab => tab?.items?.length > 0);
     const selectedTabId = filteredTabs?.[0]?.id;
     return (
         <Tabs
@@ -174,9 +169,8 @@ function DetailsInfo({
         >
             {filteredTabs.map(({Component, ...tab}, idx) => (
                 <Tab key={idx} eventKey={tab?.id} title={<DetailInfoFieldLabel field={tab} />}>
-                    <Component 
+                    <Component
                         fields={tab?.items}
-                        resource={resource}
                         formatHref={formatHref}
                         resourceTypesInfo={resourceTypesInfo} />
                 </Tab>

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -280,7 +280,7 @@ function DetailsPanel({
                             : null}
                     </div>
                 </div>
-                <DetailsInfo tabs={tabs} resource={resource} formatHref={formatHref} resourceTypesInfo={types}/>
+                <DetailsInfo tabs={tabs} formatHref={formatHref} resourceTypesInfo={types}/>
             </section>
         </div>
     );

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -280,7 +280,7 @@ function DetailsPanel({
                             : null}
                     </div>
                 </div>
-                <DetailsInfo tabs={tabs} formatHref={formatHref} resourceTypesInfo={types}/>
+                <DetailsInfo tabs={tabs} resource={resource} formatHref={formatHref} resourceTypesInfo={types}/>
             </section>
         </div>
     );

--- a/geonode_mapstore_client/client/js/epics/gnsearch.js
+++ b/geonode_mapstore_client/client/js/epics/gnsearch.js
@@ -15,7 +15,8 @@ import {
     getResourceByPk,
     getDocumentByPk,
     getFeaturedResources,
-    getResourceByUuid
+    getResourceByUuid,
+    getDatasetByPk
 } from '@js/api/geonode/v2';
 import {
     SEARCH_RESOURCES,
@@ -287,7 +288,11 @@ export const gnsSelectResourceEpic = (action$, store) =>
             const resources = state.gnsearch?.resources || [];
             const selectedResource = resources.find(({ pk, resource_type: resourceType}) =>
                 pk === action.pk && action.ctype === resourceType);
-            return Observable.defer(() => action.ctype !== 'document' ? getResourceByPk(action.pk) : getDocumentByPk(action.pk))
+            const resourcesRequest = {
+                'document': getDocumentByPk,
+                'dataset': getDatasetByPk
+            };
+            return Observable.defer(() => resourcesRequest[action.ctype] ? resourcesRequest[action.ctype](action.pk) : getResourceByPk(action.pk))
                 .switchMap((resource) => {
                     return Observable.of(setResource({
                         ...resource,

--- a/geonode_mapstore_client/client/js/utils/AppUtils.js
+++ b/geonode_mapstore_client/client/js/utils/AppUtils.js
@@ -237,7 +237,7 @@ export function setupConfiguration({
      *      msAPI.onAction('CHANGE_MAP_VIEW', onChangeMapView);
      *  });
      * </script>
-     * 
+     *
      * @example
      * <!--
      * use mapstore api offAction method to listen to an action only once
@@ -258,7 +258,7 @@ export function setupConfiguration({
      *      msAPI.onAction('CHANGE_MAP_VIEW', onChangeMapView);
      *  });
      * </script>
-     * 
+     *
      * @example
      * <!--
      * use mapstore api triggerAction method to dispatch an action

--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -453,6 +453,26 @@
     }
     
 }
+
+.gn-details-info-table {
+    padding: 0.5rem 0;
+    font-size: @font-size-small;
+    position: relative;
+    * {
+        position: relative;
+    }
+    .table {
+        thead > tr > th {
+            padding: 0.25rem;
+            font-weight: lighter;
+        }
+        tbody > tr > td {
+            padding: 0.25rem;
+            font-weight: lighter;
+        }
+    }
+}
+
 .gn-details-panel-content-img {
     > img,
     > .gn-details-panel-preview-wrapper {

--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -462,17 +462,19 @@
         position: relative;
     }
     .table {
-        thead > tr > th {
-            padding: 0.25rem;
-            font-weight: bold;
-        }
-        tbody > tr > td {
-            padding: 0.25rem;
-            font-weight: lighter;
-        }
-        tbody > tr > td:empty::before {
-            content: "empty";
-            color: grey;
+        table-layout: fixed;
+        tbody > tr {
+            > th {
+                padding: 0.25rem;
+                font-weight: bold;
+            }
+
+            > td {
+                padding: 0.25rem;
+                font-weight: lighter;
+                word-wrap: break-word;
+            }
+
         }
     }
 }

--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -464,11 +464,15 @@
     .table {
         thead > tr > th {
             padding: 0.25rem;
-            font-weight: lighter;
+            font-weight: bold;
         }
         tbody > tr > td {
             padding: 0.25rem;
             font-weight: lighter;
+        }
+        tbody > tr > td:empty::before {
+            content: "empty";
+            color: grey;
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -770,6 +770,11 @@
                             ]
                         },
                         {
+                            "type": "attribute-table",
+                            "id": "attributes",
+                            "labelId": "gnviewer.attributes"
+                        },
+                        {
                             "type": "linked-resources",
                             "id": "related",
                             "labelId": "gnviewer.linkedResources",
@@ -3315,6 +3320,11 @@
                                     "disableIf": "{!context.getMetadataDetailUrl(state('gnResourceData'))}"
                                 }
                             ]
+                        },
+                        {
+                            "type": "attribute-table",
+                            "id": "attributes",
+                            "labelId": "gnviewer.attributes"
                         },
                         {
                             "type": "linked-resources",

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -772,7 +772,9 @@
                         {
                             "type": "attribute-table",
                             "id": "attributes",
-                            "labelId": "gnviewer.attributes"
+                            "labelId": "gnviewer.attributes",
+                            "disableIf": "{context.get(state('gnResourceData'), 'resource_type') !== 'dataset'}",
+                            "items": "{context.get(state('gnResourceData'), 'attribute_set')}"
                         },
                         {
                             "type": "linked-resources",
@@ -3324,7 +3326,9 @@
                         {
                             "type": "attribute-table",
                             "id": "attributes",
-                            "labelId": "gnviewer.attributes"
+                            "labelId": "gnviewer.attributes",
+                            "disableIf": "{context.get(state('gnResourceData'), 'resource_type') !== 'dataset'}",
+                            "items": "{context.get(state('gnResourceData'), 'attribute_set')}"
                         },
                         {
                             "type": "linked-resources",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -131,7 +131,8 @@
             "search": "Suchen...",
             "permissionsMissing": "Sie sind nicht berechtigt, diese Ressource anzuzeigen",
             "filter": "Filter",
-            "noPreview": "Für diese Ressource ist keine Vorschau verfügbar"
+            "noPreview": "Für diese Ressource ist keine Vorschau verfügbar",
+            "na": "n.a."
         },
         "viewer": {
             "document": {

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -131,7 +131,8 @@
             "search": "Search...",
             "permissionsMissing": "You don't have permission to view or download the resource",
             "filter": "Filter",
-            "noPreview": "A preview is not available for this resource"
+            "noPreview": "A preview is not available for this resource",
+            "na": "N/A"
         },
         "viewer": {
             "document": {


### PR DESCRIPTION
This PR brings back the attribute table as a tab next to the info fields tab in the DetailsViewer. The PR is meant (for now) to gather feedback and improvement ideas from @giohappy @gannebamm @mattiagiupponi. 

## Context

The following issues are pointing to the missing attribute table in the DetailsViewer:

* https://github.com/GeoNode/geonode/issues/10693
* https://github.com/GeoNode/geonode/issues/10378#issuecomment-1352778569

## Approach

To bring back the attribute table and put it next to the details info fields, I introduced the new `attribute_table` type and extended the `DetailsInfo` Component to either render the info fields or the attribute table:

https://github.com/Thuenen-52North-Erweiterung-GeoNode/geonode-mapstore-client/blob/8f48fae71eb5c340c448cfc31814a02fd8e5c92d/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx#L205-L209

The Tab-Config in `localConfig.json` now includes another tab of type `attribute_table`:

https://github.com/Thuenen-52North-Erweiterung-GeoNode/geonode-mapstore-client/blob/8f48fae71eb5c340c448cfc31814a02fd8e5c92d/geonode_mapstore_client/static/mapstore/configs/localConfig.json#L3252-L3256

During rendering the dataset is queried and the attributes are rendered as table component:

https://github.com/Thuenen-52North-Erweiterung-GeoNode/geonode-mapstore-client/blob/8f48fae71eb5c340c448cfc31814a02fd8e5c92d/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx#L193-L202

## Version 3.x

Version 3.x [rendered the attribute table in a Django Template](https://github.com/GeoNode/geonode/blob/3.3.x/geonode/layers/templates/layers/layer_detail.html#LL161C9-L161C36) and respects also different display variants depending on Mosaic or Time. I focused for now on a simple the dataset.

## Other approaches I tried

* The structure of configurable `DetailsInfoFields` (actually a pure list) and the attribute table is different. So just using the config options of the `DetailsViewer`'s tabs falls short.
* Get the data within `_geonode_config.html` Django-Template did not work out, because the actual dataset containing `attributes_all` is only available within embedded Map.
* Extending [PluginContextUtils.js](https://github.com/GeoNode/geonode-mapstore-client/blob/master/geonode_mapstore_client/client/js/utils/PluginsContextUtils.js#L17) and triggering a query for example via `"items": "{context.getFeatureCatalogueItems(state('gnResourceData'))}"` does not work, since as far as I could see geonode-mapstore-client does not support asynchronous configuration

## Improvement Ideas and Questions

* Do you think, there potential to show more different content types in the details tabs? Currently, the type `attribute_table` is focused strictly on the attribute table. In a more generic solution, however, this could be just `table`. Furthermore, other types could be added like `linked documents`, `used in (maps, dashboards, geostories, ..)`, `user access`, ... just to name a few.
* Do you have plans to make the configuration asynchronous? Currently, it seems not an easy task. Are there opportunities to make the configuration more asynchronous?