### PR TITLE
#1539: Enhance spatial extent management

### DIFF
--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsLocations.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsLocations.jsx
@@ -18,7 +18,7 @@ import mapTypeHOC from "@mapstore/framework/components/map/enhancers/mapType";
 import ZoomTo from "@js/components/ZoomTo/ZoomTo";
 import { getPolygonFromExtent, bboxToFeatureGeometry } from "@mapstore/framework/utils/CoordinatesUtils";
 import DrawSupport from "@js/components/DrawExtent";
-import { Message } from "@mapstore/framework/components/I18N/I18N";
+import Message from "@mapstore/framework/components/I18N/Message";
 import tooltip from "@mapstore/framework/components/misc/enhancers/tooltip";
 import CopyToClipboardCmp from 'react-copy-to-clipboard';
 import Button from "@mapstore/framework/components/misc/Button";
@@ -96,6 +96,31 @@ const BoundingBoxAndCenter = ({extent, center }) => {
     );
 };
 
+const getFeatureStyle = (type, isDrawn) => {
+    if (type === "polygon") {
+        return {
+            color: isDrawn ? "#ffaa01" : "#397AAB",
+            opacity: 0.8,
+            fillColor: isDrawn
+                ? "rgba(255, 170, 1, 0.1)"
+                : "#397AAB",
+            fillOpacity: 0.2,
+            weight: 2
+        };
+    }
+    return {
+        iconAnchor: [0.5, 0.5],
+        anchorXUnits: "fraction",
+        anchorYUnits: "fraction",
+        fillColor: isDrawn ? "#ffaa01" : "#397AAB",
+        opacity: 1,
+        size: 16,
+        fillOpacity: 1,
+        shape: "plus",
+        symbolUrl: '/static/mapstore/symbols/plus.svg'
+    };
+};
+
 const DetailsLocations = ({ onSetExtent, fields, allowEdit: allowEditProp, resource } = {}) => {
     const extent = get(fields, 'extent.coords');
     const initialExtent = get(fields, 'initialExtent.coords');
@@ -109,63 +134,53 @@ const DetailsLocations = ({ onSetExtent, fields, allowEdit: allowEditProp, resou
     return (
         <div className="gn-viewer-extent-map">
             <BoundingBoxAndCenter center={center} extent={extent} />
-            <Map
-                id="gn-locations-map"
-                key={`${resource?.resource_type}:${resource?.pk}`}
-                mapType={"openlayers"}
-                map={{
-                    registerHooks: false,
-                    projection: 'EPSG:4326'
-                }}
-                styleMap={{
-                    position: 'relative',
-                    flex: 1,
-                    height: '100%'
-                }}
-                layers={[
-                    {
-                        type: 'osm',
-                        title: 'Open Street Map',
-                        name: 'mapnik',
-                        source: 'osm',
-                        group: 'background',
-                        visibility: true
-                    },
-                    ...(!isEmpty(extent)
-                        ? [
-                            {
-                                id: "extent-location",
-                                type: "vector",
-                                features: [
-                                    {
-                                        ...polygon,
-                                        style: {
-                                            color: isDrawn ? "#ffaa01" : "#397AAB",
-                                            opacity: 0.8,
-                                            fillColor: isDrawn
-                                                ? "rgba(255, 170, 1, 0.1)"
-                                                : "#397AAB",
-                                            fillOpacity: 0.2,
-                                            weight: 2
+            <div className="map-wrapper">
+                <Map
+                    id="gn-locations-map"
+                    key={`${resource?.resource_type}:${resource?.pk}`}
+                    mapType={"openlayers"}
+                    map={{
+                        registerHooks: false,
+                        projection: "EPSG:3857"
+                    }}
+                    options={{interactive: allowEdit}}
+                    styleMap={{
+                        height: '100%'
+                    }}
+                    layers={[
+                        {
+                            type: 'osm',
+                            title: 'Open Street Map',
+                            name: 'mapnik',
+                            source: 'osm',
+                            group: 'background',
+                            visibility: true
+                        },
+                        ...(!isEmpty(extent)
+                            ? [
+                                {
+                                    id: "extent-location",
+                                    type: "vector",
+                                    features: [
+                                        {
+                                            ...polygon,
+                                            style: getFeatureStyle("polygon", isDrawn)
+                                        },
+                                        {
+                                            ...center,
+                                            style: getFeatureStyle("point", isDrawn)
                                         }
-                                    },
-                                    {
-                                        ...center,
-                                        style: {
-                                            iconGlyph: "sort-desc",
-                                            iconShape: "circle",
-                                            iconColor: isDrawn ? "yellow" : "blue"
-                                        }
-                                    }
-                                ]
-                            }
-                        ]
-                        : [])
-                ]}
-            >
-                <ZoomTo extent={extent?.join(",")} nearest={false} />
-                {allowEdit && <DrawSupport onSetExtent={onSetExtent}/>}
-            </Map>
+                                    ]
+                                }
+                            ]
+                            : [])
+                    ]}
+                >
+                    <ZoomTo extent={extent?.join(",")} nearest={false} />
+                    {allowEdit && <DrawSupport onSetExtent={onSetExtent}/>}
+                </Map>
+                {allowEdit && <Message msgId="gnviewer.mapExtentHelpText"/>}
+            </div>
         </div>
     );
 };

--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -190,6 +190,15 @@
                 border-bottom-style: solid;
             }
         }
+        .map-wrapper {
+            position: relative;
+            flex: 1;
+            height: 100%;
+            > span {
+                font-weight: lighter;
+                font-size: @font-size-small;
+            }
+        }
     }
 }
 

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -350,7 +350,8 @@
             "maxLat": "Max Lat",
             "maxLon": "Max Lon",
             "centerLat": "Center Lat",
-            "centerLon": "Center Lon"
+            "centerLon": "Center Lon",
+            "mapExtentHelpText": "Sie können die Position und Ausdehnung der Ressource bearbeiten, indem Sie (shift) klicken und ziehen, um einen Bereich zu zeichnen, oder indem Sie auf die Markierung klicken und ziehen"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -350,7 +350,8 @@
             "maxLat": "Max Lat",
             "maxLon": "Max Lon",
             "centerLat": "Center Lat",
-            "centerLon": "Center Lon"
+            "centerLon": "Center Lon",
+            "mapExtentHelpText": "You can edit the position and extent of the resource by (shift) clicking and dragging to draw an area, or clicking and dragging the marker"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -349,7 +349,8 @@
             "maxLat": "Max Lat",
             "maxLon": "Max Lon",
             "centerLat": "Centro Lat",
-            "centerLon": "Centro Lon"
+            "centerLon": "Centro Lon",
+            "mapExtentHelpText": "Puede editar la posición y la extensión del recurso haciendo (shift) haciendo clic y arrastrando para dibujar un área, o haciendo clic y arrastrando el marcador"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -319,7 +319,8 @@
             "maxLat": "Max Lat",
             "maxLon": "Max Lon",
             "centerLat": "Center Lat",
-            "centerLon": "Center Lon"
+            "centerLon": "Center Lon",
+            "mapExtentHelpText": "You can edit the position and extent of the resource by (shift) clicking and dragging to draw an area, or clicking and dragging the marker"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -350,7 +350,8 @@
             "maxLat": "Max Lat",
             "maxLon": "Max Lon",
             "centerLat": "Centre Lat",
-            "centerLon": "Centre Lon"
+            "centerLon": "Centre Lon",
+            "mapExtentHelpText": "Vous pouvez modifier la position et l'étendue de la ressource en cliquant (shift) et en faisant glisser pour dessiner une zone, ou en cliquant et en faisant glisser le marqueur"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -319,7 +319,8 @@
             "maxLat": "Max Lat",
             "maxLon": "Max Lon",
             "centerLat": "Center Lat",
-            "centerLon": "Center Lon"
+            "centerLon": "Center Lon",
+            "mapExtentHelpText": "You can edit the position and extent of the resource by (shift) clicking and dragging to draw an area, or clicking and dragging the marker"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -352,7 +352,8 @@
             "maxLat": "Max Lat",
             "maxLon": "Max Lon",
             "centerLat": "Centro Lat",
-            "centerLon": "Centro Lon"
+            "centerLon": "Centro Lon",
+            "mapExtentHelpText": "È possibile modificare la posizione e l'estensione della risorsa facendo clic (shift) e trascinando per disegnare un'area oppure facendo clic e trascinando il contrassegno"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -319,7 +319,8 @@
             "maxLat": "Max Lat",
             "maxLon": "Max Lon",
             "centerLat": "Center Lat",
-            "centerLon": "Center Lon"
+            "centerLon": "Center Lon",
+            "mapExtentHelpText": "You can edit the position and extent of the resource by (shift) clicking and dragging to draw an area, or clicking and dragging the marker"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -319,7 +319,8 @@
             "maxLat": "Max Lat",
             "maxLon": "Max Lon",
             "centerLat": "Center Lat",
-            "centerLon": "Center Lon"
+            "centerLon": "Center Lon",
+            "mapExtentHelpText": "You can edit the position and extent of the resource by (shift) clicking and dragging to draw an area, or clicking and dragging the marker"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -319,7 +319,8 @@
             "maxLat": "Max Lat",
             "maxLon": "Max Lon",
             "centerLat": "Center Lat",
-            "centerLon": "Center Lon"
+            "centerLon": "Center Lon",
+            "mapExtentHelpText": "You can edit the position and extent of the resource by (shift) clicking and dragging to draw an area, or clicking and dragging the marker"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -320,7 +320,8 @@
             "maxLat": "Max Lat",
             "maxLon": "Max Lon",
             "centerLat": "Center Lat",
-            "centerLon": "Center Lon"
+            "centerLon": "Center Lon",
+            "mapExtentHelpText": "You can edit the position and extent of the resource by (shift) clicking and dragging to draw an area, or clicking and dragging the marker"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -318,7 +318,8 @@
             "maxLat": "Max Lat",
             "maxLon": "Max Lon",
             "centerLat": "Center Lat",
-            "centerLon": "Center Lon"
+            "centerLon": "Center Lon",
+            "mapExtentHelpText": "You can edit the position and extent of the resource by (shift) clicking and dragging to draw an area, or clicking and dragging the marker"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -318,7 +318,8 @@
             "maxLat": "Max Lat",
             "maxLon": "Max Lon",
             "centerLat": "Center Lat",
-            "centerLon": "Center Lon"
+            "centerLon": "Center Lon",
+            "mapExtentHelpText": "You can edit the position and extent of the resource by (shift) clicking and dragging to draw an area, or clicking and dragging the marker"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/symbols/plus.svg
+++ b/geonode_mapstore_client/static/mapstore/symbols/plus.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 -240 1200 1200">
+  <g transform="matrix(1 0 0 -1 0 960)">
+   <path
+d="M1070 399h-376v-379q0 -39 -27.5 -65t-66 -26t-66 26t-27.5 65v379h-379q-35 0 -62.5 27t-27.5 66t27.5 64.5t62.5 25.5h379v380q0 38 27.5 64.5t66 26.5t66 -26.5t27.5 -64.5v-380h376q39 0 65 -25.5t26 -64.5t-26 -66t-65 -27z" />
+  </g>
+</svg>

--- a/geonode_mapstore_client/static/mapstore/symbols/symbols.json
+++ b/geonode_mapstore_client/static/mapstore/symbols/symbols.json
@@ -14,5 +14,6 @@
   {"name": "arrow-south-west", "label": "Arrow South West"},
   {"name": "arrow-west", "label": "Arrow West"},
   {"name": "arrow-north-west", "label": "Arrow North West"},
-  {"name": "traffic-cone", "label": "Traffic Cone"}
+  {"name": "traffic-cone", "label": "Traffic Cone"},
+  {"name": "plus", "label": "Plus"}
 ]


### PR DESCRIPTION
### Description
This PR enhances the spatial extent map with draw and translate interactions

- Draw extent by shift + click to dragging
- Click on center marker to move extent on map
- Interactions on map is disabled when resource is not editable
- Label to denote edit mechanism when resource is editable

### Issue
- #1539 

### Screenshot

https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/907dc7ca-fe61-4776-b1b8-8a6d822d138c

