### PR TITLE
#1657 - Add unadvertised identifier to the resource

### DIFF
--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -24,6 +24,7 @@ import { getUserName } from '@js/utils/SearchUtils';
 import { useInView } from 'react-intersection-observer';
 import DetailsResourcePreview from './DetailsResourcePreview';
 import DetailsThumbnail from './DetailsThumbnail';
+import Unadvertised from '@js/components/Unadvertised';
 
 const CopyToClipboard = tooltip(CopyToClipboardCmp);
 
@@ -112,6 +113,7 @@ const DetailsPanelTools = ({
 
     return (
         <div className="gn-details-panel-tools">
+            <Unadvertised resource={resource}/>
             <ResourceStatus resource={resource} />
             {enableFavorite &&
             <Button

--- a/geonode_mapstore_client/client/js/components/ResourceCard/ResourceCard.jsx
+++ b/geonode_mapstore_client/client/js/components/ResourceCard/ResourceCard.jsx
@@ -16,6 +16,7 @@ import ResourceStatus from '@js/components/ResourceStatus';
 import ALink from '@js/components/ALink';
 import AuthorInfo from '@js/components/AuthorInfo/AuthorInfo';
 import ActionButtons from '@js/components/ActionButtons';
+import Unadvertised from '@js/components/Unadvertised';
 
 
 const ResourceCard = forwardRef(({
@@ -136,6 +137,9 @@ const ResourceCard = forwardRef(({
                             </div>
                             <div>
                                 <ResourceStatus resource={res} />
+                            </div>
+                            <div>
+                                <Unadvertised resource={res}/>
                             </div>
                         </div>
                         <p ref={abstractRef} className={`card-text gn-card-description ${layoutCardsStyle}`}>

--- a/geonode_mapstore_client/client/js/components/Unadvertised/Unadvertised.jsx
+++ b/geonode_mapstore_client/client/js/components/Unadvertised/Unadvertised.jsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+import tooltip from '@mapstore/framework/components/misc/enhancers/tooltip';
+import FaIcon from '@js/components/FaIcon/FaIcon';
+
+const Icon = (props) => {
+    return (<div {...props} className="gn-unadvertised"><FaIcon name="eye-slash" /></div> );
+};
+
+const IconWithTooltip = tooltip(Icon);
+
+const Unadvertised = ({resource}) => {
+    if (resource.advertised) {
+        return null;
+    }
+    return (
+        <IconWithTooltip
+            tooltipId={"gnviewer.unadvertised"}
+            className={'gn-unadvertised'}
+        />
+    );
+};
+
+export default Unadvertised;

--- a/geonode_mapstore_client/client/js/components/Unadvertised/Unadvertised.jsx
+++ b/geonode_mapstore_client/client/js/components/Unadvertised/Unadvertised.jsx
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import isNil from 'lodash/isNil';
 
 import tooltip from '@mapstore/framework/components/misc/enhancers/tooltip';
 import FaIcon from '@js/components/FaIcon/FaIcon';
@@ -18,7 +19,7 @@ const Icon = (props) => {
 const IconWithTooltip = tooltip(Icon);
 
 const Unadvertised = ({resource}) => {
-    if (resource.advertised) {
+    if (isNil(resource.advertised) || resource.advertised) {
         return null;
     }
     return (

--- a/geonode_mapstore_client/client/js/components/Unadvertised/index.js
+++ b/geonode_mapstore_client/client/js/components/Unadvertised/index.js
@@ -1,0 +1,1 @@
+export { default } from './Unadvertised';

--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -376,6 +376,11 @@
         button {
             margin: 4px;
         }
+        .gn-unadvertised {
+            padding: 0.25rem 0.5rem;
+            font-size: 0.875rem;
+            line-height: 1.5;
+        }
     }
     .inEdit{
         align-items: center;

--- a/geonode_mapstore_client/client/themes/geonode/less/_resource-card.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_resource-card.less
@@ -46,6 +46,9 @@
             .color-var(@theme-vars[primary]);
         }
     }
+    .gn-unadvertised {
+        .color-var(@theme-vars[warning])
+    }
 }
 
 // **************
@@ -322,4 +325,9 @@ button.btn.btn-default.gn-resource-status.gn-status-button {
             }
         }
     }
+}
+
+.gn-unadvertised {
+    cursor: pointer;
+    pointer-events: auto;
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -358,7 +358,8 @@
             "maxLon": "Max Lon",
             "centerLat": "Lat",
             "centerLon": "Lon",
-            "mapExtentHelpText": "<b>Sie können die Ausdehnung und Position dieser Ressource bearbeiten</b>. Shift-Klick und ziehen Sie, um eine neue Ausdehnung zu zeichnen, klicken Sie auf die Markierung und klicken und ziehen Sie dann, um ihre Position festzulegen"
+            "mapExtentHelpText": "<b>Sie können die Ausdehnung und Position dieser Ressource bearbeiten</b>. Shift-Klick und ziehen Sie, um eine neue Ausdehnung zu zeichnen, klicken Sie auf die Markierung und klicken und ziehen Sie dann, um ihre Position festzulegen",
+            "unadvertised": "Ressource wird nicht beworben. Es ist im Katalog und in den Suchergebnissen ausgeblendet"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -358,7 +358,8 @@
             "maxLon": "Max Lon",
             "centerLat": "Lat",
             "centerLon": "Lon",
-            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position"
+            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position",
+            "unadvertised": "Resource is not advertised. It is hidden from the catalog and search results"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -357,7 +357,8 @@
             "maxLon": "Max Lon",
             "centerLat": "Lat",
             "centerLon": "Lon",
-            "mapExtentHelpText": "<b>Puedes editar la extensión y posición de este recurso</b>. Shift-clic y arrastre para dibujar una nueva extensión, haga clic en el marcador y luego haga clic y arrastre para establecer su posición"
+            "mapExtentHelpText": "<b>Puedes editar la extensión y posición de este recurso</b>. Shift-clic y arrastre para dibujar una nueva extensión, haga clic en el marcador y luego haga clic y arrastre para establecer su posición",
+            "unadvertised": "El recurso no se anuncia. Está oculto en el catálogo y en los resultados de búsqueda."
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -327,7 +327,8 @@
             "maxLon": "Max Lon",
             "centerLat": "Lat",
             "centerLon": "Lon",
-            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position"
+            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position",
+            "unadvertised": "Resource is not advertised. It is hidden from the catalog and search results"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -358,7 +358,8 @@
             "maxLon": "Max Lon",
             "centerLat": "Lat",
             "centerLon": "Lon",
-            "mapExtentHelpText": "<b>Vous pouvez modifier l'étendue et la position de cette ressource</b>. Shift-clic et faites glisser pour dessiner une nouvelle étendue, cliquez sur le marqueur puis cliquez et faites glisser pour définir sa position"
+            "mapExtentHelpText": "<b>Vous pouvez modifier l'étendue et la position de cette ressource</b>. Shift-clic et faites glisser pour dessiner une nouvelle étendue, cliquez sur le marqueur puis cliquez et faites glisser pour définir sa position",
+            "unadvertised": "La ressource n'est pas annoncée. Il est masqué du catalogue et des résultats de recherche"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -327,7 +327,8 @@
             "maxLon": "Max Lon",
             "centerLat": "Lat",
             "centerLon": "Lon",
-            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position"
+            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position",
+            "unadvertised": "Resource is not advertised. It is hidden from the catalog and search results"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -360,7 +360,8 @@
             "maxLon": "Max Lon",
             "centerLat": "Lat",
             "centerLon": "Lon",
-            "mapExtentHelpText": "<b>Puoi modificare l'estensione e la posizione di questa risorsa</b>. Shift-clic e trascina per disegnare una nuova estensione, fare clic sul marcatore, quindi fare clic e trascinare per impostarne la posizione"
+            "mapExtentHelpText": "<b>Puoi modificare l'estensione e la posizione di questa risorsa</b>. Shift-clic e trascina per disegnare una nuova estensione, fare clic sul marcatore, quindi fare clic e trascinare per impostarne la posizione",
+            "unadvertised": "La risorsa non è pubblicizzata. È nascosto dal catalogo e dai risultati della ricerca"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -361,7 +361,7 @@
             "centerLat": "Lat",
             "centerLon": "Lon",
             "mapExtentHelpText": "<b>Puoi modificare l'estensione e la posizione di questa risorsa</b>. Shift-clic e trascina per disegnare una nuova estensione, fare clic sul marcatore, quindi fare clic e trascinare per impostarne la posizione",
-            "unadvertised": "La risorsa non è pubblicizzata. È nascosto dal catalogo e dai risultati della ricerca"
+            "unadvertised": "La risorsa non è pubblicizzata. E' nascosta dal catalogo e dai risultati della ricerca"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -327,7 +327,8 @@
             "maxLon": "Max Lon",
             "centerLat": "Lat",
             "centerLon": "Lon",
-            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position"
+            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position",
+            "unadvertised": "Resource is not advertised. It is hidden from the catalog and search results"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -327,7 +327,8 @@
             "maxLon": "Max Lon",
             "centerLat": "Lat",
             "centerLon": "Lon",
-            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position"
+            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position",
+            "unadvertised": "Resource is not advertised. It is hidden from the catalog and search results"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -327,7 +327,8 @@
             "maxLon": "Max Lon",
             "centerLat": "Lat",
             "centerLon": "Lon",
-            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position"
+            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position",
+            "unadvertised": "Resource is not advertised. It is hidden from the catalog and search results"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -328,7 +328,8 @@
             "maxLon": "Max Lon",
             "centerLat": "Lat",
             "centerLon": "Lon",
-            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position"
+            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position",
+            "unadvertised": "Resource is not advertised. It is hidden from the catalog and search results"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -327,7 +327,8 @@
             "maxLon": "Max Lon",
             "centerLat": "Lat",
             "centerLon": "Lon",
-            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position"
+            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position",
+            "unadvertised": "Resource is not advertised. It is hidden from the catalog and search results"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -327,7 +327,8 @@
             "maxLon": "Max Lon",
             "centerLat": "Lat",
             "centerLon": "Lon",
-            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position"
+            "mapExtentHelpText": "<b>You can edit the extent and position of this resource</b>. Shift-click and drag to draw a new extent, click on the marker and then click and drag to set its position",
+            "unadvertised": "Resource is not advertised. It is hidden from the catalog and search results"
         }
     }
 }


### PR DESCRIPTION
### Description
This PR adds an identifier to unadvertised resources in the resource grid, detail panel (viewer & preview) along with tooltip

### Issue
- #1657 

### Screenshot
<kbd>
<img width="300" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/109531db-fead-4d62-a425-4c2c37c8991e">
</kbd>
<kbd>
<img width="500" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/51fd666d-2bdf-4e37-921f-36a4648ac16c">
</kbd>
<kbd>
<img width="600" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/1d17b1b8-97de-4b41-9282-c5a39f405b44">
</kbd>
