### PR TITLE
#1480: Order supported datasets format

### DIFF
--- a/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
+++ b/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
@@ -41,13 +41,18 @@ function getDatasetFileType(file, supportedTypes) {
 const cancelTokens = {};
 const sources = {};
 
+const reorderDatasetFileTypes = (supportedDatasetFileTypes = []) => {
+    const order = {vector: 1, raster: 2};
+    return supportedDatasetFileTypes?.sort((a, b) => order[a.format] - order[b.format]) ?? [];
+};
+
 function UploadList({
     children,
     onSuccess
 }) {
     const { maxParallelUploads, upload: uploadSettings = {} } = getConfigProp('geoNodeSettings') || {};
 
-    const { supportedDatasetFileTypes: supportedDatasetTypes } = uploadSettings;
+    const supportedDatasetTypes = reorderDatasetFileTypes(uploadSettings.supportedDatasetFileTypes);
 
     const supportedExtensions = supportedDatasetTypes.map(({ ext }) => ext || []).flat();
     const supportedMimeTypes = supportedDatasetTypes.map(({ mimeType }) => mimeType || []).flat();


### PR DESCRIPTION
### Description
This PR reorders supported datasets format

### Issue
- https://github.com/GeoNode/geonode-mapstore-client/issues/1480#issuecomment-1610173198

### Screenshot
<img width="304" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/44fcd0a4-03d3-4228-9ddc-492548f8cd87">
