### PR TITLE
#1726: Fix - Tile format select input not shown

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/layersettings/WMSLayerSettings.jsx
+++ b/geonode_mapstore_client/client/js/plugins/layersettings/WMSLayerSettings.jsx
@@ -17,6 +17,7 @@ import InfoPopover from '@mapstore/framework/components/widgets/widget/InfoPopov
 import { getSupportedFormat } from '@mapstore/framework/api/WMS';
 import { getConfigProp } from '@mapstore/framework/utils/ConfigUtils';
 import LegendImage from '@mapstore/framework/plugins/TOC/components/Legend';
+import { DEFAULT_SUPPORTED_GET_MAP_FORMAT } from '@mapstore/framework/utils/WMSUtils';
 import Select from 'react-select';
 import GeneralSettings from '@js/plugins/layersettings/GeneralSettings';
 import VisibilitySettings from '@js/plugins/layersettings/VisibilitySettings';
@@ -215,8 +216,8 @@ function WMSLayerSettings({
                             isLoading={!!formatLoading}
                             options={formatLoading
                                 ? []
-                                : (formats?.map((value) => ({ value, label: value }))
-                                || imageFormats)}
+                                : (formats ?? imageFormats ?? DEFAULT_SUPPORTED_GET_MAP_FORMAT).map((_format) => _format?.value ? _format : ({ value: _format, label: _format }))
+                            }
                             value={format}
                             onChange={({ value }) => onChange({ format: value })}/>
                         <Button


### PR DESCRIPTION
### Description
This PR fixes the tile format select input options not being displayed

### Issue
- #1726 

### Screenshot 
<img width="351" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/56420d77-6d21-446b-be5a-e6386f4568ec">
