### PR TITLE
#1573: Fix - Map save doesn't preserve zoom when created from a dataset

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -62,7 +62,8 @@ import {
 import {
     setControlProperty,
     resetControls,
-    SET_CONTROL_PROPERTY
+    SET_CONTROL_PROPERTY,
+    setControlProperties
 } from '@mapstore/framework/actions/controls';
 import {
     resourceToLayerConfig,
@@ -219,7 +220,7 @@ const resourceTypes = {
                             }
                             : mapConfig),
                         ...(extent
-                            ? [ setControlProperty('fitBounds', 'geometry', extent) ]
+                            ? [ setControlProperties('fitBounds', 'geometry', extent, "duration", 400) ]
                             : []),
                         setControlProperty('toolbar', 'expanded', false)
                     );

--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -220,6 +220,7 @@ const resourceTypes = {
                             }
                             : mapConfig),
                         ...(extent
+                            // Add duration to allow map config to be properly updated with zoom on fitBounds action
                             ? [ setControlProperties('fitBounds', 'geometry', extent, "duration", 400) ]
                             : []),
                         setControlProperty('toolbar', 'expanded', false)

--- a/geonode_mapstore_client/client/js/plugins/FitBounds.jsx
+++ b/geonode_mapstore_client/client/js/plugins/FitBounds.jsx
@@ -30,15 +30,17 @@ function FitBoundsPlugin({ mapProjection, ...props }) {
         return geometry;
     }
     const geometry = useMemo(() => validateGeometry(props.geometry, mapProjection), [props.geometry, mapProjection]);
-    return <FitBounds active { ...props } geometry={geometry}/>;
+    return <FitBounds active { ...props } duration={props.duration} geometry={geometry}/>;
 }
 
 const ConnectedFitBoundsPlugin = connect(
     createSelector([
         state => state?.controls?.fitBounds?.geometry,
+        state => state?.controls?.fitBounds?.duration,
         projectionSelector
-    ], (geometry, mapProjection) => ({
+    ], (geometry, duration, mapProjection) => ({
         geometry,
+        duration,
         mapProjection
     }))
 )(FitBoundsPlugin);


### PR DESCRIPTION
### Description
This PR fixes the zoom not preserved when saving a map created from a dataset

### Issue
- #1573
