### PR TITLE
#1621: Implement search service configuration for Maps

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -1161,6 +1161,9 @@
                 }
             },
             {
+                "name": "SearchServicesConfig"
+            },
+            {
                 "name": "FullScreen",
                 "override": {
                     "Toolbar": {
@@ -2021,6 +2024,9 @@
                         "min-width: 768px"
                     ]
                 }
+            },
+            {
+                "name": "SearchServicesConfig"
             },
             {
                 "name": "FullScreen",

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -1161,9 +1161,6 @@
                 }
             },
             {
-                "name": "SearchServicesConfig"
-            },
-            {
                 "name": "FullScreen",
                 "override": {
                     "Toolbar": {


### PR DESCRIPTION
### Description
This PR enables search service config plugin for maps (map_viewer and dataset_viewer)

### Issue
- #1621 

### Screenshot
<img width="1982" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/58e207a3-9854-4dc8-a08d-cbe70fa0414a">
