### PR TITLE
#1562: Adopt extent property for resources

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnsave.js
+++ b/geonode_mapstore_client/client/js/epics/gnsave.js
@@ -8,7 +8,7 @@
 
 import axios from '@mapstore/framework/libs/ajax';
 import { Observable } from 'rxjs';
-import { mapInfoSelector, mapSelector } from '@mapstore/framework/selectors/map';
+import { mapInfoSelector } from '@mapstore/framework/selectors/map';
 import { userSelector } from '@mapstore/framework/selectors/security';
 import {
     error as errorNotification,
@@ -69,6 +69,7 @@ import {
 import {
     ResourceTypes,
     cleanCompactPermissions,
+    extentConfig,
     toGeoNodeMapConfig
 } from '@js/utils/ResourceUtils';
 import {
@@ -77,23 +78,31 @@ import {
 } from '@js/utils/ResourceServiceUtils';
 import { setControlProperty } from '@mapstore/framework/actions/controls';
 
-function parseMapBody(body, map) {
-    const geoNodeMap = toGeoNodeMapConfig(body.data, map);
+function parseMapBody(body) {
+    const geoNodeMap = toGeoNodeMapConfig(body.data);
     return {
         ...body,
         ...geoNodeMap
     };
 }
 
+function withExtent(body) {
+    const extentConf = extentConfig(body.data);
+    return {
+        ...body,
+        ...extentConf
+    };
+}
+
 const SaveAPI = {
     [ResourceTypes.MAP]: (state, id, body) => {
-        const map =  mapSelector(state) || {};
         return id
-            ? updateMap(id, { ...parseMapBody(body, map), id })
-            : createMap(parseMapBody(body, map));
+            ? updateMap(id, { ...parseMapBody(body), id })
+            : createMap(parseMapBody(body));
     },
-    [ResourceTypes.GEOSTORY]: (state, id, body) => {
+    [ResourceTypes.GEOSTORY]: (state, id, _body) => {
         const user = userSelector(state);
+        const body = { ...withExtent(_body) };
         return id
             ? updateGeoApp(id, body)
             : createGeoApp({
@@ -103,8 +112,9 @@ const SaveAPI = {
                 ...body
             });
     },
-    [ResourceTypes.DASHBOARD]: (state, id, body) => {
+    [ResourceTypes.DASHBOARD]: (state, id, _body) => {
         const user = userSelector(state);
+        const body = { ...withExtent(_body) };
         return id
             ? updateGeoApp(id, body)
             : createGeoApp({
@@ -114,7 +124,8 @@ const SaveAPI = {
                 ...body
             });
     },
-    [ResourceTypes.DOCUMENT]: (state, id, body) => {
+    [ResourceTypes.DOCUMENT]: (state, id, _body) => {
+        const body = { ...withExtent(_body) };
         return id ? updateDocument(id, body) : false;
     },
     [ResourceTypes.DATASET]: (state, id, body) => {

--- a/geonode_mapstore_client/client/js/utils/CoordinatesUtils.js
+++ b/geonode_mapstore_client/client/js/utils/CoordinatesUtils.js
@@ -9,6 +9,7 @@
 
 import isNil from 'lodash/isNil';
 import join from 'lodash/join';
+import isEmpty from 'lodash/isEmpty';
 import { reprojectBbox, getViewportGeometry } from '@mapstore/framework/utils/CoordinatesUtils';
 import turfBbox from '@turf/bbox';
 
@@ -101,24 +102,20 @@ export const boundsToExtentString = (bounds, fromCrs) => {
     return join(reprojectedExtents.map(ext => join(ext.map((val) => val.toFixed(4)), ',')), ',');
 };
 
-
-export function bboxToPolygon(bbox, crs) {
+export function bboxToExtent(bbox, crs) {
+    if (isEmpty(bbox)) {
+        return {};
+    }
     const { minx, miny, maxx, maxy } = bbox.bounds;
     const extent = [minx, miny, maxx, maxy];
-    const llExtent = bbox.crs === crs
+    const _extent = bbox.crs === crs
         ? extent
         : reprojectBbox(extent, bbox.crs, crs);
-    const [minxLL, minyLL, maxxLL, maxyLL] = llExtent;
     return {
-        type: 'Polygon',
-        // coordinates direction counter-clockwise
-        coordinates: [[
-            [minxLL, minyLL],
-            [maxxLL, minyLL],
-            [maxxLL, maxyLL],
-            [minxLL, maxyLL],
-            [minxLL, minyLL]
-        ]]
+        bbox: {
+            srid: crs,
+            coords: _extent
+        }
     };
 }
 

--- a/geonode_mapstore_client/client/js/utils/__tests__/CoordinatesUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/CoordinatesUtils-test.js
@@ -19,7 +19,7 @@ describe('Test Coordinates Utils', () => {
             bounds: {minx: -10, miny: -10, maxx: 10, maxy: 10},
             crs: 'EPSG:4326'
         };
-        const bbox = bboxToExtent(_bbox, 'EPSG:4326');
+        const {bbox} = bboxToExtent(_bbox, 'EPSG:4326');
         const {coords, srid} = bbox;
         expect(srid).toBe('EPSG:4326');
         expect(coords).toEqual([-10, -10, 10, 10]);

--- a/geonode_mapstore_client/client/js/utils/__tests__/CoordinatesUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/CoordinatesUtils-test.js
@@ -9,25 +9,20 @@
 
 import expect from 'expect';
 import {
-    bboxToPolygon,
+    bboxToExtent,
     getExtent
 } from '../CoordinatesUtils';
 
 describe('Test Coordinates Utils', () => {
     it('should keep the wms params from the url if available', () => {
-        const bbox = {
+        const _bbox = {
             bounds: {minx: -10, miny: -10, maxx: 10, maxy: 10},
             crs: 'EPSG:4326'
         };
-        const polygon = bboxToPolygon(bbox, 'EPSG:4326');
-        expect(polygon.type).toBe('Polygon');
-        expect(polygon.coordinates).toEqual([[
-            [-10, -10],
-            [10, -10],
-            [10, 10],
-            [-10, 10],
-            [-10, -10]
-        ]]);
+        const bbox = bboxToExtent(_bbox, 'EPSG:4326');
+        const {coords, srid} = bbox;
+        expect(srid).toBe('EPSG:4326');
+        expect(coords).toEqual([-10, -10, 10, 10]);
     });
 
     it('should get extent from Bbox', () => {

--- a/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
@@ -27,7 +27,8 @@ import {
     getResourceTypesInfo,
     ResourceTypes,
     FEATURE_INFO_FORMAT,
-    isDocumentExternalSource
+    isDocumentExternalSource,
+    extentConfig
 } from '../ResourceUtils';
 
 describe('Test Resource Utils', () => {
@@ -170,9 +171,6 @@ describe('Test Resource Utils', () => {
         };
         const geoNodeMapConfig = toGeoNodeMapConfig(data, mapState);
         expect(geoNodeMapConfig.maplayers.length).toBe(1);
-        expect(geoNodeMapConfig.srid).toBe('EPSG:3857');
-        expect(geoNodeMapConfig.bbox_polygon).toBeTruthy();
-        expect(geoNodeMapConfig.ll_bbox_polygon).toBeTruthy();
     });
     it('should be able to compare background layers with different ids', () => {
         expect(compareBackgroundLayers({ type: 'osm', source: 'osm', id: '11' }, { type: 'osm', source: 'osm' })).toBe(true);
@@ -987,5 +985,21 @@ describe('Test Resource Utils', () => {
         // NOT DOCUMENT
         resource = {...resource, resource_type: "dataset"};
         expect(isDocumentExternalSource(resource)).toBeFalsy();
+    });
+    it('extentConfig', () => {
+        const data = {
+            map: {
+                bbox: {
+                    bounds: {minx: -10, miny: -10, maxx: 10, maxy: 10},
+                    crs: "EPSG:4326"
+                },
+                projection: "EPSG:4326"
+            }
+        };
+        const extentConf = extentConfig(data);
+        expect(extentConf).toBeTruthy();
+        expect(extentConf.bbox).toBeTruthy();
+        expect(extentConf.bbox.coords).toEqual([-10, -10, 10, 10]);
+        expect(extentConf.bbox.srid).toBe("EPSG:4326");
     });
 });


### PR DESCRIPTION
### Description
This PR removes remove any reference to `ll_bbox_polygon` and `bbox_polygon` and updates the client to use `extent` for read and `bbox` to write

### Issue
- #1562 