### PR TITLE
#1695 - Remove selection of LongitudinalProfileTool plugin from map viewer

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
@@ -539,15 +539,6 @@
           "history": false
         }
       }
-    },
-    {
-      "name": "LongitudinalProfileTool",
-      "glyph": "1-line",
-      "title": "plugins.LongitudinalProfileTool.title",
-      "description": "plugins.LongitudinalProfileTool.description",
-      "dependencies": [
-        "SidebarMenu"
-      ]
     }
   ]
 }


### PR DESCRIPTION
### Description
This PR removes the selection of `LongitudinalProfileTool` plugin from map viewer

### Issue
- #1695 

> [!NOTE]
> Open any viewer created with `LongitudinalProfileTool` plugin and save to update the viewer excluding the removed plugin or simply remove the viewer