### PR TITLE
Fix - Duplicated API requests on viewer resource load

### DIFF
--- a/geonode_mapstore_client/client/js/routes/Viewer.jsx
+++ b/geonode_mapstore_client/client/js/routes/Viewer.jsx
@@ -81,18 +81,20 @@ function ViewerRoute({
         pluginsConfig
     });
 
-    const pluginsRef = useRef(null);
+    const viewer = useRef({ resourceLoaded: false, prevPluginsLength: null });
+    const { resourceLoaded, prevPluginsLength } = viewer.current ?? {};
     useEffect(() => {
-        if (!pluginsRef.current || pluginsCfgLength === 0) {
+        if (!prevPluginsLength || pluginsCfgLength === 0) {
             // to ensure and prevent loading and requesting of resource configurations
             // post initialization when user plugin is employed
-            pluginsRef.current = pluginsCfgLength;
+            viewer.current.prevPluginsLength = pluginsCfgLength;
         }
     }, [pluginsCfgLength]);
 
-    const pluginLoading = pluginsRef.current === pluginsCfgLength && pending;
+    const pluginLoading = prevPluginsLength === pluginsCfgLength && pending;
     useEffect(() => {
-        if (!pluginLoading && pk !== undefined) {
+        if (!pluginLoading && !resourceLoaded && pk !== undefined) {
+            viewer.current.resourceLoaded = true;
             if (pk === 'new') {
                 onCreate(resourceType, {
                     params: match.params


### PR DESCRIPTION
### Description
This PR enhances plugin loading along with user extension plugin load and requesting of resource data without compromising the display of loader and without the duplication of api request for resource data fetching

### Screenshot
<img width="1983" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/c278880c-33ad-4666-bf0e-4dfa1f355919">
