### PR TITLE
#1482: Use the available height for the abstract text in a card

### DIFF
--- a/geonode_mapstore_client/client/js/components/ResourceCard/ResourceCard.jsx
+++ b/geonode_mapstore_client/client/js/components/ResourceCard/ResourceCard.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useState, useRef } from 'react';
 import Message from '@mapstore/framework/components/I18N/Message';
 import FaIcon from '@js/components/FaIcon';
 import Button from '@js/components/Button';
@@ -36,6 +36,7 @@ const ResourceCard = forwardRef(({
         pathname: `/detail/${res.resource_type}/${res.pk}`
     })
 }, ref) => {
+    const abstractRef = useRef();
     const res = data;
     const types = getTypesInfo();
     const { icon } = types[res.subtype] || types[res.resource_type] || {};
@@ -54,7 +55,14 @@ const ResourceCard = forwardRef(({
     function handleClick() {
         onClick(data);
     }
-    const imgClassName = layoutCardsStyle === 'list' ? 'card-img-left' : 'card-img-top';
+    const isCardLayoutList = layoutCardsStyle === 'list';
+    const imgClassName = isCardLayoutList ? 'card-img-left' : 'card-img-top';
+
+    const renderEllipsis = () => {
+        const isOverflowing = isCardLayoutList && abstractRef?.current?.clientHeight < abstractRef?.current?.scrollHeight;
+        return isOverflowing ? <span className="ellipsis">...</span> : null;
+    };
+
     return (
         <div
             ref={ref}
@@ -62,7 +70,7 @@ const ResourceCard = forwardRef(({
             className={`gn-resource-card${active ? ' active' : ''}${
                 readOnly ? ' read-only' : ''
             } gn-card-type-${layoutCardsStyle} ${
-                layoutCardsStyle === 'list' ? 'rounded-0' : ''
+                isCardLayoutList ? 'rounded-0' : ''
             }${className ? ` ${className}` : ''}`}
         >
             {!readOnly && (
@@ -74,7 +82,7 @@ const ResourceCard = forwardRef(({
             {!readOnly &&
                 options &&
                 options.length > 0 &&
-                layoutCardsStyle === 'grid' && (
+                !isCardLayoutList && (
                 <ActionButtons
                     buildHrefByTemplate={buildHrefByTemplate}
                     resource={res}
@@ -130,13 +138,14 @@ const ResourceCard = forwardRef(({
                                 <ResourceStatus resource={res} />
                             </div>
                         </div>
-                        <p className="card-text gn-card-description">
+                        <p ref={abstractRef} className={`card-text gn-card-description ${layoutCardsStyle}`}>
                             {res.raw_abstract ? res.raw_abstract : '...'}
                         </p>
+                        {renderEllipsis()}
                         {!readOnly &&
                             options &&
                             options.length > 0 &&
-                            layoutCardsStyle === 'list' && (
+                            isCardLayoutList && (
                             <ActionButtons
                                 buildHrefByTemplate={buildHrefByTemplate}
                                 resource={res}

--- a/geonode_mapstore_client/client/themes/geonode/less/_resource-card.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_resource-card.less
@@ -186,8 +186,16 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        &.list {
+            white-space: unset;
+            max-height: 2.2rem;
+        }
         .gn-spinner {
             margin-right: 0.4rem;
+        }
+        &+.ellipsis {
+            position: absolute;
+            bottom: 0.625rem;
         }
     }
     .card-title {

--- a/geonode_mapstore_client/client/themes/geonode/less/_resource-card.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_resource-card.less
@@ -189,13 +189,13 @@
         &.list {
             white-space: unset;
             max-height: 2.2rem;
+            &+.ellipsis {
+                position: absolute;
+                bottom: 0.625rem;
+            }
         }
         .gn-spinner {
             margin-right: 0.4rem;
-        }
-        &+.ellipsis {
-            position: absolute;
-            bottom: 0.625rem;
         }
     }
     .card-title {


### PR DESCRIPTION
### Description
This PR makes the resource card to use available space to display abstract text especially in list mode. This is achieved by programatically adding ellipsis when more lines of text present.

### Issue
- #1482 

### Screenshot
<img width="1474" alt="Screenshot 2023-08-08 at 1 32 14 PM" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/32ded655-1662-49dc-8f18-79ce604d0dbd">
<img width="1095" alt="Screenshot 2023-08-08 at 1 32 03 PM" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/c4675bb7-03a5-4de5-9dcb-f4f35913b3a2">