### PR TITLE
#1584: Linked resources refer to new properties

### DIFF
--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -297,7 +297,7 @@ export const getLinkedResourcesByPk = (pk) => {
             'page_size': 99999
         }
     })
-        .then(({ data }) => data.resources ?? []);
+        .then(({ data }) => data ?? {});
 };
 
 export const getResourceByUuid = (uuid) => {

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsLinkedResources.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsLinkedResources.jsx
@@ -40,12 +40,12 @@ const DetailsLinkedResources = ({ fields, resourceTypesInfo }) => {
             type: 'linkedTo'
         },
         {
-            resources: linkedToFields.filter(resource => resource.internal) ?? [],
-            type: 'uses'
-        },
-        {
             resources: linkedByFields?.filter(resource => !resource.internal) ?? [],
             type: 'linkedBy'
+        },
+        {
+            resources: linkedToFields.filter(resource => resource.internal) ?? [],
+            type: 'uses'
         },
         {
             resources: linkedByFields.filter(resource => resource.internal) ?? [],

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsLinkedResources.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsLinkedResources.jsx
@@ -7,27 +7,58 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import isEmpty from 'lodash/isEmpty';
 
 import FaIcon from '@js/components/FaIcon';
+import Message from '@mapstore/framework/components/I18N/Message';
 
-const DetailsLinkedResources = ({
-    fields,
-    resourceTypesInfo
-}) => {
-    return (
-        fields.map((field, key) => {
-            const {icon} = resourceTypesInfo[field.resource_type] ?? {};
-            return (
-                <div key={key} className="gn-details-info-fields">
+const DetailLinkedResource = ({resources, type}) => {
+    return !isEmpty(resources) && (
+        <>
+            <Message msgId={`gnviewer.linkedResources.${type}`} />
+            {resources.map((field, key) => {
+                return (<div key={key} className="gn-details-info-fields">
                     <div className="gn-details-info-row linked-resources">
-                        <FaIcon name={icon}/>
+                        {field.icon && <FaIcon name={field.icon} />}
                         <a key={field.pk} href={field.detail_url}>
                             {field.title}
                         </a>
                     </div>
-                </div>
-            );
-        })
+                </div>);
+            })}
+        </>
+    );
+};
+
+const DetailsLinkedResources = ({ fields, resourceTypesInfo }) => {
+    const linkedToFields = fields?.linkedTo?.map(resource=> ({...resource, icon: resourceTypesInfo[resource.resource_type]?.icon}));
+    const linkedByFields = fields?.linkedBy?.map(resource=> ({...resource, icon: resourceTypesInfo[resource.resource_type]?.icon}));
+
+    const linkedResources = [
+        {
+            resources: linkedToFields?.filter(resource => !resource.internal) ?? [],
+            type: 'linkedTo'
+        },
+        {
+            resources: linkedToFields.filter(resource => resource.internal) ?? [],
+            type: 'uses'
+        },
+        {
+            resources: linkedByFields?.filter(resource => !resource.internal) ?? [],
+            type: 'linkedBy'
+        },
+        {
+            resources: linkedByFields.filter(resource => resource.internal) ?? [],
+            type: 'usedBy'
+        }
+    ];
+
+    return (
+        <div className="linked-resources">
+            {
+                linkedResources.map(({resources, type})=> <DetailLinkedResource resources={resources} type={type}/>)
+            }
+        </div>
     );
 };
 

--- a/geonode_mapstore_client/client/js/epics/__tests__/detailviewer-test.js
+++ b/geonode_mapstore_client/client/js/epics/__tests__/detailviewer-test.js
@@ -42,8 +42,9 @@ describe('gnresource epics', () => {
         const testState = {
             gnresource: {data: {}}
         };
+        const linkedTo = [{pk: 2, title: "Title"}];
         mockAxios.onGet(new RegExp(`resources/${pk}/linked_resources`))
-            .reply(() => [200, { resources: [{pk: 2, title: "Title"}] }]);
+            .reply(() => [200, { linked_to: linkedTo }]);
 
         testEpic(
             gnGetLinkedResources,
@@ -55,6 +56,42 @@ describe('gnresource epics', () => {
                         .toEqual([
                             UPDATE_RESOURCE_PROPERTIES
                         ]);
+                    expect(actions[0].properties.linkedResources)
+                        .toEqual({linkedTo, linkedBy: []});
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            },
+            testState
+        );
+    });
+    it('gnGetLinkedResources on empty resources', (done) => {
+        const NUM_ACTIONS = 1;
+        const pk = 1;
+        const resource = {
+            pk,
+            'title': 'Map',
+            'thumbnail_url': 'thumbnail.jpeg'
+        };
+        const testState = {
+            gnresource: {data: {}}
+        };
+        mockAxios.onGet(new RegExp(`resources/${pk}/linked_resources`))
+            .reply(() => [200, { linked_to: [] }]);
+
+        testEpic(
+            gnGetLinkedResources,
+            NUM_ACTIONS,
+            setResource(resource),
+            (actions) => {
+                try {
+                    expect(actions.map(({ type }) => type))
+                        .toEqual([
+                            UPDATE_RESOURCE_PROPERTIES
+                        ]);
+                    expect(actions[0].properties.linkedResources)
+                        .toEqual({});
                 } catch (e) {
                     done(e);
                 }

--- a/geonode_mapstore_client/client/js/epics/detailviewer.js
+++ b/geonode_mapstore_client/client/js/epics/detailviewer.js
@@ -26,8 +26,12 @@ export const gnGetLinkedResources = (action$, store) =>
         .switchMap((action) =>
             Observable.defer(() =>
                 getLinkedResourcesByPk(action.data.pk)
-                    .then((linkedResources) => linkedResources)
-                    .catch(() => [])
+                    .then((linkedResources) => {
+                        const linkedTo = linkedResources.linked_to ?? [];
+                        const linkedBy = linkedResources.linked_by ?? [];
+                        return isEmpty(linkedTo) && isEmpty(linkedBy) ? {} : ({ linkedTo, linkedBy });
+                    })
+                    .catch(() => {})
             ).switchMap((linkedResources) =>
                 Observable.of(
                     updateResourceProperties({linkedResources})

--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -451,6 +451,11 @@
     }
     .tab-content {
         margin-top: 0.5rem;
+        .linked-resources {
+            > span {
+                font-size: @font-size-small;
+            }
+        }
     }
 }
 

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -798,7 +798,7 @@
                         {
                             "type": "linked-resources",
                             "id": "related",
-                            "labelId": "gnviewer.linkedResources",
+                            "labelId": "gnviewer.linkedResources.label",
                             "items": "{context.get(state('gnResourceData'), 'linkedResources')}"
                         }
                     ]
@@ -1673,7 +1673,7 @@
                         {
                             "type": "linked-resources",
                             "id": "related",
-                            "labelId": "gnviewer.linkedResources",
+                            "labelId": "gnviewer.linkedResources.label",
                             "items": "{context.get(state('gnResourceData'), 'linkedResources')}"
                         }
                     ]
@@ -2327,7 +2327,7 @@
                         {
                             "type": "linked-resources",
                             "id": "related",
-                            "labelId": "gnviewer.linkedResources",
+                            "labelId": "gnviewer.linkedResources.label",
                             "items": "{context.get(state('gnResourceData'), 'linkedResources')}"
                         }
                     ]
@@ -2648,7 +2648,7 @@
                         {
                             "type": "linked-resources",
                             "id": "related",
-                            "labelId": "gnviewer.linkedResources",
+                            "labelId": "gnviewer.linkedResources.label",
                             "items": "{context.get(state('gnResourceData'), 'linkedResources')}"
                         }
                     ]
@@ -2887,7 +2887,7 @@
                         {
                             "type": "linked-resources",
                             "id": "related",
-                            "labelId": "gnviewer.linkedResources",
+                            "labelId": "gnviewer.linkedResources.label",
                             "items": "{context.get(state('gnResourceData'), 'linkedResources')}"
                         }
                     ]
@@ -3427,7 +3427,7 @@
                         {
                             "type": "linked-resources",
                             "id": "related",
-                            "labelId": "gnviewer.linkedResources",
+                            "labelId": "gnviewer.linkedResources.label",
                             "items": "{context.get(state('gnResourceData'), 'linkedResources')}"
                         }
                     ]

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -335,7 +335,13 @@
             "abstract": "Zusammenfassung",
             "readMore": "Weiterlesen",
             "readLess": "Weniger lesen",
-            "linkedResources": "Verknüpfte Ressourcen",
+            "linkedResources": {
+                "label": "Verknüpfte Ressourcen",
+                "linkedBy": "Verbunden von",
+                "linkedTo": "Verbunden mit",
+                "uses": "Verwendet",
+                "usedBy": "Benutzt von"
+            },
             "extent": "Ausmaß",
             "dateFilter": {
                 "from": "Datum von",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -335,7 +335,13 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources",
+            "linkedResources": {
+                "label": "Linked Resources",
+                "linkedBy": "Linked By",
+                "linkedTo": "Linked To",
+                "uses": "Uses",
+                "usedBy": "Used By"
+            },
             "extent": "Extent",
             "dateFilter": {
                 "from": "Date from",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -334,7 +334,13 @@
             "abstract": "Resumen",
             "readMore": "Leer más",
             "readLess": "Leer menos",
-            "linkedResources": "Recursos vinculados",
+            "linkedResources": {
+                "label": "Recursos vinculados",
+                "linkedBy": "Vinculado por",
+                "linkedTo": "Vinculado a",
+                "uses": "Usos",
+                "usedBy": "Usado por"
+            },
             "extent": "Extensión",
             "dateFilter": {
                 "from": "Fecha desde",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -304,7 +304,13 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources",
+            "linkedResources": {
+                "label": "Linked Resources",
+                "linkedBy": "Linked By",
+                "linkedTo": "Linked To",
+                "uses": "Uses",
+                "usedBy": "Used By"
+            },
             "extent": "Extent",
             "dateFilter": {
                 "from": "Date from",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -335,7 +335,13 @@
             "abstract": "Résumé",
             "readMore": "En savoir plus",
             "readLess": "Lire moins",
-            "linkedResources": "Ressources liées",
+            "linkedResources": {
+                "label": "Ressources liées",
+                "linkedBy": "Lié par",
+                "linkedTo": "Lié à",
+                "uses": "Les usages",
+                "usedBy": "Utilisé par"
+            },
             "extent": "Étendue",
             "dateFilter": {
                 "from": "Date de",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -304,7 +304,13 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources",
+            "linkedResources": {
+                "label": "Linked Resources",
+                "linkedBy": "Linked By",
+                "linkedTo": "Linked To",
+                "uses": "Uses",
+                "usedBy": "Used By"
+            },
             "extent": "Extent",
             "dateFilter": {
                 "from": "Date from",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -337,7 +337,13 @@
             "abstract": "Astratto",
             "readMore": "Leggi di più",
             "readLess": "Leggi di meno",
-            "linkedResources": "Risorse collegate",
+            "linkedResources": {
+                "label": "Risorse collegate",
+                "linkedBy": "Collegato da",
+                "linkedTo": "Collegato a",
+                "uses": "Usi",
+                "usedBy": "Usato da"
+            },
             "extent": "Estensione",
             "dateFilter": {
                 "from": "Data da",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -304,7 +304,13 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources",
+            "linkedResources": {
+                "label": "Linked Resources",
+                "linkedBy": "Linked By",
+                "linkedTo": "Linked To",
+                "uses": "Uses",
+                "usedBy": "Used By"
+            },
             "extent": "Extent",
             "dateFilter": {
                 "from": "Date from",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -304,7 +304,13 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources",
+            "linkedResources": {
+                "label": "Linked Resources",
+                "linkedBy": "Linked By",
+                "linkedTo": "Linked To",
+                "uses": "Uses",
+                "usedBy": "Used By"
+            },
             "extent": "Extent",
             "dateFilter": {
                 "from": "Date from",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -304,7 +304,13 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources",
+            "linkedResources": {
+                "label": "Linked Resources",
+                "linkedBy": "Linked By",
+                "linkedTo": "Linked To",
+                "uses": "Uses",
+                "usedBy": "Used By"
+            },
             "extent": "Extent",
             "dateFilter": {
                 "from": "Date from",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -305,7 +305,13 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
-            "linkedResources": "Linked Resources",
+            "linkedResources": {
+                "label": "Linked Resources",
+                "linkedBy": "Linked By",
+                "linkedTo": "Linked To",
+                "uses": "Uses",
+                "usedBy": "Used By"
+            },
             "extent": "Extent",
             "dateFilter": {
                 "from": "Date from",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -304,6 +304,13 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
+            "linkedResources": {
+                "label": "Linked Resources",
+                "linkedBy": "Linked By",
+                "linkedTo": "Linked To",
+                "uses": "Uses",
+                "usedBy": "Used By"
+            },
             "extent": "Extent",
             "dateFilter": {
                 "from": "Date from",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -304,6 +304,13 @@
             "abstract": "Abstract",
             "readMore": "Read more",
             "readLess": "Read less",
+            "linkedResources": {
+                "label": "Linked Resources",
+                "linkedBy": "Linked By",
+                "linkedTo": "Linked To",
+                "uses": "Uses",
+                "usedBy": "Used By"
+            },
             "extent": "Extent",
             "dateFilter": {
                 "from": "Date from",


### PR DESCRIPTION
### Description
This PR updated linked resources tab with `linked_by` and `linked_to` fields and remove deprecated `resources` prop

### Issue
- #1584 

### Screenshot
<img width="372" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/08cdb0b2-516c-4aa9-baa4-cd0936a816f4">
<img width="387" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/4bec96e3-6155-4c57-b50c-8e415736a21f">
