### PR TITLE
#1619: Fix - Preview remote document in iframe

### DIFF
--- a/geonode_mapstore_client/client/js/components/MediaViewer/Media.jsx
+++ b/geonode_mapstore_client/client/js/components/MediaViewer/Media.jsx
@@ -71,6 +71,7 @@ const Media = ({ resource, ...props }) => {
                 thumbnail={() => getResourceImageSource(resource?.thumbnail_url)}
                 src={resource.href}
                 url={resource ? metadataPreviewUrl(resource) : ''}
+                embedUrl={resource?.embed_url}
             />
         </Suspense>);
     }

--- a/geonode_mapstore_client/client/js/components/MediaViewer/PdfViewer.jsx
+++ b/geonode_mapstore_client/client/js/components/MediaViewer/PdfViewer.jsx
@@ -3,19 +3,22 @@ import Loader from '@mapstore/framework/components/misc/Loader';
 
 import { getFileFromDownload } from '@js/utils/FileUtils';
 
-const PdfViewer = ({src}) => {
+const PdfViewer = ({src, embedUrl}) => {
     const [filePath, setFilePath] = useState(null);
     const [loading, setLoading] = useState(false);
 
     useEffect(() => {
-        setLoading(true);
-        getFileFromDownload(src)
-            .then((fileURL) => {
-                setLoading(false);
-                setFilePath(fileURL);
-            }).finally(() => {
-                setLoading(false);
-            });
+        if (embedUrl) {
+            setFilePath(embedUrl);
+        } else {
+            setLoading(true);
+            getFileFromDownload(src)
+                .then((fileURL) => {
+                    setFilePath(fileURL);
+                }).finally(() => {
+                    setLoading(false);
+                });
+        }
     }, []);
 
     if (loading) {


### PR DESCRIPTION
### Description
This PR fixes the pdf preview in the viewer. It uses `embed_url` when available for PDF viewer

### Screenshot
<img width="1794" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/c20e9ac6-5817-4722-8f92-81ec2a383772">

### Issue
- #1619 