### PR TITLE
#1722: Fix - LayerSettings select dropdown are covered by titles

### DIFF
--- a/geonode_mapstore_client/client/themes/geonode/less/_layer-settings.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_layer-settings.less
@@ -51,7 +51,7 @@
         .form-group {
             margin-bottom: 0.25rem;
         }
-        .Select-menu-outer {
+        .Select.is-open, .Select-menu-outer {
             z-index: 200;
         }
         .gn-layer-settings-section-title {


### PR DESCRIPTION
### Description
This PR fixes the layer settings select dropdown are covered by titles

### Issue
- #1722 

### Screenshot
<img width="351" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/f8ad8d58-3dbd-417e-854e-1ce3f3dec72c">
