### PR TITLE
Fix #1462 The Format option on the Print tool is present twice

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -866,31 +866,22 @@
                 "name": "Print",
                 "cfg": {
                     "useFixedScales": true,
-                    "mapWidth": 256
-                }
-            },
-            {
-                "name": "PrintOutputFormat",
-                "cfg": {
-                    "allowedFormats": [
-                        {
-                            "value": "pdf",
-                            "name": "PDF"
-                        },
-                        {
-                            "value": "png",
-                            "name": "PNG"
-                        },
-                        {
-                            "value": "jpg",
-                            "name": "JPEG"
-                        }
-                    ]
-                },
-                "override": {
-                    "Print": {
-                        "target": "left-panel",
-                        "position": 3
+                    "mapWidth": 256,
+                    "outputFormatOptions": {
+                        "allowedFormats": [
+                            {
+                                "value": "pdf",
+                                "name": "PDF"
+                            },
+                            {
+                                "value": "png",
+                                "name": "PNG"
+                            },
+                            {
+                                "value": "jpg",
+                                "name": "JPEG"
+                            }
+                        ]
                     }
                 }
             },
@@ -1731,31 +1722,22 @@
                 "name": "Print",
                 "cfg": {
                     "useFixedScales": true,
-                    "mapWidth": 256
-                }
-            },
-            {
-                "name": "PrintOutputFormat",
-                "cfg": {
-                    "allowedFormats": [
-                        {
-                            "value": "pdf",
-                            "name": "PDF"
-                        },
-                        {
-                            "value": "png",
-                            "name": "PNG"
-                        },
-                        {
-                            "value": "jpg",
-                            "name": "JPEG"
-                        }
-                    ]
-                },
-                "override": {
-                    "Print": {
-                        "target": "left-panel",
-                        "position": 3
+                    "mapWidth": 256,
+                    "outputFormatOptions": {
+                        "allowedFormats": [
+                            {
+                                "value": "pdf",
+                                "name": "PDF"
+                            },
+                            {
+                                "value": "png",
+                                "name": "PNG"
+                            },
+                            {
+                                "value": "jpg",
+                                "name": "JPEG"
+                            }
+                        ]
                     }
                 }
             },


### PR DESCRIPTION
This PR remove duplicated configuration for the format inside the Print plugin

![image](https://github.com/GeoNode/geonode-mapstore-client/assets/19175505/26602d7b-48a2-4ad6-a3fd-8ba9e37f3a50)
