### PR TITLE
Configuration update for the plugins available inside the context creator

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -431,6 +431,26 @@ export const plugins = {
     MapViewersCatalogPlugin: toModulePlugin(
         'MapViewersCatalog',
         () => import(/* webpackChunkName: 'plugins/map-viewers-catalog' */ '@js/plugins/MapViewersCatalog')
+    ),
+    MapExportPlugin: toModulePlugin(
+        'MapExport',
+        () => import(/* webpackChunkName: 'plugins/mapExport' */ '@mapstore/framework/plugins/MapExport')
+    ),
+    MapImportPlugin: toModulePlugin(
+        'MapImport',
+        () => import(/* webpackChunkName: 'plugins/mapImport' */ '@mapstore/framework/plugins/MapImport')
+    ),
+    SearchByBookmarkPlugin: toModulePlugin(
+        'SearchByBookmark',
+        () => import(/* webpackChunkName: 'plugins/searchByBookmark' */ '@mapstore/framework/plugins/SearchByBookmark')
+    ),
+    CRSSelectorPlugin: toModulePlugin(
+        'CRSSelector',
+        () => import(/* webpackChunkName: 'plugins/CRSSelector' */ '@mapstore/framework/plugins/CRSSelector')
+    ),
+    SettingsPlugin: toModulePlugin(
+        'Settings',
+        () => import(/* webpackChunkName: 'plugins/settings' */ '@mapstore/framework/plugins/Settings')
     )
 };
 

--- a/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
@@ -443,3 +443,9 @@ div#mapstore-globalspinner {
 .ms-map-views {
     left: 44px;
 }
+#mapstore-settings {
+    .form-group-sm select.form-control {
+        height: @input-height-base;
+        line-height: @input-height-base;
+    }
+}

--- a/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
@@ -54,20 +54,69 @@
         "activateMetedataTool": false
       },
       "children": [
+        "TOCItemsSettings",
         "FeatureEditor",
         "FilterLayer",
         "AddGroup",
-        "Swipe"
+        "Swipe",
+        "VisualStyleEditor"
       ],
       "autoEnableChildren": [
+        "TOCItemsSettings",
         "FeatureEditor",
         "FilterLayer",
-        "AddGroup"
+        "AddGroup",
+        "VisualStyleEditor"
       ],
       "dependencies": [
         "DrawerMenu",
         "MapLoading"
       ]
+    },
+    {
+      "name": "TOCItemsSettings",
+      "glyph": "wrench",
+      "title": "plugins.TOCItemsSettings.title",
+      "description": "plugins.TOCItemsSettings.description",
+      "children": [
+        "StyleEditor"
+      ]
+    },
+    {
+      "name": "StyleEditor",
+      "glyph": "1-stilo",
+      "title": "plugins.StyleEditor.title",
+      "description": "plugins.StyleEditor.description"
+    },
+    {
+      "name": "VisualStyleEditor",
+      "glyph": "1-stilo",
+      "title": "plugins.VisualStyleEditor.title",
+      "description": "plugins.VisualStyleEditor.description",
+      "defaultConfig": {
+        "showLayerProperties": true,
+        "styleService": {
+            "baseUrl": "{state('settings') && state('settings').geonodeUrl && state('settings').geonodeUrl + 'gs/' || '/gs/'}",
+            "formats": [
+                "css",
+                "sld"
+            ],
+            "availableUrls": [
+                "{state('settings') && state('settings').geoserverUrl || '/geoserver/'}",
+                "{state('settings') && state('settings').geonodeUrl && state('settings').geonodeUrl + 'gs/' || '/gs/'}"
+            ],
+            "fonts": [
+                "Arial",
+                "Courier New",
+                "Monospaced",
+                "SansSerif",
+                "Serif",
+                "Times New Roman"
+            ]
+        },
+        "editingAllowedRoles": null,
+        "enableSetDefaultStyle": true
+      }
     },
     {
       "name": "FeatureEditor",
@@ -143,7 +192,10 @@
         "viewerOptions": {
           "container": "{context.ReactSwipe}"
         }
-      }
+      },
+      "children": [
+        "Settings"
+      ]
     },
     {
       "name": "Locate",
@@ -255,6 +307,9 @@
       "name": "Swipe"
     },
     {
+      "name": "SearchByBookmark"
+    },
+    {
       "name": "Search",
       "glyph": "search",
       "title": "plugins.Search.title",
@@ -262,6 +317,9 @@
       "dependencies": [
         "OmniBar",
         "SearchServicesConfig"
+      ],
+      "children": [
+        "SearchByBookmark"
       ],
       "defaultConfig": {
         "withToggle": [
@@ -425,6 +483,68 @@
       "defaultConfig": {
         "wrap": true
       }
+    },
+    {
+      "name": "MapImport",
+      "glyph": "upload",
+      "title": "plugins.MapImport.title",
+      "description": "plugins.MapImport.description",
+      "dependencies": [
+        "SidebarMenu"
+      ]
+    },
+    {
+      "name": "MapExport",
+      "glyph": "download",
+      "title": "plugins.MapExport.title",
+      "description": "plugins.MapExport.description",
+      "dependencies": [
+        "SidebarMenu"
+      ]
+    },
+    {
+      "name": "CRSSelector",
+      "glyph": "crs",
+      "title": "plugins.CRSSelector.title",
+      "description": "plugins.CRSSelector.description",
+      "dependencies": [
+        "MapFooter"
+      ],
+      "defaultConfig": {
+        "additionalCRS": {},
+        "filterAllowedCRS": [
+          "EPSG:4326",
+          "EPSG:3857"
+        ],
+        "allowedRoles": [
+          "ADMIN"
+        ]
+      }
+    },
+    {
+      "name": "Settings",
+      "glyph": "cog",
+      "title": "plugins.Settings.title",
+      "description": "plugins.Settings.description",
+      "dependencies": [
+        "SidebarMenu"
+      ],
+      "defaultConfig": {
+        "wrap": true,
+        "overrideSettings": {
+          "language": false,
+          "history": false
+        }
+      }
+    },
+    {
+      "name": "LongitudinalProfileTool",
+      "glyph": "1-line",
+      "title": "plugins.LongitudinalProfileTool.title",
+      "description": "plugins.LongitudinalProfileTool.description",
+      "dependencies": [
+        "SidebarMenu"
+      ]
     }
   ]
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -15,6 +15,12 @@
                 "emptyList": "Keine Ergebnisse für diese Anfrage. Versuchen Sie, den Filter zu wechseln oder einen anderen Dienst aus der Eingabe in der oberen rechten Ecke auszuwählen."
             }
         },
+        "plugins": {
+            "VisualStyleEditor": {
+                "description": "Der Stileditor des Datensatzes",
+                "title": "Visueller Stil-Editor"
+            }
+        },
         "gnhome": {
             "description": "<h1>GeoNode</h1><p>Austausch von Geodaten und Karten.</p>",
             "orderBy": "Sortieren nach",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -15,6 +15,12 @@
                 "emptyList": "No results for this request. Try to change filter or select a different service from the input in the top right corner."
             }
         },
+        "plugins": {
+            "VisualStyleEditor": {
+                "description": "Dataset's style editor",
+                "title": "Visual Style Editor"
+            }
+        },
         "gnhome": {
             "description": "<h1>GeoNode</h1><p>sharing geospatial data and maps.</p>",
             "orderBy": "Order by",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -15,6 +15,12 @@
                 "emptyList": "No hay resultados para esta solicitud. Intente cambiar el filtro o seleccione un servicio diferente de la entrada en la esquina superior derecha."
             }
         },
+        "plugins": {
+            "VisualStyleEditor": {
+                "description": "Editor de estilo del conjunto de datos",
+                "title": "Editor de estilo visual"
+            }
+        },
         "gnhome": {
             "description": "<h1>GeoNode</h1><p>compartir datos y mapas geoespaciales.</p>",
             "orderBy": "Ordenar por",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -15,6 +15,12 @@
                 "emptyList": "No results for this request. Try to change filter or select a different service from the input in the top right corner."
             }
         },
+        "plugins": {
+            "VisualStyleEditor": {
+                "description": "Dataset's style editor",
+                "title": "Visual Style Editor"
+            }
+        },
         "gnhome": {
             "description": "<h1>GeoNode</h1><p>sharing geospatial data and maps.</p>",
             "orderBy": "Order by",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -15,6 +15,12 @@
                 "emptyList": "Aucun résultat pour cette demande. Essayez de changer le filtre ou sélectionnez un service différent à partir de l'entrée dans le coin supérieur droit."
             }
         },
+        "plugins": {
+            "VisualStyleEditor": {
+                "description": "Éditeur de style du jeu de données",
+                "title": "Éditeur de styles visuels"
+            }
+        },
         "gnhome": {
             "description": "<h1>GeoNode</h1><p>partager des données et des cartes géospatiales.</p>",
             "orderBy": "Commandé par",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -15,6 +15,12 @@
                 "emptyList": "No results for this request. Try to change filter or select a different service from the input in the top right corner."
             }
         },
+        "plugins": {
+            "VisualStyleEditor": {
+                "description": "Dataset's style editor",
+                "title": "Visual Style Editor"
+            }
+        },
         "gnhome": {
             "description": "<h1>GeoNode</h1><p>sharing geospatial data and maps.</p>",
             "orderBy": "Order by",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -15,6 +15,12 @@
                 "emptyList": "Nessun risultato per questa richiesta. Prova a cambiare il filtro o selezionare un altro servizio nel selettore in alto a destra."
             }
         },
+        "plugins": {
+            "VisualStyleEditor": {
+                "description": "Editor di stile del set di dati",
+                "title": "Editor dello stile visivo"
+            }
+        },
         "gnhome": {
             "description": "<h1>GeoNode</h1><p>condivisione di dati geospaziali e mappe.</p>",
             "orderBy": "Ordinato da",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -15,6 +15,12 @@
                 "emptyList": "No results for this request. Try to change filter or select a different service from the input in the top right corner."
             }
         },
+        "plugins": {
+            "VisualStyleEditor": {
+                "description": "Dataset's style editor",
+                "title": "Visual Style Editor"
+            }
+        },
         "gnhome": {
             "description": "<h1>GeoNode</h1><p>sharing geospatial data and maps.</p>",
             "orderBy": "Order by",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -15,6 +15,12 @@
                 "emptyList": "No results for this request. Try to change filter or select a different service from the input in the top right corner."
             }
         },
+        "plugins": {
+            "VisualStyleEditor": {
+                "description": "Dataset's style editor",
+                "title": "Visual Style Editor"
+            }
+        },
         "gnhome": {
             "description": "<h1>GeoNode</h1><p>sharing geospatial data and maps.</p>",
             "orderBy": "Order by",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -15,6 +15,12 @@
                 "emptyList": "No results for this request. Try to change filter or select a different service from the input in the top right corner."
             }
         },
+        "plugins": {
+            "VisualStyleEditor": {
+                "description": "Dataset's style editor",
+                "title": "Visual Style Editor"
+            }
+        },
         "gnhome": {
             "description": "<h1>GeoNode</h1><p>sharing geospatial data and maps.</p>",
             "orderBy": "Order by",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -16,6 +16,12 @@
                 "emptyList": "No results for this request. Try to change filter or select a different service from the input in the top right corner."
             }
         },
+        "plugins": {
+            "VisualStyleEditor": {
+                "description": "Dataset's style editor",
+                "title": "Visual Style Editor"
+            }
+        },
         "gnhome": {
             "description": "<h1>GeoNode</h1><p>sharing geospatial data and maps.</p>",
             "orderBy": "Order by",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -15,6 +15,12 @@
                 "emptyList": "No results for this request. Try to change filter or select a different service from the input in the top right corner."
             }
         },
+        "plugins": {
+            "VisualStyleEditor": {
+                "description": "Dataset's style editor",
+                "title": "Visual Style Editor"
+            }
+        },
         "gnhome": {
             "description": "<h1>GeoNode</h1><p>sharing geospatial data and maps.</p>",
             "orderBy": "Order by",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -15,6 +15,12 @@
                 "emptyList": "No results for this request. Try to change filter or select a different service from the input in the top right corner."
             }
         },
+        "plugins": {
+            "VisualStyleEditor": {
+                "description": "Dataset's style editor",
+                "title": "Visual Style Editor"
+            }
+        },
         "gnhome": {
             "description": "<h1>GeoNode</h1><p>sharing geospatial data and maps.</p>",
             "orderBy": "Order by",


### PR DESCRIPTION
### Description
This PR enhances and updates context creator plugins and configurations

### Plugins excluded
`MapCatalog` - list Mapstore resources (not useful in Geonode) as we already have datasets catalog
`MapTemplate` - performs creation of templates relying on Geostore

### Screenshot
<img width="1984" alt="Screenshot 2024-02-15 at 5 02 37 PM" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/0d8bb394-1a96-4ec6-9a4e-242e4fd1f30a">
