### PR TITLE
#1557: Remove info variant on DetailViewer button

### DIFF
--- a/geonode_mapstore_client/client/themes/geonode/less/_menu.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_menu.less
@@ -145,7 +145,7 @@ nav.hide-navigation#gn-topbar {
         display: flex;
         flex-direction: row;
         flex: 1;
-        padding: 0 0.8rem;
+        padding: 0 0.3rem;
         align-items: center;
     }
 

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -502,7 +502,6 @@
                     "leftMenuItems": [
                         {
                             "type": "plugin",
-                            "variant": "info",
                             "size": "md",
                             "name": "DetailViewerButton"
                         },
@@ -1446,7 +1445,6 @@
                     "leftMenuItems": [
                         {
                             "type": "plugin",
-                            "variant": "info",
                             "size": "md",
                             "name": "DetailViewerButton"
                         },
@@ -2111,7 +2109,6 @@
                     "leftMenuItems": [
                         {
                             "type": "plugin",
-                            "variant": "info",
                             "size": "md",
                             "name": "DetailViewerButton"
                         },
@@ -2419,7 +2416,6 @@
                     "leftMenuItems": [
                         {
                             "type": "plugin",
-                            "variant": "info",
                             "size": "md",
                             "name": "DetailViewerButton"
                         },
@@ -2657,7 +2653,6 @@
                     "leftMenuItems": [
                         {
                             "type": "plugin",
-                            "variant": "info",
                             "size": "md",
                             "name": "DetailViewerButton"
                         },


### PR DESCRIPTION
<img width="387" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/fd84ef9b-7a61-4700-b668-6daf84d5a191">

### Issue
- #1557