### PR TITLE
#1728: Fix - Missing scrollbar for legend in datasets

### DIFF
--- a/geonode_mapstore_client/client/themes/geonode/less/_legend.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_legend.less
@@ -16,5 +16,13 @@
 .gn-legend-wrapper {
     .ms-layers-tree {
         padding-top: 0;
+        &.legend-tree {
+            .ms-node-layer {
+                ul {
+                    max-height: 500px;
+                    overflow: auto;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description
This PR fixes the missing scrollbar on legends in datasets when lengthier

### Issue
- #1728 

### Screenshot
<img width="214" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/1e242335-7614-4301-9bf9-b263cc3ba439">
