### PR TITLE
#1685 - Fix: Mapviewer doesn't show configure plugin steps

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -393,13 +393,14 @@ const resourceTypes = {
             return Observable.throw(new Error(error));
         },
         removeLinkedResourceObservable: (payload) => {
-            const { resource, response } = payload;
+            const { response } = payload;
             const { success, error: [error] } = response;
-            return success
-                ? Observable.of(setResourcePathParameters({...resource?.params, appPk: null}))
-                : Observable.throw(new Error(error));
+            if (success) {
+                window.location.reload();
+                return Observable.empty();
+            }
+            return Observable.throw(new Error(error));
         }
-        // }
     }
 };
 

--- a/geonode_mapstore_client/client/js/routes/Viewer.jsx
+++ b/geonode_mapstore_client/client/js/routes/Viewer.jsx
@@ -91,7 +91,7 @@ function ViewerRoute({
         }
     }, [pluginsCfgLength]);
 
-    const pluginLoading = prevPluginsLength === pluginsCfgLength && pending;
+    const pluginLoading = prevPluginsLength !== null && prevPluginsLength !== pluginsCfgLength ? false : pending;
     useEffect(() => {
         if (!pluginLoading && !resourceLoaded && pk !== undefined) {
             viewer.current.resourceLoaded = true;


### PR DESCRIPTION
### Description
- This PR fixes the new map viewer loading 
  - The following works fine as well
  - Map load
  - User plugin load
  - Map viewer load
  - No duplicate resource calls
- Reload map on unlink viewer resource to reset map's default plugin

### Issue
- #1685 