### PR TITLE
[Backport 4.1.x] Fix #1447 Implement date filtering (#1448)

### DIFF
--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -876,11 +876,11 @@ export const getFacetItemsByFacetName = ({ name: facetName, style, filterKey }, 
             isNextPageAvailable,
             items: items.map(({label, is_localized: isLocalized, key, count} = {})=> {
                 const item = {
-                    id: String(key),
                     type: "filter",
                     ...(isLocalized ? { label } : { labelId: label }),
                     count,
                     filterKey,
+                    filterValue: String(key),
                     style
                 };
                 setFilterById(filterKey + key, item);

--- a/geonode_mapstore_client/client/js/components/Accordion/Accordion.jsx
+++ b/geonode_mapstore_client/client/js/components/Accordion/Accordion.jsx
@@ -101,7 +101,7 @@ Accordion.propTypes = {
     title: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
     titleId: PropTypes.string,
     identifier: PropTypes.string,
-    content: PropTypes.node,
+    content: PropTypes.func,
     loadItems: PropTypes.func,
     items: PropTypes.array
 };
@@ -109,7 +109,7 @@ Accordion.propTypes = {
 Accordion.defaultProps = {
     title: null,
     identifier: "",
-    content: null,
+    content: () => null,
     noItemsMsgId: "gnhome.emptyAccordion"
 };
 export default Accordion;

--- a/geonode_mapstore_client/client/js/components/ActionButtons/ActionButtons.jsx
+++ b/geonode_mapstore_client/client/js/components/ActionButtons/ActionButtons.jsx
@@ -29,9 +29,8 @@ function ActionButtons({
             onClick={event => event.stopPropagation()}
             style={isDropdownEmpty ? { display: 'none' } : {}}
         >
-            <Dropdown className="gn-card-options" pullRight>
+            <Dropdown className="gn-card-options" pullRight id={`gn-card-options-${resource.pk2 || resource.pk}`}>
                 <Dropdown.Toggle
-                    id={`gn-card-options-${resource.pk2 || resource.pk}`}
                     variant="default"
                     size="sm"
                     noCaret

--- a/geonode_mapstore_client/client/js/components/FiltersForm/DateRangeFilter.jsx
+++ b/geonode_mapstore_client/client/js/components/FiltersForm/DateRangeFilter.jsx
@@ -1,0 +1,75 @@
+
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { DateTimePicker } from 'react-widgets';
+import { FormGroup } from 'react-bootstrap';
+import moment from 'moment';
+import momentLocalizer from 'react-widgets/lib/localizers/moment';
+
+import Message from '@mapstore/framework/components/I18N/Message';
+
+momentLocalizer(moment);
+
+function DateRangeFilter({
+    query,
+    filterKey = 'date',
+    labelId = 'gnviewer.dateFilter',
+    onChange
+}) {
+
+    const format = 'YYYY-MM-DD';
+    const dateFromFilterKey = `filter{${filterKey}.gte}`;
+    const dateToFilterKey = `filter{${filterKey}.lte}`;
+    const dateFromValue = query[dateFromFilterKey] ? moment(query[dateFromFilterKey]).toDate() : undefined;
+    const dateToValue = query[dateToFilterKey] ? moment(query[dateToFilterKey]).toDate() : undefined;
+
+    function parseDate(value, time) {
+        const date = moment(value);
+        if (date.isValid()) {
+            return `${date.format(format)}${time}`;
+        }
+        return null;
+    }
+
+    return (
+        <>
+            <FormGroup>
+                <label><Message msgId={`${labelId}.from`}/></label>
+                <DateTimePicker
+                    value={dateFromValue}
+                    max={dateToValue}
+                    time={false}
+                    onChange={(value) => {
+                        onChange({
+                            [dateFromFilterKey]: parseDate(value, 'T00:00:00')
+                        });
+                    }}
+                />
+            </FormGroup>
+            <FormGroup>
+                <label><Message msgId={`${labelId}.to`}/></label>
+                <DateTimePicker
+                    value={dateToValue}
+                    min={dateFromValue}
+                    time={false}
+                    onChange={(value) => {
+                        onChange({
+                            [dateToFilterKey]: parseDate(value, 'T23:59:59')
+                        });
+                    }}
+                />
+            </FormGroup>
+        </>
+    );
+}
+
+DateRangeFilter.defaultProps = {};
+
+export default DateRangeFilter;

--- a/geonode_mapstore_client/client/js/components/FiltersForm/FilterByExtent.jsx
+++ b/geonode_mapstore_client/client/js/components/FiltersForm/FilterByExtent.jsx
@@ -27,7 +27,8 @@ function FilterByExtent({
     projection,
     onChange,
     vectorLayerStyle,
-    layers
+    layers,
+    labelId = 'gnviewer.extent'
 }) {
 
     const enabled = !!extent;
@@ -68,7 +69,7 @@ function FilterByExtent({
                 id="gn-filter-by-extent-switch"
                 onChange={handleOnSwitch}
             >
-                <Message msgId="gnhome.extent"/>
+                <Message msgId={labelId}/>
             </Checkbox>
             <div
                 className="gn-filter-by-extent-map"

--- a/geonode_mapstore_client/client/js/components/FiltersForm/FilterItems.jsx
+++ b/geonode_mapstore_client/client/js/components/FiltersForm/FilterItems.jsx
@@ -8,256 +8,335 @@
 import React from 'react';
 import castArray from 'lodash/castArray';
 import isNil from 'lodash/isNil';
+import debounce from 'lodash/debounce';
 import PropTypes from 'prop-types';
-import { FormGroup, Checkbox } from 'react-bootstrap';
+import { FormGroup, Checkbox, FormControl as FormControlRB } from 'react-bootstrap';
 import ReactSelect from 'react-select';
 
 import Accordion from "@js/components/Accordion";
 import SelectInfiniteScroll from '@js/components/SelectInfiniteScroll';
-import { getFilterLabelById } from '@js/utils/SearchUtils';
-import Message from '@mapstore/framework/components/I18N/Message';
+import { getFilterLabelById, getFilterById } from '@js/utils/SearchUtils';
 import localizedProps from '@mapstore/framework/components/misc/enhancers/localizedProps';
+import withDebounceOnCallback from '@mapstore/framework/components/misc/enhancers/withDebounceOnCallback';
+import { getMessageById } from '@mapstore/framework/utils/LocaleUtils';
+import FilterByExtent from './FilterByExtent';
+import DateRangeFilter from './DateRangeFilter';
+
+const FormControl = localizedProps('placeholder')(FormControlRB);
+function InputControl({ onChange, value, debounceTime, ...props }) {
+    return <FormControl {...props} value={value} onChange={event => onChange(event.target.value)}/>;
+}
+const InputControlWithDebounce = withDebounceOnCallback('onChange', 'value')(InputControl);
 
 const SelectSync = localizedProps('placeholder')(ReactSelect);
 
 function Facet({
     item,
     active,
+    label,
     onChange
 }) {
+    const filterValue = item.filterValue || item.id;
     return (
-        <div key={item.id} className={`facet${active ? " active" : ""}`} onClick={onChange}>
+        <div className={`facet${active ? " active" : ""}`} onClick={onChange}>
             <input
                 type="checkbox"
-                id={item.id}
-                name={item.id}
+                id={filterValue}
+                name={filterValue}
                 checked={!!active}
                 onKeyDown={(event) => event.key === 'Enter' ? onChange() : null}
                 style={{ display: 'block', width: 0, height: 0, overflow: 'hidden', opacity: 0, padding: 0, margin: 0 }}
             />
-            {item.labelId ? <Message msgId={item.labelId}/> : <span>{item.label}</span>}
+            {label}
             {!isNil(item.count) && <span className="facet-count">{`(${item.count})`}</span>}
         </div>
     );
 }
-function FilterItems({
+
+function ExtentFilterWithDebounce({
     id,
-    items,
-    suggestionsRequestTypes,
-    values,
+    labelId,
+    query,
+    timeDebounce,
+    layers,
+    vectorLayerStyle,
     onChange
 }) {
+    const extentChange = debounce((extent) => {
+        onChange({ extent });
+    }, timeDebounce);
     return (
-        <>
-            {items.map((field) => {
-                if (field.type === 'select' && field.loadItems) {
-                    const filterKey = field.key;
-                    const currentValues = castArray(values[filterKey] || []);
-                    return (
-                        <FormGroup
-                            key={field.id}
-                            controlId={field.id}
-                        >
-                            <label><strong>{field.labelId ? <Message msgId={field.labelId}/> : field.label}</strong></label>
-                            <SelectInfiniteScroll
-                                value={currentValues.map((value) => {
-                                    return {
-                                        value,
-                                        label: getFilterLabelById(filterKey, value) || value
-                                    };
-                                })}
-                                multi
-                                placeholder={field.placeholderId}
-                                onChange={(selected) => {
-                                    onChange({
-                                        [filterKey]: selected.map(({ value }) => value)
-                                    });
-                                }}
-                                loadOptions={({ q, ...params }) => field.loadItems({
-                                    ...params,
-                                    ...(q && { topic_contains: q }),
-                                    page: params.page - 1
-                                })
-                                    .then((response) => {
-                                        return {
-                                            ...response,
-                                            results: response.items.map((item) => ({
-                                                ...item,
-                                                selectOption: {
-                                                    value: item.id,
-                                                    label: `${item.label} (${item.count})`
-                                                }
-                                            }))
-                                        };
-                                    })}
-                            />
-                        </FormGroup>
-                    );
-                }
-                if (field.type === 'select') {
-                    const {
-                        id: formId,
-                        labelId,
-                        label,
-                        placeholderId,
-                        description,
-                        options,
-                        suggestionsRequestKey
-                    } = field;
-                    const key = `${id}-${formId || suggestionsRequestKey}`;
-                    const filterKey = suggestionsRequestKey
-                        ? suggestionsRequestTypes[suggestionsRequestKey]?.filterKey
-                        : `filter{${formId}.in}`;
-
-                    const currentValues = castArray(suggestionsRequestKey
-                        ? values[suggestionsRequestTypes[suggestionsRequestKey]?.filterKey] || []
-                        : values[filterKey] || []);
-
-                    const optionsProp = suggestionsRequestKey
-                        ? { loadOptions: suggestionsRequestTypes[suggestionsRequestKey]?.loadOptions }
-                        : { options: options.map(option => ({ value: option, label: option })) };
-                    const Select = suggestionsRequestKey ? SelectInfiniteScroll : SelectSync;
-                    return (
-                        <FormGroup
-                            key={key}
-                            controlId={key}
-                        >
-                            <label><strong>{labelId ? <Message msgId={labelId}/> : label}</strong></label>
-                            <Select
-                                value={currentValues.map((value) => ({ value, label: getFilterLabelById(filterKey, value) || value }))}
-                                multi
-                                placeholder={placeholderId}
-                                onChange={(selected) => {
-                                    onChange({
-                                        [filterKey]: selected.map(({ value }) => value)
-                                    });
-                                }}
-                                { ...optionsProp }
-                            />
-                            {description &&
-                            <div className="text-muted">
-                                {description}
-                            </div>}
-                        </FormGroup>
-                    );
-                }
-                if (field.type === 'group') {
-                    return (<>
-                        <div className="gn-filter-form-group-title">
-                            <strong><Message msgId={field.labelId}/> </strong>
-                        </div>
-                        <FilterItems
-                            id={id}
-                            items={field.items}
-                            suggestionsRequestTypes={suggestionsRequestTypes}
-                            values={values}
-                            onChange={onChange}
-                        />
-                    </>);
-                }
-                if (field.type === 'divider') {
-                    return <div key={field.id} className="gn-filter-form-divider"></div>;
-                }
-                if (field.type === 'link') {
-                    return <div key={field.id} className="gn-filter-form-link"><a href={field.href}>{field.labelId && <Message msgId={field.labelId} /> || field.label}</a></div>;
-                }
-                if (field.type === 'filter') {
-                    const filterKey = field.filterKey || "f";
-                    const customFilters = castArray( values[filterKey] || []);
-                    const isFacet = (item) => item.style === 'facet';
-                    const renderFacet = ({item, active, onChangeFacet, renderChild}) => {
-                        return (
-                            <div className="gn-facet-wrapper">
-                                <Facet item={item} active={active} onChange={onChangeFacet}/>
-                                {item.items && renderChild && <div className="facet-children">{renderChild()}</div>}
-                            </div>
-                        );
-                    };
-
-                    const filterChild = () => {
-                        return field.items && field.items.map((item) => {
-                            const active = customFilters.find(value => value === item.id);
-                            const onChangeFilter = () => {
-                                onChange({
-                                    f: active
-                                        ? customFilters.filter(value => value !== item.id)
-                                        : [...customFilters.filter(value => field.id !== value), item.id, field.id]
-                                });
-                            };
-                            return (
-                                <div className={'gn-sub-filter-items'}>
-                                    {isFacet(item)
-                                        ? renderFacet({item, active, onChangeFacet: onChangeFilter})
-                                        : <Checkbox
-                                            key={item.id}
-                                            type="checkbox"
-                                            checked={!!active}
-                                            value={item.id}
-                                            onChange={onChangeFilter}
-                                        >
-                                            {item.labelId ? <Message msgId={item.labelId}/> : item.label}
-                                        </Checkbox>
-                                    }
-                                </div>
-                            );
-                        } );
-                    };
-                    const active = customFilters.find(value => value === field.id);
-                    const parentFilterIds = [
-                        field.id,
-                        ...(field.items
-                            ? field.items.map((item) => item.id)
-                            : [])
-                    ];
-                    const onChangeFilterParent = () => {
-                        onChange({
-                            [filterKey]: active
-                                ? customFilters.filter(value => !parentFilterIds.includes(value))
-                                : [...customFilters, field.id]
-                        });
-                    };
-                    return isFacet(field)
-                        ? renderFacet({
-                            item: field,
-                            active,
-                            onChangeFacet: onChangeFilterParent,
-                            renderChild: filterChild
-                        }) : (
-                            <FormGroup key={field.id} controlId={'gn-radio-filter-' + field.id}>
-                                <Checkbox
-                                    type="checkbox"
-                                    checked={!!active}
-                                    value={field.id}
-                                    onChange={onChangeFilterParent}>
-                                    {field.labelId ? <Message msgId={field.labelId}/> : field.label}
-                                    {filterChild()}
-                                </Checkbox>
-                            </FormGroup>
-                        );
-                }
-                if (field.type === 'accordion' && !field.facet && field.id) {
-                    const key = `${id}-${field.id}`;
-                    return (<Accordion
-                        key={key}
-                        title={field.label}
-                        titleId={field.labelId}
-                        identifier={key}
-                        loadItems={field.loadItems}
-                        items={field.items}
-                        content={(accordionItems) => (
-                            <FilterItems
-                                id={id}
-                                items={accordionItems}
-                                suggestionsRequestTypes={suggestionsRequestTypes}
-                                values={values}
-                                onChange={onChange}
-                            />)
-                        }
-                    />);
-                }
-                return null;
+        <FilterByExtent
+            id={id}
+            labelId={labelId}
+            extent={query.extent}
+            layers={layers}
+            vectorLayerStyle={vectorLayerStyle}
+            onChange={(({ extent }) =>{
+                extentChange(extent);
             })}
-        </>
+        />
+    );
+}
+function FilterItem({
+    id,
+    suggestionsRequestTypes,
+    values,
+    onChange,
+    extentProps,
+    timeDebounce,
+    field
+}, { messages }) {
+
+
+    if (field.type === 'search') {
+        return (
+            <InputControlWithDebounce
+                placeholder="gnhome.search"
+                value={values.q || ''}
+                debounceTime={300}
+                onChange={(q) => onChange({ q })}
+            />
+        );
+    }
+    if (field.type === 'extent') {
+        return (
+            <ExtentFilterWithDebounce
+                labelId={field.labelId}
+                id={field.uuid}
+                query={values}
+                timeDebounce={timeDebounce}
+                layers={field?.layers || extentProps?.layers}
+                vectorLayerStyle={field?.vectorStyle || extentProps?.style}
+                onChange={onChange}
+            />
+        );
+    }
+    if (field.type === 'date-range') {
+        return (
+            <DateRangeFilter
+                query={values}
+                labelId={field.labelId}
+                filterKey={field.filterKey}
+                onChange={onChange}
+            />
+        );
+    }
+    if (field.type === 'select' && field.loadItems) {
+        const filterKey = field.key;
+        const currentValues = castArray(values[filterKey] || []);
+        const getLabelValue = (item) => item.labelId
+            ? `${getMessageById(messages, item.labelId)} (${item.count})`
+            : `${item.label || ''} (${item.count})`;
+        return (
+            <FormGroup
+                controlId={field.id}
+            >
+                <label><strong>{field.labelId ? getMessageById(messages, field.labelId) : field.label}</strong></label>
+                <SelectInfiniteScroll
+                    value={currentValues.map((value) => {
+                        const selectedFilter = getFilterById(filterKey, value);
+                        return {
+                            value,
+                            label: selectedFilter ? getLabelValue(selectedFilter) : value
+                        };
+                    })}
+                    multi
+                    placeholder={field.placeholderId}
+                    onChange={(selected) => {
+                        onChange({
+                            [filterKey]: selected.map(({ value }) => value)
+                        });
+                    }}
+                    loadOptions={({ q, ...params }) => field.loadItems({
+                        ...params,
+                        ...(q && { topic_contains: q }),
+                        page: params.page - 1
+                    })
+                        .then((response) => {
+                            return {
+                                ...response,
+                                results: response.items.map((item) => ({
+                                    ...item,
+                                    selectOption: {
+                                        value: item.filterValue,
+                                        label: getLabelValue(item)
+                                    }
+                                }))
+                            };
+                        })}
+                />
+            </FormGroup>
+        );
+    }
+    if (field.type === 'select') {
+        const {
+            id: formId,
+            labelId,
+            label,
+            placeholderId,
+            description,
+            options,
+            suggestionsRequestKey
+        } = field;
+        const key = `${id}-${formId || suggestionsRequestKey}`;
+        const filterKey = suggestionsRequestKey
+            ? suggestionsRequestTypes[suggestionsRequestKey]?.filterKey
+            : `filter{${formId}.in}`;
+
+        const currentValues = castArray(suggestionsRequestKey
+            ? values[suggestionsRequestTypes[suggestionsRequestKey]?.filterKey] || []
+            : values[filterKey] || []);
+
+        const optionsProp = suggestionsRequestKey
+            ? { loadOptions: suggestionsRequestTypes[suggestionsRequestKey]?.loadOptions }
+            : { options: options.map(option => ({ value: option, label: option })) };
+        const Select = suggestionsRequestKey ? SelectInfiniteScroll : SelectSync;
+        return (
+            <FormGroup
+                controlId={key}
+            >
+                <label><strong>{labelId ? getMessageById(messages, labelId) : label}</strong></label>
+                <Select
+                    value={currentValues.map((value) => ({ value, label: getFilterLabelById(filterKey, value) || value }))}
+                    multi
+                    placeholder={placeholderId}
+                    onChange={(selected) => {
+                        onChange({
+                            [filterKey]: selected.map(({ value }) => value)
+                        });
+                    }}
+                    { ...optionsProp }
+                />
+                {description &&
+                <div className="text-muted">
+                    {description}
+                </div>}
+            </FormGroup>
+        );
+    }
+    if (field.type === 'group') {
+        return (<>
+            <div className="gn-filter-form-group-title">
+                <strong>{getMessageById(messages, field.labelId)} </strong>
+            </div>
+            <FilterItems
+                id={id}
+                items={field.items}
+                suggestionsRequestTypes={suggestionsRequestTypes}
+                values={values}
+                onChange={onChange}
+            />
+        </>);
+    }
+    if (field.type === 'divider') {
+        return <div className="gn-filter-form-divider"></div>;
+    }
+    if (field.type === 'link') {
+        return <div className="gn-filter-form-link"><a href={field.href}>{field.labelId && getMessageById(messages, field.labelId) || field.label}</a></div>;
+    }
+    if (field.type === 'filter') {
+        const filterKey = field.filterKey || "f";
+        const customFilters = castArray( values[filterKey] || []);
+        const getFilterValue = (item) => item.filterValue || item.id;
+        const isFacet = (item) => item.style === 'facet';
+        const renderFacet = ({item, active, onChangeFacet, renderChild}) => {
+            return (
+                <div className="gn-facet-wrapper">
+                    <Facet label={item.labelId ? getMessageById(messages, item.labelId) : <span>{item.label}</span>} item={item} active={active} onChange={onChangeFacet}/>
+                    {item.items && renderChild && <div className="facet-children">{renderChild()}</div>}
+                </div>
+            );
+        };
+
+        const filterChild = () => {
+            return field.items && field.items.map((item) => {
+                const active = customFilters.find(value => value === getFilterValue(item));
+                const onChangeFilter = () => {
+                    onChange({
+                        f: active
+                            ? customFilters.filter(value => value !== getFilterValue(item))
+                            : [...customFilters.filter(value => field.id !== value), getFilterValue(item), getFilterValue(field)]
+                    });
+                };
+                return (
+                    <div className={'gn-sub-filter-items'} key={item.uuid}>
+                        {isFacet(item)
+                            ? renderFacet({item, active, onChangeFacet: onChangeFilter})
+                            : <Checkbox
+                                type="checkbox"
+                                checked={!!active}
+                                value={getFilterValue(item)}
+                                onChange={onChangeFilter}
+                            >
+                                {item.labelId ? getMessageById(messages, item.labelId) : item.label}
+                            </Checkbox>
+                        }
+                    </div>
+                );
+            } );
+        };
+        const active = customFilters.find(value => value === getFilterValue(field));
+        const parentFilterIds = [
+            getFilterValue(field),
+            ...(field.items
+                ? field.items.map((item) => getFilterValue(item))
+                : [])
+        ];
+        const onChangeFilterParent = () => {
+            onChange({
+                [filterKey]: active
+                    ? customFilters.filter(value => !parentFilterIds.includes(value))
+                    : [...customFilters, getFilterValue(field)]
+            });
+        };
+        return isFacet(field)
+            ? renderFacet({
+                item: field,
+                active,
+                onChangeFacet: onChangeFilterParent,
+                renderChild: filterChild
+            }) : (
+                <FormGroup controlId={'gn-radio-filter-' + getFilterValue(field)}>
+                    <Checkbox
+                        type="checkbox"
+                        checked={!!active}
+                        value={getFilterValue(field)}
+                        onChange={onChangeFilterParent}>
+                        {field.labelId ? getMessageById(messages, field.labelId) : field.label}
+                        {filterChild()}
+                    </Checkbox>
+                </FormGroup>
+            );
+    }
+    if (field.type === 'accordion' && !field.facet && field.id) {
+        const key = `${id}-${field.id}`;
+        return (<Accordion
+            title={field.labelId ? getMessageById(messages, field.labelId) : field.label}
+            identifier={key}
+            loadItems={field.loadItems}
+            items={field.items}
+            content={(accordionItems) => (
+                <FilterItems
+                    id={id}
+                    items={accordionItems}
+                    suggestionsRequestTypes={suggestionsRequestTypes}
+                    values={values}
+                    onChange={onChange}
+                />)
+            }
+        />);
+    }
+    return null;
+}
+
+FilterItem.contextTypes = {
+    messages: PropTypes.object
+};
+
+function FilterItems({ items, ...props }) {
+    return items.map((field, idx) =>
+        <FilterItem key={field.uuid || `${field.id || ''}-${idx}`} {...props} field={field} />
     );
 }
 

--- a/geonode_mapstore_client/client/js/components/FiltersForm/__tests__/FilterItems-test.jsx
+++ b/geonode_mapstore_client/client/js/components/FiltersForm/__tests__/FilterItems-test.jsx
@@ -165,6 +165,70 @@ describe('FilterItems component', () => {
 
             isExpanded() && Simulate.click(filterItemsAccordionTitleNode);
         });
+        it('should render field date-range from', (done) => {
+            const items = [
+                {
+                    type: 'date-range',
+                    filterKey: 'date',
+                    labelId: 'gnviewer.dateFilter'
+                }
+            ];
+            ReactDOM.render( <FilterItems id="test" items={items} onChange={(value) => {
+                try {
+                    expect(value['filter{date.gte}']).toBeTruthy();
+                    expect(value['filter{date.gte}'].split('T')[1]).toBe('00:00:00');
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            }}/>, document.getElementById("container"));
+
+            const dateTimePickersLabels = document.querySelectorAll('label > span');
+            expect(dateTimePickersLabels.length).toBe(2);
+            expect([...dateTimePickersLabels].map(node => node.innerText)).toEqual([ 'gnviewer.dateFilter.from', 'gnviewer.dateFilter.to' ]);
+            const dateTimePickers = document.querySelectorAll('.rw-datetimepicker');
+            expect(dateTimePickers.length).toBe(2);
+            const dateTimePickersButtons = document.querySelectorAll('.rw-btn-calendar');
+            expect(dateTimePickersButtons.length).toBe(2);
+
+            Simulate.click(dateTimePickersButtons[0]);
+
+            const calendarButton = document.querySelectorAll('tbody .rw-btn');
+
+            Simulate.click(calendarButton[0]);
+        });
+        it('should render field date-range to', (done) => {
+            const items = [
+                {
+                    type: 'date-range',
+                    filterKey: 'date',
+                    labelId: 'gnviewer.dateFilter'
+                }
+            ];
+            ReactDOM.render( <FilterItems id="test" items={items} onChange={(value) => {
+                try {
+                    expect(value['filter{date.lte}']).toBeTruthy();
+                    expect(value['filter{date.lte}'].split('T')[1]).toBe('23:59:59');
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            }}/>, document.getElementById("container"));
+
+            const dateTimePickersLabels = document.querySelectorAll('label > span');
+            expect(dateTimePickersLabels.length).toBe(2);
+            expect([...dateTimePickersLabels].map(node => node.innerText)).toEqual([ 'gnviewer.dateFilter.from', 'gnviewer.dateFilter.to' ]);
+            const dateTimePickers = document.querySelectorAll('.rw-datetimepicker');
+            expect(dateTimePickers.length).toBe(2);
+            const dateTimePickersButtons = document.querySelectorAll('.rw-btn-calendar');
+            expect(dateTimePickersButtons.length).toBe(2);
+
+            Simulate.click(dateTimePickersButtons[1]);
+
+            const calendarButton = document.querySelectorAll('tbody .rw-btn');
+
+            Simulate.click(calendarButton[0]);
+        });
     });
 
 });

--- a/geonode_mapstore_client/client/js/components/FiltersMenu/FiltersMenu.jsx
+++ b/geonode_mapstore_client/client/js/components/FiltersMenu/FiltersMenu.jsx
@@ -83,9 +83,8 @@ const FiltersMenu = forwardRef(({
                         <FaIcon name={cardLayoutStyle === 'grid' ? 'list' : 'th'} />
                     </Button>
                     {orderOptions.length > 0 &&
-                    <Dropdown pullRight>
+                    <Dropdown pullRight id="sort-dropdown">
                         <Dropdown.Toggle
-                            id="sort-dropdown"
                             bsStyle="default"
                             bsSize="sm"
                             noCaret

--- a/geonode_mapstore_client/client/js/components/Menu/Menu.js
+++ b/geonode_mapstore_client/client/js/components/Menu/Menu.js
@@ -67,7 +67,7 @@ Menu.propTypes = {
     items: PropTypes.array.isRequired,
     containerClass: PropTypes.string,
     childrenClass: PropTypes.string,
-    query: PropTypes.string,
+    query: PropTypes.object,
     formatHref: PropTypes.func
 
 };

--- a/geonode_mapstore_client/client/js/plugins/ResourcesGrid.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ResourcesGrid.jsx
@@ -299,6 +299,9 @@ function ResourcesGrid({
     ],
     filtersFormItems = [
         {
+            type: 'search'
+        },
+        {
             type: 'group',
             labelId: 'gnhome.customFiltersTitle',
             items: [
@@ -412,6 +415,15 @@ function ResourcesGrid({
             type: "accordion",
             style: "facet",
             facet: "thesaurus"
+        },
+        {
+            type: 'date-range',
+            filterKey: 'date',
+            labelId: 'gnviewer.dateFilter'
+        },
+        {
+            labelId: 'gnviewer.extent',
+            type: 'extent'
         }
     ],
     pagePath = '',

--- a/geonode_mapstore_client/client/js/plugins/save/SaveModal.jsx
+++ b/geonode_mapstore_client/client/js/plugins/save/SaveModal.jsx
@@ -36,7 +36,7 @@ function SaveModal({
     const [thumbnail, setThumbnail] =  useState();
     const [name, setName] =  useState('');
     const [description, setDescription] =  useState('');
-    const [nameValidation, setNameValidation] =  useState(false);
+    const [nameValidation, setNameValidation] =  useState();
 
     const state = useRef();
     state.current = {

--- a/geonode_mapstore_client/client/js/utils/AppUtils.js
+++ b/geonode_mapstore_client/client/js/utils/AppUtils.js
@@ -28,6 +28,7 @@ import isFunction from 'lodash/isFunction';
 
 import url from 'url';
 import axios from '@mapstore/framework/libs/ajax';
+import moment from 'moment';
 import { addLocaleData } from 'react-intl';
 import { setViewer } from '@mapstore/framework/utils/MapInfoUtils';
 
@@ -154,6 +155,8 @@ function setupLocale(locale) {
                         });
                     });
             }
+            // setup locale for moment
+            moment.locale(locale);
             return locale;
         });
 }

--- a/geonode_mapstore_client/client/js/utils/SearchUtils.js
+++ b/geonode_mapstore_client/client/js/utils/SearchUtils.js
@@ -9,6 +9,7 @@
 import url from 'url';
 import castArray from 'lodash/castArray';
 import omit from 'lodash/omit';
+import uuid from 'uuid/v1';
 
 let filters = {};
 
@@ -93,15 +94,15 @@ export const updateFilterFormItemsWithFacet = (formItems, facetItems) => {
             return [
                 ...acc,
                 ...filteredFacetItems
-                    .map(({ name, key, label, labelId, loadItems } = {}) => {
+                    .map(({ name, key, label, is_localized: isLocalized, loadItems } = {}) => {
                         return {
+                            uuid: uuid(),
                             name,
                             key,
                             id: name,
                             type: formItem.type,
                             style: formItem.style,
-                            labelId,
-                            label,
+                            ...(isLocalized ? { labelId: label } : { label }),
                             loadItems: (params) => loadItems({ name, style: formItem.style, filterKey: key }, params)
                         };
                     })
@@ -112,13 +113,17 @@ export const updateFilterFormItemsWithFacet = (formItems, facetItems) => {
                 ...acc,
                 {
                     ...formItem,
+                    uuid: formItem.uuid || uuid(),
                     items: updateFilterFormItemsWithFacet(formItem.items, facetItems)
                 }
             ];
         }
         return [
             ...acc,
-            formItem
+            {
+                ...formItem,
+                uuid: formItem.uuid || uuid()
+            }
         ];
     }, []);
 };

--- a/geonode_mapstore_client/client/js/utils/__tests__/SearchUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/SearchUtils-test.js
@@ -20,15 +20,11 @@ describe('Test Resource Utils', () => {
         expect(filterFormItemsContainFacet([ { type: 'group', items: [{ type: 'accordion', facet: 'thesaurus' }] }, { type: 'filter' } ])).toBe(true);
     });
     describe('Test updateFilterFormItemsWithFacet', () => {
-        it('test with no facet items', () => {
-            const formItems = ["1", "2"];
-            const items = updateFilterFormItemsWithFacet(formItems);
-            expect(items).toEqual(formItems);
-        });
         it('test with no facet item in filter form items', () => {
             const formItems = [{name: "1"}, {name: "2"}];
             const items = updateFilterFormItemsWithFacet(formItems);
-            expect(items).toEqual(formItems);
+            expect(items[0].name).toEqual(formItems[0].name);
+            expect(items[1].name).toEqual(formItems[1].name);
         });
         it('test with facet item and filter form items', () => {
             const formItems = [{name: "1"}, {style: "facet", type: "accordion", facet: "thesaurus"}];
@@ -48,7 +44,7 @@ describe('Test Resource Utils', () => {
             const facetItems = {name: "some-name", key: "filterkey", label: "label1", type: "owner"};
             const items = updateFilterFormItemsWithFacet(formItems, [facetItems]);
             expect(items.length).toBe(1);
-            expect(items).toEqual([formItems[0]]);
+            expect(items[0].name).toEqual(formItems[0].name);
         });
         it('test with nested facet item', () => {
             const formItems = [{ type: "group", items: [{style: "facet", type: "accordion", facet: "thesaurus"}] }];

--- a/geonode_mapstore_client/client/themes/geonode/less/_filter-form.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_filter-form.less
@@ -222,6 +222,7 @@
         cursor: pointer;
         font-weight: 600;
         padding: 0.4rem 0.25rem;
+        padding-left: 0;
         .accordion-title-label {
             flex: 1;
             display: flex;

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -78,7 +78,6 @@
             "logOut": "Ausloggen",
             "terms": "Bedingungen",
             "privacy": "Datenschutz",
-            "extent": "Ausmaß",
             "enableFilterByExtent": "Filter nach Ausmaß aktivieren",
             "advancedSearch": "Erweiterte Suche",
             "apply": "Anwenden",
@@ -330,7 +329,12 @@
             "abstract": "Zusammenfassung",
             "readMore": "Weiterlesen",
             "readLess": "Weniger lesen",
-            "linkedResources": "Verknüpfte Ressourcen"
+            "linkedResources": "Verknüpfte Ressourcen",
+            "extent": "Ausmaß",
+            "dateFilter": {
+                "from": "Datum von",
+                "to": "Datum bis"
+            }
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -78,7 +78,6 @@
             "logOut": "Log out",
             "terms": "Terms",
             "privacy": "Privacy",
-            "extent": "Extent",
             "enableFilterByExtent": "Enable filter by extent",
             "advancedSearch": "Advanced search",
             "apply": "Apply",
@@ -330,7 +329,12 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources"
+            "linkedResources": "Linked Resources",
+            "extent": "Extent",
+            "dateFilter": {
+                "from": "Date from",
+                "to": "Date to"
+            }
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -78,7 +78,6 @@
             "logOut": "Salir",
             "terms": "Terms",
             "privacy": "Privacy",
-            "extent": "Extensión",
             "enableFilterByExtent": "Habilitar el filtro por extensión",
             "advancedSearch": "Búsqueda avanzada",
             "apply": "Aplicar",
@@ -329,7 +328,12 @@
             "abstract": "Resumen",
             "readMore": "Leer más",
             "readLess": "Leer menos",
-            "linkedResources": "Recursos vinculados"
+            "linkedResources": "Recursos vinculados",
+            "extent": "Extensión",
+            "dateFilter": {
+                "from": "Fecha desde",
+                "to": "Fecha hasta"
+            }
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -77,7 +77,6 @@
             "logOut": "Log out",
             "terms": "Terms",
             "privacy": "Privacy",
-            "extent": "Extent",
             "enableFilterByExtent": "Enable filter by extent",
             "advancedSearch": "Advanced search",
             "apply": "Apply",
@@ -299,7 +298,12 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources"
+            "linkedResources": "Linked Resources",
+            "extent": "Extent",
+            "dateFilter": {
+                "from": "Date from",
+                "to": "Date to"
+            }
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -78,7 +78,6 @@
             "logOut": "Se déconnecter",
             "terms": "Terms",
             "privacy": "Privacy",
-            "extent": "Étendue",
             "enableFilterByExtent": "Activer le filtre par étendue",
             "advancedSearch": "Recherche vvancée",
             "apply": "Appliquer",
@@ -330,7 +329,12 @@
             "abstract": "Résumé",
             "readMore": "En savoir plus",
             "readLess": "Lire moins",
-            "linkedResources": "Ressources liées"
+            "linkedResources": "Ressources liées",
+            "extent": "Étendue",
+            "dateFilter": {
+                "from": "Date de",
+                "to": "Date à"
+            }
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -77,7 +77,6 @@
             "logOut": "Log out",
             "terms": "Terms",
             "privacy": "Privacy",
-            "extent": "Extent",
             "enableFilterByExtent": "Enable filter by extent",
             "advancedSearch": "Advanced search",
             "apply": "Apply",
@@ -299,7 +298,12 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources"
+            "linkedResources": "Linked Resources",
+            "extent": "Extent",
+            "dateFilter": {
+                "from": "Date from",
+                "to": "Date to"
+            }
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -80,7 +80,6 @@
             "logOut": "Esci",
             "terms": "Termini e condizioni",
             "privacy": "Privacy",
-            "extent": "Estensione",
             "enableFilterByExtent": "Abilita filtro per estensione",
             "advancedSearch": "Ricerca avanzata",
             "apply": "Applica",
@@ -332,7 +331,12 @@
             "abstract": "Astratto",
             "readMore": "Leggi di più",
             "readLess": "Leggi di meno",
-            "linkedResources": "Risorse collegate"
+            "linkedResources": "Risorse collegate",
+            "extent": "Estensione",
+            "dateFilter": {
+                "from": "Data da",
+                "to": "Data a"
+            }
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -77,7 +77,6 @@
             "logOut": "Log out",
             "terms": "Terms",
             "privacy": "Privacy",
-            "extent": "Extent",
             "enableFilterByExtent": "Enable filter by extent",
             "advancedSearch": "Advanced search",
             "apply": "Apply",
@@ -299,7 +298,12 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources"
+            "linkedResources": "Linked Resources",
+            "extent": "Extent",
+            "dateFilter": {
+                "from": "Date from",
+                "to": "Date to"
+            }
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -77,7 +77,6 @@
             "logOut": "Log out",
             "terms": "Terms",
             "privacy": "Privacy",
-            "extent": "Extent",
             "enableFilterByExtent": "Enable filter by extent",
             "advancedSearch": "Advanced search",
             "apply": "Apply",
@@ -299,7 +298,12 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources"
+            "linkedResources": "Linked Resources",
+            "extent": "Extent",
+            "dateFilter": {
+                "from": "Date from",
+                "to": "Date to"
+            }
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -77,7 +77,6 @@
             "logOut": "Log out",
             "terms": "Terms",
             "privacy": "Privacy",
-            "extent": "Extent",
             "enableFilterByExtent": "Enable filter by extent",
             "advancedSearch": "Advanced search",
             "apply": "Apply",
@@ -299,7 +298,12 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources"
+            "linkedResources": "Linked Resources",
+            "extent": "Extent",
+            "dateFilter": {
+                "from": "Date from",
+                "to": "Date to"
+            }
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -78,7 +78,6 @@
             "logOut": "Log out",
             "terms": "Terms",
             "privacy": "Privacy",
-            "extent": "Extent",
             "enableFilterByExtent": "Enable filter by extent",
             "advancedSearch": "Advanced search",
             "apply": "Apply",
@@ -300,7 +299,12 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources"
+            "linkedResources": "Linked Resources",
+            "extent": "Extent",
+            "dateFilter": {
+                "from": "Date from",
+                "to": "Date to"
+            }
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -77,7 +77,6 @@
             "logOut": "Log out",
             "terms": "Terms",
             "privacy": "Privacy",
-            "extent": "Extent",
             "enableFilterByExtent": "Enable filter by extent",
             "advancedSearch": "Advanced search",
             "apply": "Apply",
@@ -298,7 +297,12 @@
             "viewFullMetadata": "View full metadata",
             "abstract": "Abstract",
             "readMore": "Read more",
-            "readLess": "Read less"
+            "readLess": "Read less",
+            "extent": "Extent",
+            "dateFilter": {
+                "from": "Date from",
+                "to": "Date to"
+            }
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -77,7 +77,6 @@
             "logOut": "Log out",
             "terms": "Terms",
             "privacy": "Privacy",
-            "extent": "Extent",
             "enableFilterByExtent": "Enable filter by extent",
             "advancedSearch": "Advanced search",
             "apply": "Apply",
@@ -298,7 +297,12 @@
             "viewFullMetadata": "View full metadata",
             "abstract": "Abstract",
             "readMore": "Read more",
-            "readLess": "Read less"
+            "readLess": "Read less",
+            "extent": "Extent",
+            "dateFilter": {
+                "from": "Date from",
+                "to": "Date to"
+            }
         }
     }
 }


### PR DESCRIPTION
This PR introduces following changes:
- add the `date-range` type to filter items
- add extent and search input to filter items
- review some configuration of select and filter for the facets
- refactor of FilterItems component to apply correctly the keys to components
- replace Message Component with getMessageById in FilterItems to apply to select options and avoid warning in particular for facets


![image](https://github.com/GeoNode/geonode-mapstore-client/assets/19175505/e0beccce-e7eb-453d-bb48-f58dbb5d6169)
