### PR TITLE
#1689: Add a warning when closing an unsaved map viewer

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/SaveAs.jsx
+++ b/geonode_mapstore_client/client/js/plugins/SaveAs.jsx
@@ -37,6 +37,7 @@ import { processResources } from '@js/actions/gnresource';
 import { getCurrentResourceCopyLoading } from '@js/selectors/resourceservice';
 import Dropdown from '@js/components/Dropdown';
 import FaIcon from '@js/components/FaIcon';
+import withPrompt from '@js/plugins/save/withPrompt';
 
 function SaveAs({
     resources,
@@ -107,24 +108,24 @@ const SaveAsPlugin = connect(
 )(SaveAs);
 
 function SaveAsButton({
-    enabled,
     onClick,
     variant,
     size,
     resource,
+    dirtyState,
     disabled
 }) {
-    return enabled
-        ? <Button
-            variant={variant || "primary"}
+
+    return (
+        <Button
+            variant={dirtyState ? 'warning' : (variant || "primary")}
             size={size}
             disabled={disabled}
             onClick={() => onClick([ resource ])}
         >
             <Message msgId="saveAs"/>
         </Button>
-        : null
-    ;
+    );
 }
 
 const canCopyResourceFunction = (state) => {
@@ -142,6 +143,10 @@ const canCopyResourceFunction = (state) => {
     };
 };
 
+const isDisabledByDirtyState = (dirtyState) => {
+    return typeof dirtyState === 'object' ? !!dirtyState : false;
+};
+
 const ConnectedSaveAsButton = connect(
     createSelector(
         getResourceData,
@@ -150,13 +155,14 @@ const ConnectedSaveAsButton = connect(
         (resource, dirtyState, canCopy) => ({
             enabled: !!canCopy(resource),
             resource,
-            disabled: !!dirtyState
+            dirtyState: !isDisabledByDirtyState(dirtyState) && !!dirtyState,
+            disabled: isDisabledByDirtyState(dirtyState)
         })
     ),
     {
         onClick: setControlProperty.bind(null, ProcessTypes.COPY_RESOURCE, 'value')
     }
-)((SaveAsButton));
+)(withPrompt(SaveAsButton));
 
 function CopyMenuItem({
     resource,

--- a/geonode_mapstore_client/client/js/plugins/save/withPrompt.jsx
+++ b/geonode_mapstore_client/client/js/plugins/save/withPrompt.jsx
@@ -1,0 +1,49 @@
+import React, { useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { getMessageById } from '@mapstore/framework/utils/LocaleUtils';
+import { Prompt } from 'react-router-dom';
+
+
+export default (Component) => {
+    const PromptComponent = (props, {messages}) => {
+        const dirtyState = useRef();
+        dirtyState.current = props.dirtyState;
+        useEffect(() => {
+            function onBeforeUnload(event) {
+                if (dirtyState.current) {
+                    (event || window.event).returnValue = null;
+                }
+            }
+            window.addEventListener('beforeunload', onBeforeUnload);
+            return () => {
+                window.removeEventListener('beforeunload', onBeforeUnload);
+            };
+        }, []);
+
+        return props.enabled
+            ? <><Component {...props}/>
+                <Prompt
+                    when={!!props.dirtyState}
+                    message={(/* nextLocation, action */) => {
+                        const confirmed = window.confirm(getMessageById(messages, 'gnviewer.prompPendingChanges')); // eslint-disable-line no-alert
+                        // if confirm the path should be the next one
+                        if (confirmed) {
+                            return true;
+                        }
+                        window.history.back(); // to return back to previous path
+                        // currently it's not possible to replace the pathname
+                        // without side effect
+                        // such as reloading of the page
+                        return false;
+                    }}
+                />
+            </>
+            : null
+        ;
+    };
+
+    PromptComponent.contextTypes = {
+        messages: PropTypes.object
+    };
+    return PromptComponent;
+};

--- a/geonode_mapstore_client/client/js/selectors/__tests__/resource-test.js
+++ b/geonode_mapstore_client/client/js/selectors/__tests__/resource-test.js
@@ -16,8 +16,10 @@ import {
     updatingThumbnailResource,
     isThumbnailChanged,
     canEditPermissions,
-    canManageResourcePermissions
+    canManageResourcePermissions,
+    isNewMapViewerResource
 } from '../resource';
+import { ResourceTypes } from '@js/utils/ResourceUtils';
 
 const testState = {
     gnresource: {
@@ -88,5 +90,11 @@ describe('resource selector', () => {
         state.gnresource.data.perms = ['change_resourcebase', 'view_resourcebase'];
         expect(canManageResourcePermissions(state)).toBeFalsy();
         state.gnresource.data.perms = undefined;
+    });
+    it('test isNewMapViewerResource', () => {
+        let state = {...testState, gnresource: {...testState.gnresource, type: ResourceTypes.VIEWER, params: {pk: "new"}}};
+        expect(isNewMapViewerResource(state)).toBeTruthy();
+        state.gnresource.params.pk = '1';
+        expect(isNewMapViewerResource(state)).toBeFalsy();
     });
 });

--- a/geonode_mapstore_client/client/js/selectors/resource.js
+++ b/geonode_mapstore_client/client/js/selectors/resource.js
@@ -253,7 +253,16 @@ function isResourceDataEqual(state, initialData = {}, currentData = {}) {
     }
 }
 
+export const isNewMapViewerResource = (state) => {
+    const isNew = state?.gnresource?.params?.pk === "new";
+    const isMapViewer = state?.gnresource?.type === ResourceTypes.VIEWER;
+    return isNew && isMapViewer;
+};
+
 export const getResourceDirtyState = (state) => {
+    if (isNewMapViewerResource(state)) {
+        return true;
+    }
     const canEdit = canEditPermissions(state);
     const isDeleting = getCurrentResourceDeleteLoading(state);
     const isCopying = getCurrentResourceCopyLoading(state);


### PR DESCRIPTION
### Description
This PR adds a prompt warning to the new map viewer. Added `withPrompt` hoc and code refactored

### Issue
- #1689 

### Screenshot
<img width="1494" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/67afbdd1-411d-4c1a-aaca-5b2ca3917c93">
