### PR TITLE
Restore missed change during merge

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -397,6 +397,7 @@ const resourceTypes = {
             const { success, error: [error] } = response;
             if (success) {
                 window.location.replace(window.location.href);
+                window.location.reload();
                 return Observable.empty();
             }
             return Observable.throw(new Error(error));


### PR DESCRIPTION
### Description
This PR restores the change that was overwritten during [merge](https://github.com/GeoNode/geonode-mapstore-client/commit/cc524c295ea4d7ab45bd92fbad16feec921354df#diff-75f1582709cf007fae6faace8c01dc40947a88e4a04e1ce7620beb0c2b044cf4L400) of `mapviewer-resource-built` with `mapviewer-resource`.

**Change**: Reload resource on removing viewer linked resource

