### PR TITLE
User extension plugin invocation improvement

### DIFF
--- a/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
@@ -23,6 +23,9 @@
     .ms-side-panel .ms-header.ms-primary .row:first-child {
         .color-var(@theme-vars[main-color]);
         .background-color-var(@theme-vars[main-bg]);
+        .col-xs-8 {
+            .color-var(@theme-vars[main-color]);
+        }
         .square-button {
             .color-var(@theme-vars[main-color], true);
             .background-color-var(@theme-vars[main-bg], true);


### PR DESCRIPTION
### Description
When the user extension plugin is employed with user plugins lazy loaded, the viewer makes unwanted requests to fetch resource configuration and loading of the viewer page when the user plugin is activated after loaded.

This PR enhances the viewer plugin loading and prevents unwanted requesting resource configurations when the user extension plugin is employed.

### Screenshot
<img width="1983" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/62f880d2-bb50-42f6-a205-19e920829d42">
