### PR TITLE
#1683: Enable the 3D plugin in the default GeoNode map configuration

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -1720,6 +1720,9 @@
                 "name": "BackgroundSelector"
             },
             {
+                "name": "GlobeViewSwitcher"
+            },
+            {
                 "name": "Identify",
                 "cfg": {
                     "viewerOptions": {


### PR DESCRIPTION
### Description
This PR updates `map_viewer` to have GlobeSwitcher plugin

### Issue
- #1683 