### PR TITLE
[Backport 4.2.x] #1627 Review remote pdf preview (#1642)

### DIFF
--- a/geonode_mapstore_client/client/js/components/MediaViewer/PdfViewer.jsx
+++ b/geonode_mapstore_client/client/js/components/MediaViewer/PdfViewer.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Loader from '@mapstore/framework/components/misc/Loader';
 import { getFileFromDownload } from '@js/utils/FileUtils';
+import MetadataPreview from '@js/components/MetadataPreview';
 
 const IframePDF = ({ src }) => {
     return (
@@ -15,17 +16,21 @@ const IframePDF = ({ src }) => {
     );
 };
 
-const AsyncIframePDF = ({ src }) => {
+const AsyncIframePDF = ({ src, url }) => {
     const [filePath, setFilePath] = useState(null);
     const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
 
     useEffect(() => {
         setLoading(true);
         getFileFromDownload(src)
             .then((fileURL) => {
-                setLoading(false);
                 setFilePath(fileURL);
-            }).finally(() => {
+            })
+            .catch(() => {
+                setError(true);
+            })
+            .finally(() => {
                 setLoading(false);
             });
     }, []);
@@ -37,12 +42,17 @@ const AsyncIframePDF = ({ src }) => {
         </div>);
     }
 
-    return (<IframePDF src={filePath}/>);
+    if (error) {
+        return (
+            <MetadataPreview url={url}/>
+        );
+    }
+
+    return filePath ? (<IframePDF src={filePath}/>) : <div className="gn-pdf-viewer" />;
 };
 
-const PdfViewer = ({ src, isExternalSource }) => {
-    const Viewer = isExternalSource ? IframePDF : AsyncIframePDF;
-    return <Viewer src={src} />;
+const PdfViewer = ({ src, url }) => {
+    return <AsyncIframePDF src={src} url={url} />;
 };
 
 export default PdfViewer;

--- a/geonode_mapstore_client/client/js/utils/FileUtils.js
+++ b/geonode_mapstore_client/client/js/utils/FileUtils.js
@@ -12,13 +12,24 @@ import isEmpty from "lodash/isEmpty";
 * @return {string} Object url to view resource in browser
 */
 export const getFileFromDownload = (downloadURL, type = 'application/pdf') => {
-    return axios.get(downloadURL, {
-        responseType: 'blob'
-    }).then(({data}) => {
+    const resolve = (data) => {
         const file = new Blob([data], {type});
         const fileURL = URL.createObjectURL(file);
         return fileURL;
-    });
+    };
+    // try a direct request
+    return fetch(downloadURL)
+        .then(res => res.blob())
+        .then((data) => resolve(data))
+        // if it fails try to use proxy
+        .catch(() =>
+            axios.get(downloadURL, {
+                responseType: 'blob'
+            })
+                .then(({ data }) => {
+                    return resolve(data);
+                })
+        );
 };
 
 

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -253,6 +253,10 @@ export const ResourceTypes = {
     DASHBOARD: 'dashboard'
 };
 
+export const isDocumentExternalSource = (resource) => {
+    return resource && resource.resource_type === ResourceTypes.DOCUMENT && resource.sourcetype === 'REMOTE';
+};
+
 export const getResourceTypesInfo = () => ({
     [ResourceTypes.DATASET]: {
         icon: 'database',
@@ -279,7 +283,7 @@ export const getResourceTypesInfo = () => ({
         name: 'Document',
         canPreviewed: (resource) => resourceHasPermission(resource, 'download_resourcebase') && !!(determineResourceType(resource.extension) !== 'unsupported'),
         hasPermission: (resource) => resourceHasPermission(resource, 'download_resourcebase'),
-        formatEmbedUrl: (resource) => resource?.embed_url && parseDevHostname(resource.embed_url),
+        formatEmbedUrl: (resource) => isDocumentExternalSource(resource) ? undefined : resource?.embed_url && parseDevHostname(resource.embed_url),
         formatDetailUrl: (resource) => resource?.detail_url && parseDevHostname(resource.detail_url),
         formatMetadataUrl: (resource) => (`/documents/${resource.pk}/metadata`),
         metadataPreviewUrl: (resource) => (`/documents/${resource.pk}/metadata_detail?preview`)
@@ -691,10 +695,6 @@ export const parseUploadFiles = (data) => {
 
 export const getResourceImageSource = (image) => {
     return image ? image : 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPAAAADICAIAAABZHvsFAAAACXBIWXMAAC4jAAAuIwF4pT92AAABiklEQVR42u3SAQ0AAAjDMMC/5+MAAaSVsKyTFHwxEmBoMDQYGgyNocHQYGgwNBgaQ4OhwdBgaDA0hgZDg6HB0GBoDA2GBkODocHQGBoMDYYGQ4OhMTQYGgwNhgZDY2gwNBgaDI2hwdBgaDA0GBpDg6HB0GBoMDSGBkODocHQYGgMDYYGQ4OhwdAYGgwNhgZDg6ExNBgaDA2GBkNjaDA0GBoMDYbG0GBoMDQYGkODocHQYGgwNIYGQ4OhwdBgaAwNhgZDg6HB0BgaDA2GBkODoTE0GBoMDYYGQ2NoMDQYGgwNhsbQYGgwNBgaQ4OhwdBgaDA0hgZDg6HB0GBoDA2GBkODocHQGBoMDYYGQ4OhMTQYGgwNhgZDY2gwNBgaDA2GxtBgaDA0GBoMjaHB0GBoMDSGBkODocHQYGgMDYYGQ4OhwdAYGgwNhgZDg6ExNBgaDA2GBkNjaDA0GBoMDYbG0GBoMDQYGgyNocHQYGgwNIYGQ4OhwdBgaAwNhgZDg6HB0BgaDA2GBkPDbQH4OQSN0W8qegAAAABJRU5ErkJggg==';
-};
-
-export const isDocumentExternalSource = (resource) => {
-    return resource && resource.resource_type === ResourceTypes.DOCUMENT && resource.sourcetype === 'REMOTE';
 };
 
 export const getDownloadUrlInfo = (resource) => {


### PR DESCRIPTION
It is not possible to prevent the popup download If a remote PDF responds with Content-Disposition that triggers it and to fix this behaviour we are introducing following changes:

- remote documents will not be previewed in the catalogue detail panel. We will show the thumbnail or the default icon.
- for all pdf files we will perform a direct request followed by a proxy request only in case the first fails. If both fails we will show the metadata preview