### PR TITLE
#1539: Spatial extent visualization and management

### DIFF
--- a/geonode_mapstore_client/client/js/actions/gnresource.js
+++ b/geonode_mapstore_client/client/js/actions/gnresource.js
@@ -34,6 +34,7 @@ export const ENABLE_MAP_THUMBNAIL_VIEWER = 'GEONODE_ENABLE_MAP_THUMBNAIL_VIEWER'
 export const DOWNLOAD_RESOURCE = 'GEONODE_DOWNLOAD_RESOURCE';
 export const DOWNLOAD_COMPLETE = 'GEONODE_DOWNLOAD_COMPLETE';
 export const UPDATE_SINGLE_RESOURCE = 'GEONODE_UPDATE_SINGLE_RESOURCE';
+export const SET_RESOURCE_EXTENT = 'GEONODE_SET_RESOURCE_EXTENT';
 
 
 /**
@@ -309,5 +310,12 @@ export function downloadComplete(resource) {
     return {
         type: DOWNLOAD_COMPLETE,
         resource
+    };
+}
+
+export function setResourceExtent(coords) {
+    return {
+        type: SET_RESOURCE_EXTENT,
+        coords
     };
 }

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx
@@ -15,6 +15,7 @@ import Tabs from '@js/components/Tabs';
 import DetailsAttributeTable from '@js/components/DetailsPanel/DetailsAttributeTable';
 import DetailsLinkedResources from '@js/components/DetailsPanel/DetailsLinkedResources';
 import Message from '@mapstore/framework/components/I18N/Message';
+import DetailsLocations from '@js/components/DetailsPanel/DetailsLocations';
 
 const replaceTemplateString = (properties, str) => {
     return Object.keys(properties).reduce((updatedStr, key) => {
@@ -144,6 +145,7 @@ function DetailsInfoFields({ fields, formatHref }) {
 const tabTypes = {
     'attribute-table': DetailsAttributeTable,
     'linked-resources': DetailsLinkedResources,
+    'locations': DetailsLocations,
     'tab': DetailsInfoFields
 };
 
@@ -156,8 +158,7 @@ const isDefaultTabType = (type) => type === 'tab';
 
 function DetailsInfo({
     tabs = [],
-    formatHref,
-    resourceTypesInfo
+    ...props
 }) {
     const filteredTabs = tabs
         .filter((tab) => !tab?.disableIf)
@@ -167,20 +168,19 @@ function DetailsInfo({
                 items: isDefaultTabType(tab.type) ? parseTabItems(tab?.items) : tab?.items,
                 Component: tabTypes[tab.type] || tabTypes.tab
             }))
-        .filter(tab => tab?.items?.length > 0);
+        .filter(tab => !isEmpty(tab?.items));
     const selectedTabId = filteredTabs?.[0]?.id;
+    const [select, onSelect] = useState(selectedTabId);
     return (
         <Tabs
             className="gn-details-info tabs-underline"
             selectedTabId={selectedTabId}
+            activeKey={select}
+            onSelect={onSelect}
             tabs={filteredTabs.map(({Component, ...tab} = {}) => ({
                 title: <DetailInfoFieldLabel field={tab} />,
                 eventKey: tab?.id,
-                component: <Component
-                    fields={tab?.items}
-                    formatHref={formatHref}
-                    resourceTypesInfo={resourceTypesInfo} />
-
+                component: <Component fields={tab?.items} {...props} />
             }))}
         />
     );

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx
@@ -169,13 +169,11 @@ function DetailsInfo({
                 Component: tabTypes[tab.type] || tabTypes.tab
             }))
         .filter(tab => !isEmpty(tab?.items));
-    const selectedTabId = filteredTabs?.[0]?.id;
-    const [select, onSelect] = useState(selectedTabId);
+    const [selectedTabId, onSelect] = useState(filteredTabs?.[0]?.id);
     return (
         <Tabs
             className="gn-details-info tabs-underline"
             selectedTabId={selectedTabId}
-            activeKey={select}
             onSelect={onSelect}
             tabs={filteredTabs.map(({Component, ...tab} = {}) => ({
                 title: <DetailInfoFieldLabel field={tab} />,

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsLocations.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsLocations.jsx
@@ -5,7 +5,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 import { connect } from 'react-redux';
 import turfCenter from "@turf/center";
 import isEmpty from "lodash/isEmpty";
@@ -98,17 +98,13 @@ const BoundingBoxAndCenter = ({extent, center, expand}) => {
     );
 };
 
-const DetailsLocations = ({ onSetExtent, fields: bbox, allowEdit} = {}) => {
-    const oldExent = useRef();
-    const {coords: extent} = {} = bbox || {};
-
-    useEffect(() => {
-        oldExent.current = extent;
-    }, []);
+const DetailsLocations = ({ onSetExtent, fields, allowEdit} = {}) => {
+    const extent = get(fields, 'extent.coords');
+    const initialExtent = get(fields, 'initialExtent.coords');
 
     const polygon = !isEmpty(extent) ? getPolygonFromExtent(extent) : null;
     const center = !isEmpty(extent) && polygon ? turfCenter(polygon) : null;
-    const isDrawn = !isEqual(isEmpty(oldExent.current) ? extent : oldExent.current, extent);
+    const isDrawn = !isEqual(initialExtent, extent);
 
     return (
         <div className="gn-viewer-extent-map">

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsLocations.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsLocations.jsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React, { useState, useEffect, useRef } from "react";
+import { connect } from 'react-redux';
+import turfCenter from "@turf/center";
+import isEmpty from "lodash/isEmpty";
+import isEqual from "lodash/isEqual";
+import get from "lodash/get";
+import wk from 'wellknown';
+
+
+import BaseMap from "@mapstore/framework/components/map/BaseMap";
+import mapTypeHOC from "@mapstore/framework/components/map/enhancers/mapType";
+import ZoomTo from "@js/components/ZoomTo/ZoomTo";
+import { getPolygonFromExtent, bboxToFeatureGeometry } from "@mapstore/framework/utils/CoordinatesUtils";
+import DrawSupport from "@js/components/DrawExtent";
+import { Message } from "@mapstore/framework/components/I18N/I18N";
+import tooltip from "@mapstore/framework/components/misc/enhancers/tooltip";
+import CopyToClipboardCmp from 'react-copy-to-clipboard';
+import Button from "@mapstore/framework/components/misc/Button";
+import FaIcon from "@js/components/FaIcon/FaIcon";
+import { setResourceExtent } from "@js/actions/gnresource";
+
+const Map = mapTypeHOC(BaseMap);
+Map.displayName = "Map";
+const CopyToClipboard = tooltip(CopyToClipboardCmp);
+
+const BoundingBoxAndCenter = ({extent, center, expand}) => {
+    const [minx, miny, maxx, maxy] = extent || [];
+    const [copied, setCopied] = useState(false);
+    useEffect(() => {
+        if (copied) {
+            setTimeout(() => {
+                setCopied(false);
+            }, 1000);
+        }
+    }, [copied]);
+    return (
+        <div className={`gn-location-info ${expand ? 'fullWidth' : ''}`}>
+            <div className="bounds">
+                <div className="title">
+                    <Message msgId={"gnviewer.boundingBox"}/>
+                    <CopyToClipboard
+                        text={!isEmpty(extent) && wk.stringify(bboxToFeatureGeometry(extent))}
+                    >
+                        <Button
+                            variant="default"
+                            onClick={()=> setCopied(true)}>
+                            <FaIcon name="copy" />
+                        </Button>
+                    </CopyToClipboard>
+                </div>
+                <div className="bounds-row">
+                    <Message msgId="gnviewer.minLat"/>
+                    {miny?.toFixed(6)}
+                </div>
+                <div className="bounds-row">
+                    <Message msgId="gnviewer.minLon"/>
+                    {minx?.toFixed(6)}
+                </div>
+                <div className="bounds-row">
+                    <Message msgId="gnviewer.maxLat"/>
+                    {maxy?.toFixed(6)}
+                </div>
+                <div className="bounds-row">
+                    <Message msgId="gnviewer.maxLon"/>
+                    {maxx?.toFixed(6)}
+                </div>
+            </div>
+            <div className="center">
+                <div className="title">
+                    <Message msgId={"gnviewer.center"}/>
+                    <CopyToClipboard
+                        text={!isEmpty(center) && wk.stringify(center)}
+                    >
+                        <Button
+                            variant="default"
+                            onClick={()=> setCopied(true)}>
+                            <FaIcon name="copy" />
+                        </Button>
+                    </CopyToClipboard>
+                </div>
+                <div className="center-row">
+                    <Message msgId="gnviewer.centerLat"/>
+                    {get(center, 'geometry.coordinates.[1]')?.toFixed(6)}
+                </div>
+                <div className="center-row">
+                    <Message msgId="gnviewer.centerLon"/>
+                    {get(center, 'geometry.coordinates.[0]')?.toFixed(6)}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const DetailsLocations = ({ onSetExtent, fields: bbox, allowEdit} = {}) => {
+    const oldExent = useRef();
+    const {coords: extent} = {} = bbox || {};
+
+    useEffect(() => {
+        oldExent.current = extent;
+    }, []);
+
+    const polygon = !isEmpty(extent) ? getPolygonFromExtent(extent) : null;
+    const center = !isEmpty(extent) && polygon ? turfCenter(polygon) : null;
+    const isDrawn = !isEqual(isEmpty(oldExent.current) ? extent : oldExent.current, extent);
+
+    return (
+        <div className="gn-viewer-extent-map">
+            <BoundingBoxAndCenter center={center} extent={extent} expand={!allowEdit}/>
+            {allowEdit && <Map
+                id="gn-locations-map"
+                mapType={"openlayers"}
+                map={{
+                    registerHooks: false,
+                    projection: "EPSG:4326"
+                }}
+                styleMap={{
+                    width: "100%",
+                    height: "100%"
+                }}
+                layers={[
+                    {
+                        type: 'osm',
+                        title: 'Open Street Map',
+                        name: 'mapnik',
+                        source: 'osm',
+                        group: 'background',
+                        visibility: true
+                    },
+                    ...(!isEmpty(extent)
+                        ? [
+                            {
+                                id: "extent-location",
+                                type: "vector",
+                                features: [
+                                    {
+                                        ...polygon,
+                                        style: {
+                                            color: isDrawn ? "#ffaa01" : "#397AAB",
+                                            opacity: 0.8,
+                                            fillColor: isDrawn
+                                                ? "rgba(255, 170, 1, 0.1)"
+                                                : "#397AAB",
+                                            fillOpacity: 0.2,
+                                            weight: 2
+                                        }
+                                    },
+                                    {
+                                        ...center,
+                                        style: {
+                                            iconGlyph: "sort-desc",
+                                            iconShape: "circle",
+                                            iconColor: isDrawn ? "yellow" : "blue"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                        : [])
+                ]}
+            >
+                <ZoomTo extent={extent?.join(",")} />
+                <DrawSupport onSetExtent={onSetExtent}/>
+            </Map>
+            }
+        </div>
+    );
+};
+
+const ConnectedDetailsLocations = connect(
+    null,
+    {
+        onSetExtent: setResourceExtent
+    }
+)(DetailsLocations);
+
+export default ConnectedDetailsLocations;

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -188,7 +188,8 @@ function DetailsPanel({
     onClose,
     tabs,
     pathname,
-    toolbarItems
+    toolbarItems,
+    onSetExtent
 }) {
     const detailsContainerNode = useRef();
     const [titleNodeRef, titleInView] = useInView();
@@ -290,7 +291,7 @@ function DetailsPanel({
                             : null}
                     </div>
                 </div>
-                <DetailsInfo tabs={tabs} formatHref={formatHref} allowEdit={activeEditMode} resourceTypesInfo={types}/>
+                <DetailsInfo tabs={tabs} formatHref={formatHref} allowEdit={activeEditMode} resourceTypesInfo={types} resource={resource} onSetExtent={onSetExtent}/>
             </section>
         </div>
     );

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -290,7 +290,7 @@ function DetailsPanel({
                             : null}
                     </div>
                 </div>
-                <DetailsInfo tabs={tabs} formatHref={formatHref} resourceTypesInfo={types}/>
+                <DetailsInfo tabs={tabs} formatHref={formatHref} allowEdit={activeEditMode} resourceTypesInfo={types}/>
             </section>
         </div>
     );

--- a/geonode_mapstore_client/client/js/components/DrawExtent/DrawExtent.jsx
+++ b/geonode_mapstore_client/client/js/components/DrawExtent/DrawExtent.jsx
@@ -9,7 +9,7 @@ import { useEffect } from 'react';
 import VectorSource from "ol/source/Vector";
 import Draw, { createBox } from "ol/interaction/Draw";
 import PropTypes from 'prop-types';
-import { Fill, Stroke, Style } from "ol/style";
+import { Fill, Stroke, Style, Circle } from "ol/style";
 
 const drawInteraction = new Draw({
     source: new VectorSource({wrapX: false}),
@@ -22,6 +22,16 @@ const drawInteraction = new Draw({
         stroke: new Stroke({
             color: "#ffaa01",
             width: 2
+        }),
+        image: new Circle({
+            stroke: new Stroke({
+                color: "#ffaa01",
+                width: 2
+            }),
+            fill: new Fill({
+                color: "rgba(255, 170, 1, 0.1)"
+            }),
+            radius: 5
         })
     })
 });

--- a/geonode_mapstore_client/client/js/components/DrawExtent/DrawExtent.jsx
+++ b/geonode_mapstore_client/client/js/components/DrawExtent/DrawExtent.jsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { useEffect } from 'react';
+import VectorSource from "ol/source/Vector";
+import Draw, { createBox } from "ol/interaction/Draw";
+import PropTypes from 'prop-types';
+import { Fill, Stroke, Style } from "ol/style";
+
+const drawInteraction = new Draw({
+    source: new VectorSource({wrapX: false}),
+    type: 'Circle',
+    geometryFunction: createBox(),
+    style: new Style({
+        fill: new Fill({
+            color: "rgba(255, 170, 1, 0.1)"
+        }),
+        stroke: new Stroke({
+            color: "#ffaa01",
+            width: 2
+        })
+    })
+});
+
+const DrawExtext = ({map, onSetExtent} = {}) => {
+    useEffect(() => {
+        let draw;
+        if (map) {
+            draw = drawInteraction;
+            draw.on('drawend', (evt) => {
+                const feature = evt.feature.clone();
+                const geometry = feature.getGeometry();
+                if (geometry.getCoordinates) {
+                    const extent = geometry.getExtent();
+                    onSetExtent(extent);
+                }
+            });
+            map.addInteraction(draw);
+        }
+        return () => {
+            map.removeInteraction(draw);
+        };
+    }, []);
+    return null;
+};
+
+DrawExtext.propTypes = {
+    map: PropTypes.object,
+    onSetExtent: PropTypes.func
+};
+
+DrawExtext.defaultProps = {
+    onSetExtent: () => {}
+};
+
+export default DrawExtext;

--- a/geonode_mapstore_client/client/js/components/DrawExtent/index.js
+++ b/geonode_mapstore_client/client/js/components/DrawExtent/index.js
@@ -1,0 +1,1 @@
+export { default } from './DrawExtent';

--- a/geonode_mapstore_client/client/js/components/Tabs/Tabs.jsx
+++ b/geonode_mapstore_client/client/js/components/Tabs/Tabs.jsx
@@ -16,12 +16,11 @@ const Tabs = ({
     identifier,
     selectedTabId,
     onSelect,
-    activeKey,
     className
 }) => {
     const [eventKeys, setEventKeys] = useLocalStorage('tabSelected', {});
     const persistSelection = isNil(selectedTabId);
-    const selectedKey = activeKey || (!persistSelection ? selectedTabId : (eventKeys[identifier] ?? 0));
+    const selectedKey = !persistSelection ? selectedTabId : (eventKeys[identifier] ?? 0);
 
     const onSelectTab = (key) => {
         const updatedEventKeys = {
@@ -34,8 +33,13 @@ const Tabs = ({
         <RTabs
             bsStyle="pills"
             className={className}
+            animation={false}
             key={identifier}
-            {...onSelect ? {activeKey} : {defaultActiveKey: selectedKey}}
+            {...!persistSelection ? {
+                activeKey: selectedTabId
+            } : {
+                defaultActiveKey: !persistSelection ? selectedTabId : eventKeys[identifier] ?? 0
+            }}
             onSelect={onSelect ? onSelect : onSelectTab}
         >
             {tabs.map((tab, index)=> {

--- a/geonode_mapstore_client/client/js/components/Tabs/Tabs.jsx
+++ b/geonode_mapstore_client/client/js/components/Tabs/Tabs.jsx
@@ -16,11 +16,12 @@ const Tabs = ({
     identifier,
     selectedTabId,
     onSelect,
+    activeKey,
     className
 }) => {
     const [eventKeys, setEventKeys] = useLocalStorage('tabSelected', {});
     const persistSelection = isNil(selectedTabId);
-    const selectedKey = !persistSelection ? selectedTabId : (eventKeys[identifier] ?? 0);
+    const selectedKey = activeKey || (!persistSelection ? selectedTabId : (eventKeys[identifier] ?? 0));
 
     const onSelectTab = (key) => {
         const updatedEventKeys = {
@@ -34,7 +35,7 @@ const Tabs = ({
             bsStyle="pills"
             className={className}
             key={identifier}
-            defaultActiveKey={selectedKey}
+            {...onSelect ? {activeKey} : {defaultActiveKey: selectedKey}}
             onSelect={onSelect ? onSelect : onSelectTab}
         >
             {tabs.map((tab, index)=> {

--- a/geonode_mapstore_client/client/js/components/ZoomTo/ZoomTo.jsx
+++ b/geonode_mapstore_client/client/js/components/ZoomTo/ZoomTo.jsx
@@ -32,11 +32,20 @@ const ZoomTo = ({
             } else {
                 bounds = aBounds;
             }
-            map.getView().fit(bounds, {
-                size: map.getSize(),
-                duration: 300,
-                nearest: true
-            });
+            // ensure when map is contained in tab and
+            // container needs update followed by zoom to extent
+            setTimeout(()=> {
+                map.updateSize();
+            }, 200);
+
+            setTimeout(()=> {
+                map.getView().fit(bounds, {
+                    size: map.getSize(),
+                    duration: 300,
+                    nearest: true
+                });
+            }, 300);
+
             // ensure to avoid other fit action by setting once to true
             once.current = true;
         }

--- a/geonode_mapstore_client/client/js/components/ZoomTo/ZoomTo.jsx
+++ b/geonode_mapstore_client/client/js/components/ZoomTo/ZoomTo.jsx
@@ -11,7 +11,8 @@ import { reprojectBbox } from '@mapstore/framework/utils/CoordinatesUtils';
 
 const ZoomTo = ({
     map,
-    extent
+    extent,
+    nearest = true
 }) => {
     const once = useRef();
     useEffect(() => {
@@ -32,20 +33,11 @@ const ZoomTo = ({
             } else {
                 bounds = aBounds;
             }
-            // ensure when map is contained in tab and
-            // container needs update followed by zoom to extent
-            setTimeout(()=> {
-                map.updateSize();
-            }, 200);
-
-            setTimeout(()=> {
-                map.getView().fit(bounds, {
-                    size: map.getSize(),
-                    duration: 300,
-                    nearest: true
-                });
-            }, 300);
-
+            map.getView().fit(bounds, {
+                size: map.getSize(),
+                duration: 300,
+                nearest
+            });
             // ensure to avoid other fit action by setting once to true
             once.current = true;
         }

--- a/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
+++ b/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
@@ -20,7 +20,8 @@ import {
     setFavoriteResource,
     setMapThumbnail,
     setResourceThumbnail,
-    enableMapThumbnailViewer
+    enableMapThumbnailViewer,
+    setResourceExtent
 } from '@js/actions/gnresource';
 import { processingDownload } from '@js/selectors/resourceservice';
 import FaIcon from '@js/components/FaIcon/FaIcon';
@@ -76,7 +77,8 @@ const ConnectedDetailsPanel = connect(
         onFavorite: setFavoriteResource,
         onMapThumbnail: setMapThumbnail,
         onResourceThumbnail: setResourceThumbnail,
-        onClose: enableMapThumbnailViewer
+        onClose: enableMapThumbnailViewer,
+        onSetExtent: setResourceExtent
     }
 )(DetailsPanel);
 

--- a/geonode_mapstore_client/client/js/reducers/gnresource.js
+++ b/geonode_mapstore_client/client/js/reducers/gnresource.js
@@ -29,7 +29,8 @@ import {
     SET_RESOURCE_COMPACT_PERMISSIONS,
     UPDATE_RESOURCE_COMPACT_PERMISSIONS,
     RESET_GEO_LIMITS,
-    ENABLE_MAP_THUMBNAIL_VIEWER
+    ENABLE_MAP_THUMBNAIL_VIEWER,
+    SET_RESOURCE_EXTENT
 } from '@js/actions/gnresource';
 import {
     cleanCompactPermissions,
@@ -214,6 +215,17 @@ function gnresource(state = defaultState, action) {
             };
         }
         return state;
+    case SET_RESOURCE_EXTENT:
+        return {
+            ...state,
+            data: {
+                ...state.data,
+                extent: {
+                    ...state.data?.extent,
+                    coords: action.coords
+                }
+            }
+        };
     default:
         return state;
     }

--- a/geonode_mapstore_client/client/js/selectors/resource.js
+++ b/geonode_mapstore_client/client/js/selectors/resource.js
@@ -122,6 +122,10 @@ export const getSelectedLayerPermissions = (state) => {
     return selectedLayerPermissions;
 };
 
+export const getResourceExtent = (state) => {
+    return state?.gnresource?.data?.extent || {};
+};
+
 export const getDataPayload = (state, resourceType) => {
     const type = resourceType || state?.gnresource?.type;
     switch (type) {
@@ -138,6 +142,14 @@ export const getDataPayload = (state, resourceType) => {
     default:
         return null;
     }
+};
+
+export const getExtentPayload = (state, resourceType) => {
+    const type = resourceType || state?.gnresource?.type;
+    if (![ResourceTypes.DATASET, ResourceTypes.MAP].includes(type)) {
+        return getResourceExtent(state);
+    }
+    return null;
 };
 
 function removeProperty(value, paths) {
@@ -233,7 +245,7 @@ export const getResourceDirtyState = (state) => {
         return null;
     }
     const resourceType = state?.gnresource?.type;
-    const metadataKeys = ['title', 'abstract', 'data'];
+    const metadataKeys = ['title', 'abstract', 'data', 'extent'];
     const { data: initialData = {}, ...resource } = pick(state?.gnresource?.initialResource || {}, metadataKeys);
     const { compactPermissions, geoLimits } = getPermissionsPayload(state);
     const currentData = JSON.parse(JSON.stringify(getDataPayload(state) || {})); // JSON stringify is needed to remove undefined values

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -12,7 +12,6 @@ import isEmpty from 'lodash/isEmpty';
 import { getConfigProp, convertFromLegacy, normalizeConfig } from '@mapstore/framework/utils/ConfigUtils';
 import { parseDevHostname } from '@js/utils/APIUtils';
 import { ProcessTypes, ProcessStatus } from '@js/utils/ResourceServiceUtils';
-import { bboxToExtent } from '@js/utils/CoordinatesUtils';
 import { uniqBy, orderBy, isString, isObject, pick, difference } from 'lodash';
 import { excludeGoogleBackground, extractTileMatrixFromSources } from '@mapstore/framework/utils/LayersUtils';
 import { determineResourceType } from '@js/utils/FileUtils';
@@ -432,15 +431,6 @@ export function toGeoNodeMapConfig(data) {
     return {
         maplayers
     };
-}
-
-export function extentConfig(data) {
-    if (!data) {
-        return {};
-    }
-    const { bbox: _bbox, projection } = data?.map ?? {};
-    const bbox = bboxToExtent(_bbox, projection);
-    return { ...bbox };
 }
 
 export function compareBackgroundLayers(aLayer, bLayer) {

--- a/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
@@ -27,8 +27,7 @@ import {
     getResourceTypesInfo,
     ResourceTypes,
     FEATURE_INFO_FORMAT,
-    isDocumentExternalSource,
-    extentConfig
+    isDocumentExternalSource
 } from '../ResourceUtils';
 
 describe('Test Resource Utils', () => {
@@ -985,21 +984,5 @@ describe('Test Resource Utils', () => {
         // NOT DOCUMENT
         resource = {...resource, resource_type: "dataset"};
         expect(isDocumentExternalSource(resource)).toBeFalsy();
-    });
-    it('extentConfig', () => {
-        const data = {
-            map: {
-                bbox: {
-                    bounds: {minx: -10, miny: -10, maxx: 10, maxy: 10},
-                    crs: "EPSG:4326"
-                },
-                projection: "EPSG:4326"
-            }
-        };
-        const extentConf = extentConfig(data);
-        expect(extentConf).toBeTruthy();
-        expect(extentConf.bbox).toBeTruthy();
-        expect(extentConf.bbox.coords).toEqual([-10, -10, 10, 10]);
-        expect(extentConf.bbox.srid).toBe("EPSG:4326");
     });
 });

--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -51,7 +51,10 @@
                     .border-bottom-color-var(@theme-vars[main-border-color]);
                 }
             }
-            
+            #gn-locations-map,
+            #gn-locations-map .ol-viewport {
+                .background-color-var(@theme-vars[main-variant-bg]);
+            }
         }
     }
     .card-img-placeholder {
@@ -157,11 +160,10 @@
         height: 300px;
         position: relative;
         display: flex;
+        width: 100%;
         .gn-location-info {
-            width: 500px;
-            &.fullWidth {
-                width: 100%;
-            }
+            font-size: @font-size-small;
+            width: 250px;
             padding-right: 10px;
             .title, .bounds-row, .center-row {
                 display: flex;
@@ -169,7 +171,7 @@
             }
             .title {
                 align-items: center;
-                font-weight: 600;
+                font-weight: lighter;
             }
             .bounds {
                 padding-bottom: 4px;

--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -45,6 +45,14 @@
         .gn-resource-permissions-missing{
             .color-var(@theme-vars[danger]);
         }
+        .gn-viewer-extent-map { 
+            .gn-location-info {
+                .bounds-row, .center-row {
+                    .border-bottom-color-var(@theme-vars[main-border-color]);
+                }
+            }
+            
+        }
     }
     .card-img-placeholder {
         .background-color-var(@theme-vars[main-bg]);
@@ -143,6 +151,42 @@
         &:last-of-type:not(.imagepreview):not(h1):not(h2):not(h3):not(h4):not(h5):not(h6) {
             padding-top: 0.3rem;
             font-size: 0.9rem;
+        }
+    }
+    .gn-viewer-extent-map {
+        height: 300px;
+        position: relative;
+        display: flex;
+        .gn-location-info {
+            width: 500px;
+            &.fullWidth {
+                width: 100%;
+            }
+            padding-right: 10px;
+            .title, .bounds-row, .center-row {
+                display: flex;
+                justify-content: space-between;
+            }
+            .title {
+                align-items: center;
+                font-weight: 600;
+            }
+            .bounds {
+                padding-bottom: 4px;
+            }
+            .center {
+                &.title {
+                    padding-top: 5px;
+                }
+            }
+            .bounds-row:last-child, .center-row:last-child {
+                border-bottom: none;
+            }
+            .bounds-row, .center-row {
+                padding: 4px 0;
+                border-bottom-width: 1px;
+                border-bottom-style: solid;
+            }
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -785,7 +785,6 @@
                         {
                             "type": "locations",
                             "id": "locations",
-                            "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
                             "labelId": "gnviewer.locations",
                             "items": "{({extent: context.get(state('gnResourceData'), 'extent')})}"
                         },
@@ -1669,7 +1668,6 @@
                             "type": "locations",
                             "id": "locations",
                             "labelId": "gnviewer.locations",
-                            "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
                             "items": "{({extent: context.get(state('gnResourceData'), 'extent')})}"
                         },
                         {
@@ -2324,7 +2322,6 @@
                             "type": "locations",
                             "id": "locations",
                             "labelId": "gnviewer.locations",
-                            "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
                             "items": "{({extent: context.get(state('gnResourceData'), 'extent'), initialExtent: context.get(state('gnResourceInitialData'), 'extent')})}"
                         },
                         {
@@ -2646,7 +2643,6 @@
                             "type": "locations",
                             "id": "locations",
                             "labelId": "gnviewer.locations",
-                            "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
                             "items": "{({extent: context.get(state('gnResourceData'), 'extent'), initialExtent: context.get(state('gnResourceInitialData'), 'extent')})}"
                         },
                         {
@@ -2886,7 +2882,6 @@
                             "type": "locations",
                             "id": "locations",
                             "labelId": "gnviewer.locations",
-                            "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
                             "items": "{({extent: context.get(state('gnResourceData'), 'extent'), initialExtent: context.get(state('gnResourceInitialData'), 'extent')})}"
                         },
                         {
@@ -3420,7 +3415,6 @@
                             "type": "locations",
                             "id": "locations",
                             "labelId": "gnviewer.locations",
-                            "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
                             "items": "{({extent: context.get(state('gnResourceData'), 'extent')})}"
                         },
                         {

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -779,6 +779,13 @@
                             ]
                         },
                         {
+                            "type": "locations",
+                            "id": "locations",
+                            "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
+                            "labelId": "gnviewer.locations",
+                            "items": "{context.get(state('gnResourceData'), 'extent')}"
+                        },
+                        {
                             "type": "attribute-table",
                             "id": "attributes",
                             "labelId": "gnviewer.attributes",
@@ -1655,6 +1662,13 @@
                             ]
                         },
                         {
+                            "type": "locations",
+                            "id": "locations",
+                            "labelId": "gnviewer.locations",
+                            "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
+                            "items": "{context.get(state('gnResourceData'), 'extent')}"
+                        },
+                        {
                             "type": "linked-resources",
                             "id": "related",
                             "labelId": "gnviewer.linkedResources",
@@ -2303,6 +2317,13 @@
                             ]
                         },
                         {
+                            "type": "locations",
+                            "id": "locations",
+                            "labelId": "gnviewer.locations",
+                            "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
+                            "items": "{context.get(state('gnResourceData'), 'extent')}"
+                        },
+                        {
                             "type": "linked-resources",
                             "id": "related",
                             "labelId": "gnviewer.linkedResources",
@@ -2618,6 +2639,13 @@
                             ]
                         },
                         {
+                            "type": "locations",
+                            "id": "locations",
+                            "labelId": "gnviewer.locations",
+                            "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
+                            "items": "{context.get(state('gnResourceData'), 'extent')}"
+                        },
+                        {
                             "type": "linked-resources",
                             "id": "related",
                             "labelId": "gnviewer.linkedResources",
@@ -2849,6 +2877,13 @@
                                     "disableIf": "{!context.getMetadataDetailUrl(state('gnResourceData'))}"
                                 }
                             ]
+                        },
+                        {
+                            "type": "locations",
+                            "id": "locations",
+                            "labelId": "gnviewer.locations",
+                            "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
+                            "items": "{context.get(state('gnResourceData'), 'extent')}"
                         },
                         {
                             "type": "linked-resources",
@@ -3376,6 +3411,13 @@
                                     "disableIf": "{!context.getMetadataDetailUrl(state('gnResourceData'))}"
                                 }
                             ]
+                        },
+                        {
+                            "type": "locations",
+                            "id": "locations",
+                            "labelId": "gnviewer.locations",
+                            "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
+                            "items": "{context.get(state('gnResourceData'), 'extent')}"
                         },
                         {
                             "type": "attribute-table",

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -65,6 +65,10 @@
             "path": "gnresource.data"
         },
         {
+            "name": "gnResourceInitialData",
+            "path": "gnresource.initialResource"
+        },
+        {
             "name": "isNewResource",
             "path": "gnresource.isNew"
         },
@@ -783,7 +787,7 @@
                             "id": "locations",
                             "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
                             "labelId": "gnviewer.locations",
-                            "items": "{context.get(state('gnResourceData'), 'extent')}"
+                            "items": "{({extent: context.get(state('gnResourceData'), 'extent')})}"
                         },
                         {
                             "type": "attribute-table",
@@ -1666,7 +1670,7 @@
                             "id": "locations",
                             "labelId": "gnviewer.locations",
                             "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
-                            "items": "{context.get(state('gnResourceData'), 'extent')}"
+                            "items": "{({extent: context.get(state('gnResourceData'), 'extent')})}"
                         },
                         {
                             "type": "linked-resources",
@@ -2321,7 +2325,7 @@
                             "id": "locations",
                             "labelId": "gnviewer.locations",
                             "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
-                            "items": "{context.get(state('gnResourceData'), 'extent')}"
+                            "items": "{({extent: context.get(state('gnResourceData'), 'extent'), initialExtent: context.get(state('gnResourceInitialData'), 'extent')})}"
                         },
                         {
                             "type": "linked-resources",
@@ -2643,7 +2647,7 @@
                             "id": "locations",
                             "labelId": "gnviewer.locations",
                             "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
-                            "items": "{context.get(state('gnResourceData'), 'extent')}"
+                            "items": "{({extent: context.get(state('gnResourceData'), 'extent'), initialExtent: context.get(state('gnResourceInitialData'), 'extent')})}"
                         },
                         {
                             "type": "linked-resources",
@@ -2883,7 +2887,7 @@
                             "id": "locations",
                             "labelId": "gnviewer.locations",
                             "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
-                            "items": "{context.get(state('gnResourceData'), 'extent')}"
+                            "items": "{({extent: context.get(state('gnResourceData'), 'extent'), initialExtent: context.get(state('gnResourceInitialData'), 'extent')})}"
                         },
                         {
                             "type": "linked-resources",
@@ -3417,7 +3421,7 @@
                             "id": "locations",
                             "labelId": "gnviewer.locations",
                             "disableIf": "{['dataset', 'map'].includes(context.get(state('gnResourceData'), 'resource_type'))}",
-                            "items": "{context.get(state('gnResourceData'), 'extent')}"
+                            "items": "{({extent: context.get(state('gnResourceData'), 'extent')})}"
                         },
                         {
                             "type": "attribute-table",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -341,7 +341,16 @@
                 "from": "Datum von",
                 "to": "Datum bis"
             },
-            "sourceType": "Quelle"
+            "sourceType": "Quelle",
+            "locations": "Standorte",
+            "boundingBox": "Begrenzungsrahmen (WGS84)",
+            "center": "Center (WGS84)",
+            "minLat": "Min Lat",
+            "minLon": "Min Lon",
+            "maxLat": "Max Lat",
+            "maxLon": "Max Lon",
+            "centerLat": "Center Lat",
+            "centerLon": "Center Lon"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -341,7 +341,16 @@
                 "from": "Date from",
                 "to": "Date to"
             },
-            "sourceType": "Source"
+            "sourceType": "Source",
+            "locations": "Locations",
+            "boundingBox": "Bounding Box (WGS84)",
+            "center": "Center (WGS84)",
+            "minLat": "Min Lat",
+            "minLon": "Min Lon",
+            "maxLat": "Max Lat",
+            "maxLon": "Max Lon",
+            "centerLat": "Center Lat",
+            "centerLon": "Center Lon"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -340,7 +340,16 @@
                 "from": "Fecha desde",
                 "to": "Fecha hasta"
             },
-            "sourceType": "Fuente"
+            "sourceType": "Fuente",
+            "locations": "Ubicaciones",
+            "boundingBox": "Cuadro delimitador (WGS84)",
+            "center": "Centro (WGS84)",
+            "minLat": "Min Lat",
+            "minLon": "Min Lon",
+            "maxLat": "Max Lat",
+            "maxLon": "Max Lon",
+            "centerLat": "Centro Lat",
+            "centerLon": "Centro Lon"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -310,7 +310,16 @@
                 "from": "Date from",
                 "to": "Date to"
             },
-            "sourceType": "Source"
+            "sourceType": "Source",
+            "locations": "Locations",
+            "boundingBox": "Bounding Box (WGS84)",
+            "center": "Center (WGS84)",
+            "minLat": "Min Lat",
+            "minLon": "Min Lon",
+            "maxLat": "Max Lat",
+            "maxLon": "Max Lon",
+            "centerLat": "Center Lat",
+            "centerLon": "Center Lon"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -341,7 +341,16 @@
                 "from": "Date de",
                 "to": "Date à"
             },
-            "sourceType": "Source"
+            "sourceType": "Source",
+            "locations": "Emplacements",
+            "boundingBox": "Boîte englobante (WGS84)",
+            "center": "Centre (WGS84)",
+            "minLat": "Min Lat",
+            "minLon": "Min Lon",
+            "maxLat": "Max Lat",
+            "maxLon": "Max Lon",
+            "centerLat": "Centre Lat",
+            "centerLon": "Centre Lon"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -310,7 +310,16 @@
                 "from": "Date from",
                 "to": "Date to"
             },
-            "sourceType": "Source"
+            "sourceType": "Source",
+            "locations": "Locations",
+            "boundingBox": "Bounding Box (WGS84)",
+            "center": "Center (WGS84)",
+            "minLat": "Min Lat",
+            "minLon": "Min Lon",
+            "maxLat": "Max Lat",
+            "maxLon": "Max Lon",
+            "centerLat": "Center Lat",
+            "centerLon": "Center Lon"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -343,7 +343,16 @@
                 "from": "Data da",
                 "to": "Data a"
             },
-            "sourceType": "Fonte"
+            "sourceType": "Fonte",
+            "locations": "Posizioni",
+            "boundingBox": "Rettangolo di selezione (WGS84)",
+            "center": "Centro (WGS84)",
+            "minLat": "Min Lat",
+            "minLon": "Min Lon",
+            "maxLat": "Max Lat",
+            "maxLon": "Max Lon",
+            "centerLat": "Centro Lat",
+            "centerLon": "Centro Lon"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -310,7 +310,16 @@
                 "from": "Date from",
                 "to": "Date to"
             },
-            "sourceType": "Source"
+            "sourceType": "Source",
+            "locations": "Locations",
+            "boundingBox": "Bounding Box (WGS84)",
+            "center": "Center (WGS84)",
+            "minLat": "Min Lat",
+            "minLon": "Min Lon",
+            "maxLat": "Max Lat",
+            "maxLon": "Max Lon",
+            "centerLat": "Center Lat",
+            "centerLon": "Center Lon"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -310,7 +310,16 @@
                 "from": "Date from",
                 "to": "Date to"
             },
-            "sourceType": "Source"
+            "sourceType": "Source",
+            "locations": "Locations",
+            "boundingBox": "Bounding Box (WGS84)",
+            "center": "Center (WGS84)",
+            "minLat": "Min Lat",
+            "minLon": "Min Lon",
+            "maxLat": "Max Lat",
+            "maxLon": "Max Lon",
+            "centerLat": "Center Lat",
+            "centerLon": "Center Lon"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -310,7 +310,16 @@
                 "from": "Date from",
                 "to": "Date to"
             },
-            "sourceType": "Source"
+            "sourceType": "Source",
+            "locations": "Locations",
+            "boundingBox": "Bounding Box (WGS84)",
+            "center": "Center (WGS84)",
+            "minLat": "Min Lat",
+            "minLon": "Min Lon",
+            "maxLat": "Max Lat",
+            "maxLon": "Max Lon",
+            "centerLat": "Center Lat",
+            "centerLon": "Center Lon"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -311,7 +311,16 @@
                 "from": "Date from",
                 "to": "Date to"
             },
-            "sourceType": "Source"
+            "sourceType": "Source",
+            "locations": "Locations",
+            "boundingBox": "Bounding Box (WGS84)",
+            "center": "Center (WGS84)",
+            "minLat": "Min Lat",
+            "minLon": "Min Lon",
+            "maxLat": "Max Lat",
+            "maxLon": "Max Lon",
+            "centerLat": "Center Lat",
+            "centerLon": "Center Lon"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -309,7 +309,16 @@
                 "from": "Date from",
                 "to": "Date to"
             },
-            "sourceType": "Source"
+            "sourceType": "Source",
+            "locations": "Locations",
+            "boundingBox": "Bounding Box (WGS84)",
+            "center": "Center (WGS84)",
+            "minLat": "Min Lat",
+            "minLon": "Min Lon",
+            "maxLat": "Max Lat",
+            "maxLon": "Max Lon",
+            "centerLat": "Center Lat",
+            "centerLon": "Center Lon"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -309,7 +309,16 @@
                 "from": "Date from",
                 "to": "Date to"
             },
-            "sourceType": "Source"
+            "sourceType": "Source",
+            "locations": "Locations",
+            "boundingBox": "Bounding Box (WGS84)",
+            "center": "Center (WGS84)",
+            "minLat": "Min Lat",
+            "minLon": "Min Lon",
+            "maxLat": "Max Lat",
+            "maxLon": "Max Lon",
+            "centerLat": "Center Lat",
+            "centerLon": "Center Lon"
         }
     }
 }


### PR DESCRIPTION
### Description
This PR adds spatial extent visualization and management to details viewer panel

### Issue
- #1539 

### Screenshot 
_Note_: I couldn't match the marker in issue with the ones supported by MS. Kindly let me know if this needs to be modified
**View**
<kbd>
<img width="792" alt="Screenshot 2023-09-28 at 7 44 16 PM" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/a5508039-ef3f-411b-b62a-111db4c4a177">
</kbd>
**Edit**
<kbd>
<img width="796" alt="Screenshot 2023-09-28 at 7 44 24 PM" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/e039be99-d263-437b-9aec-98a2f83e2845">
</kbd>

