### PR TITLE
Add override settings block

### DIFF
--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -41,30 +41,30 @@
         const cardsMenuItems = getJSONScriptVariable('menu-CARDS_MENU', []);
         const geoNodeSettings = getJSONScriptVariable('GEONODE_SETTINGS', {});
 
-        const baseLayers = geoNodeSettings.MAP_BASELAYERS || [];
-        const baseLayersSources = geoNodeSettings.MAP_BASELAYERS_SOURCES || {};
-        const defaultMapCRS = geoNodeSettings.DEFAULT_MAP_CRS || 'EPSG:3857';
-        const defaultMapCenterX = geoNodeSettings.DEFAULT_MAP_CENTER_X || 0;
-        const defaultMapCenterY = geoNodeSettings.DEFAULT_MAP_CENTER_Y || 0;
-        const defaultMapZoom = geoNodeSettings.DEFAULT_MAP_ZOOM || 0;
-        const defaultTileSize = geoNodeSettings.DEFAULT_TILE_SIZE || 512;
-        const defaultThumbnailSize = geoNodeSettings.DEFAULT_THUMBNAIL_SIZE || {'width': 500, 'height': 200};
-        const datasetMaxUploadSize = geoNodeSettings.DATASET_MAX_UPLOAD_SIZE;
-        const documentMaxUploadSize = geoNodeSettings.DOCUMENT_MAX_UPLOAD_SIZE;
-        const maxParallelUploads = geoNodeSettings.MAX_PARALLEL_UPLOADS
-        const defaultLayerFormat = geoNodeSettings.DEFAULT_LAYER_FORMAT || 'image/png';
-        const catalogueServices = geoNodeSettings.CATALOGUE_SERVICES || {};
-        const catalogueSelectedService = geoNodeSettings.CATALOGUE_SELECTED_SERVICE || '';
-        const createLayer = geoNodeSettings.CREATE_LAYER || false
-        const timeEnabled = geoNodeSettings.TIME_ENABLED || false;
-        const allowedDocumentTypes = geoNodeSettings.ALLOWED_DOCUMENT_TYPES || [];
-        const languages = geoNodeSettings.LANGUAGES;
-        const projectionDefs = geoNodeSettings.PROJECTION_DEFS || [];
-        const pluginsConfigPatchRules  = geoNodeSettings.PLUGINS_CONFIG_PATCH_RULES || [];
-        const translationsPath = geoNodeSettings.TRANSLATIONS_PATH;
-        const extensionsFolder = geoNodeSettings.EXTENSIONS_FOLDER_PATH;
-        const supportedDatasetFileTypes = geoNodeSettings.SUPPORTED_DATASET_FILE_TYPES;
-        const customFilters = geoNodeSettings.CUSTOM_FILTERS || {
+        let baseLayers = geoNodeSettings.MAP_BASELAYERS || [];
+        let baseLayersSources = geoNodeSettings.MAP_BASELAYERS_SOURCES || {};
+        let defaultMapCRS = geoNodeSettings.DEFAULT_MAP_CRS || 'EPSG:3857';
+        let defaultMapCenterX = geoNodeSettings.DEFAULT_MAP_CENTER_X || 0;
+        let defaultMapCenterY = geoNodeSettings.DEFAULT_MAP_CENTER_Y || 0;
+        let defaultMapZoom = geoNodeSettings.DEFAULT_MAP_ZOOM || 0;
+        let defaultTileSize = geoNodeSettings.DEFAULT_TILE_SIZE || 512;
+        let defaultThumbnailSize = geoNodeSettings.DEFAULT_THUMBNAIL_SIZE || {'width': 500, 'height': 200};
+        let datasetMaxUploadSize = geoNodeSettings.DATASET_MAX_UPLOAD_SIZE;
+        let documentMaxUploadSize = geoNodeSettings.DOCUMENT_MAX_UPLOAD_SIZE;
+        let maxParallelUploads = geoNodeSettings.MAX_PARALLEL_UPLOADS
+        let defaultLayerFormat = geoNodeSettings.DEFAULT_LAYER_FORMAT || 'image/png';
+        let catalogueServices = geoNodeSettings.CATALOGUE_SERVICES || {};
+        let catalogueSelectedService = geoNodeSettings.CATALOGUE_SELECTED_SERVICE || '';
+        let createLayer = geoNodeSettings.CREATE_LAYER || false
+        let timeEnabled = geoNodeSettings.TIME_ENABLED || false;
+        let allowedDocumentTypes = geoNodeSettings.ALLOWED_DOCUMENT_TYPES || [];
+        let languages = geoNodeSettings.LANGUAGES;
+        let projectionDefs = geoNodeSettings.PROJECTION_DEFS || [];
+        let pluginsConfigPatchRules  = geoNodeSettings.PLUGINS_CONFIG_PATCH_RULES || [];
+        let translationsPath = geoNodeSettings.TRANSLATIONS_PATH;
+        let extensionsFolder = geoNodeSettings.EXTENSIONS_FOLDER_PATH;
+        let supportedDatasetFileTypes = geoNodeSettings.SUPPORTED_DATASET_FILE_TYPES;
+        let customFilters = geoNodeSettings.CUSTOM_FILTERS || {
             "my-resources": {
                 "filter{owner.pk}": "{state('user') && state('user').pk}"
             },
@@ -109,12 +109,12 @@
             }
         };
 
-        const isEmbed = checkBoolean('{{ is_embed }}') || false;
-        const pluginsConfigKey = '{{ plugins_config_key }}';
-        const siteUrl = '{{ SITEURL }}' || '';
-        const siteName = '{{ SITE_NAME }}' || 'Geonode';
-        const geoServerPublicLocation = '{{ GEOSERVER_PUBLIC_LOCATION }}' || '';
-        const isMobile = '{{ request.user_agent.is_mobile }}' === 'True' ? true : false;
+        let isEmbed = checkBoolean('{{ is_embed }}') || false;
+        let pluginsConfigKey = '{{ plugins_config_key }}';
+        let siteUrl = '{{ SITEURL }}' || '';
+        let siteName = '{{ SITE_NAME }}' || 'Geonode';
+        let geoServerPublicLocation = '{{ GEOSERVER_PUBLIC_LOCATION }}' || '';
+        let isMobile = '{{ request.user_agent.is_mobile }}' === 'True' ? true : false;
         {% block override_settings %}
         {% endblock %}
         window.__GEONODE_CONFIG__ = {

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -115,7 +115,8 @@
         const siteName = '{{ SITE_NAME }}' || 'Geonode';
         const geoServerPublicLocation = '{{ GEOSERVER_PUBLIC_LOCATION }}' || '';
         const isMobile = '{{ request.user_agent.is_mobile }}' === 'True' ? true : false;
-
+        {% block override_settings %}
+        {% endbloc %
         window.__GEONODE_CONFIG__ = {
             languageCode: '{{ LANGUAGE_CODE }}',
             languages: languages,

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -116,7 +116,7 @@
         const geoServerPublicLocation = '{{ GEOSERVER_PUBLIC_LOCATION }}' || '';
         const isMobile = '{{ request.user_agent.is_mobile }}' === 'True' ? true : false;
         {% block override_settings %}
-        {% endbloc %
+        {% endblock %}
         window.__GEONODE_CONFIG__ = {
             languageCode: '{{ LANGUAGE_CODE }}',
             languages: languages,

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/search_bar.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/search_bar.html
@@ -108,8 +108,10 @@
                 }
 
                 const newQueryHash = newParams.join('&');
-
+                
+                {% block searchbar_search_href %}
                 location.href = '/catalogue/#/search' + (newQueryHash ? '?' + newQueryHash : '');
+                {% endblock %}
 
                 clearRequest();
                 suggestions = [];
@@ -122,12 +124,14 @@
                 loading = true;
                 searchLoading.style.visibility = 'visible';
                 timeout = setTimeout(function() {
+                    {% block searchbar_url_suggestion %}
                     const url = '/api/v2/resources' +
                     '?page=' + options.page +
                     '&search=' + options.value +
                     '&search_fields=title' +
                     '&search_fields=abstract' +
                     '&filter{metadata_only}=false';
+                    {% endblock %}
                     request = $.ajax({
                         url: url,
                         type: 'GET',


### PR DESCRIPTION
With this PR we want to add:
- additional block tag in the django template
- Let the `_geonode_config.html` being overridable by geonode-project itself