### PR TITLE
Point to geoserver public UI

### DIFF
--- a/geonode_mapstore_client/templatetags/get_menu_json.py
+++ b/geonode_mapstore_client/templatetags/get_menu_json.py
@@ -182,7 +182,7 @@ def get_user_menu(context):
     admin_only = (
         [
             {"type": "link", "href": "/admin/", "label": "Admin"},
-            {"type": "link", "href": "/geoserver/", "label": "GeoServer"},
+            {"type": "link", "href": settings.GEOSERVER_WEB_UI_LOCATION, "label": "GeoServer"},
         ]
         + monitoring
         + [devider]


### PR DESCRIPTION
The user menu includes a link pointing to `/geoserver` for logged in admins. However, it always should point to the public Web UI using `settings.GEOSERVER_WEB_UI_LOCATION` setting.

![image](https://github.com/GeoNode/geonode-mapstore-client/assets/881756/6e94ace0-8f1e-4f3a-9403-9545433c7ca0)
