### PR TITLE
#1635: Share option is available only to user with manage permissions

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/Share.jsx
+++ b/geonode_mapstore_client/client/js/plugins/Share.jsx
@@ -24,7 +24,7 @@ import {
     isNewResource,
     getResourceId,
     getCompactPermissions,
-    canEditPermissions,
+    canManageResourcePermissions,
     getResourceData,
     getViewedResourceType
 } from '@js/selectors/resource';
@@ -179,7 +179,7 @@ const SharePlugin = connect(
         mapInfoSelector,
         getCompactPermissions,
         layersSelector,
-        canEditPermissions,
+        canManageResourcePermissions,
         getCurrentResourcePermissionsLoading,
         getResourceData,
         getViewedResourceType

--- a/geonode_mapstore_client/client/js/selectors/__tests__/resource-test.js
+++ b/geonode_mapstore_client/client/js/selectors/__tests__/resource-test.js
@@ -15,7 +15,8 @@ import {
     getResourceThumbnail,
     updatingThumbnailResource,
     isThumbnailChanged,
-    canEditPermissions
+    canEditPermissions,
+    canManageResourcePermissions
 } from '../resource';
 
 const testState = {
@@ -79,5 +80,12 @@ describe('resource selector', () => {
 
     it('should get permissions from users in groups with manage rights', () => {
         expect(canEditPermissions(testState)).toBeTruthy();
+    });
+    it('test manage resource permissions', () => {
+        let state = {...testState};
+        state.gnresource.data.perms = ['change_resourcebase_permissions'];
+        expect(canManageResourcePermissions(state)).toBeTruthy();
+        state.gnresource.data.perms = ['change_resourcebase', 'view_resourcebase'];
+        expect(canManageResourcePermissions(state)).toBeFalsy();
     });
 });

--- a/geonode_mapstore_client/client/js/selectors/__tests__/resource-test.js
+++ b/geonode_mapstore_client/client/js/selectors/__tests__/resource-test.js
@@ -87,5 +87,6 @@ describe('resource selector', () => {
         expect(canManageResourcePermissions(state)).toBeTruthy();
         state.gnresource.data.perms = ['change_resourcebase', 'view_resourcebase'];
         expect(canManageResourcePermissions(state)).toBeFalsy();
+        state.gnresource.data.perms = undefined;
     });
 });

--- a/geonode_mapstore_client/client/js/selectors/resource.js
+++ b/geonode_mapstore_client/client/js/selectors/resource.js
@@ -117,6 +117,11 @@ export const canEditPermissions = (state) => {
     return ['owner', 'manage'].includes(permissions) || inheritsPerms(user, groups) || inheritsPerms(user, organizations);
 };
 
+export const canManageResourcePermissions = (state) => {
+    const perms = getResourcePerms(state);
+    return perms.includes('change_resourcebase_permissions');
+};
+
 export const getSelectedLayerPermissions = (state) => {
     const selectedLayerPermissions = state?.gnresource?.selectedLayerPermissions;
     return selectedLayerPermissions;


### PR DESCRIPTION
### Description
This PR fixes the share manage resource permission by checking `perms` array of the resource instead of the `/permissions` api response

### Issue
- #1635 