### PR TITLE
#1730: Fix - Incorrect positioning of panels

### DIFF
--- a/geonode_mapstore_client/client/js/epics/__tests__/gnresource-test.js
+++ b/geonode_mapstore_client/client/js/epics/__tests__/gnresource-test.js
@@ -12,7 +12,8 @@ import axios from '@mapstore/framework/libs/ajax';
 import { testEpic } from '@mapstore/framework/epics/__tests__/epicTestUtils';
 import {
     gnViewerSetNewResourceThumbnail,
-    closeInfoPanelOnMapClick
+    closeInfoPanelOnMapClick,
+    closeDatasetCatalogPanel
 } from '@js/epics/gnresource';
 import {
     setResourceThumbnail,
@@ -24,6 +25,7 @@ import { SET_CONTROL_PROPERTY } from '@mapstore/framework/actions/controls';
 import {
     SHOW_NOTIFICATION
 } from '@mapstore/framework/actions/notifications';
+import { newMapInfoRequest } from '@mapstore/framework/actions/mapInfo';
 
 let mockAxios;
 
@@ -123,6 +125,46 @@ describe('gnresource epics', () => {
                         .toEqual([
                             SET_CONTROL_PROPERTY
                         ]);
+                } catch (e) {
+                    done(e);
+                }
+                done();
+            },
+            testState
+        );
+
+    });
+    it('close dataset panels on map info panel open', (done) => {
+        const NUM_ACTIONS = 1;
+        const testState = {
+            context: {
+                currentContext: {
+                    plugins: {
+                        desktop: [
+                            {name: "Identify"}
+                        ]
+                    }
+                }
+            },
+            mapInfo: {
+                requests: ["something"]
+            },
+            controls: {
+                datasetsCatalog: {
+                    enabled: true
+                }
+            }
+        };
+
+        testEpic(closeDatasetCatalogPanel,
+            NUM_ACTIONS,
+            newMapInfoRequest(),
+            (actions) => {
+                try {
+                    expect(actions.length).toBe(1);
+                    expect(actions[0].type).toBe(SET_CONTROL_PROPERTY);
+                    expect(actions[0].control).toBe("datasetsCatalog");
+                    expect(actions[0].value).toBe(false);
                 } catch (e) {
                     done(e);
                 }

--- a/geonode_mapstore_client/client/js/epics/datasetscatalog.js
+++ b/geonode_mapstore_client/client/js/epics/datasetscatalog.js
@@ -8,7 +8,7 @@
 
 import { SET_CONTROL_PROPERTY } from '@mapstore/framework/actions/controls';
 import { updateMapLayout, UPDATE_MAP_LAYOUT } from '@mapstore/framework/actions/maplayout';
-import { mapLayoutSelector } from '@mapstore/framework/selectors/maplayout';
+import { mapLayoutSelector, boundingSidebarRectSelector } from '@mapstore/framework/selectors/maplayout';
 import { getConfigProp } from "@mapstore/framework/utils/ConfigUtils";
 import { LayoutSections } from "@js/utils/LayoutUtils";
 
@@ -27,13 +27,21 @@ export const gnUpdateDatasetsCatalogMapLayout = (action$, store) =>
         })
         .map(({ layout }) => {
             const mapLayout = getConfigProp('mapLayout') || { left: { sm: 300, md: 500, lg: 600 }, right: { md: 658 }, bottom: { sm: 30 } };
+            const boundingSidebarRect = boundingSidebarRectSelector(store.getState());
+            const left = !!store.getState()?.controls?.drawer?.enabled ? mapLayout.left.sm : null;
             const action = updateMapLayout({
                 ...mapLayoutSelector(store.getState()),
                 ...layout,
                 right: mapLayout.right.md,
+                ...(left && {left}),
                 boundingMapRect: {
                     ...(layout?.boundingMapRect || {}),
-                    right: mapLayout.right.md
+                    right: mapLayout.right.md,
+                    ...(left && {left})
+                },
+                boundingSidebarRect: {
+                    ...boundingSidebarRect,
+                    ...layout.boundingSidebarRect
                 }
             });
             return { ...action, source: LayoutSections.PANEL }; // add an argument to avoid infinite loop.

--- a/geonode_mapstore_client/client/js/epics/layersettings.js
+++ b/geonode_mapstore_client/client/js/epics/layersettings.js
@@ -7,7 +7,7 @@
  */
 
 import { updateMapLayout, UPDATE_MAP_LAYOUT } from '@mapstore/framework/actions/maplayout';
-import { mapLayoutSelector } from '@mapstore/framework/selectors/maplayout';
+import { mapLayoutSelector, boundingSidebarRectSelector } from '@mapstore/framework/selectors/maplayout';
 import { getConfigProp } from "@mapstore/framework/utils/ConfigUtils";
 import { SHOW_SETTINGS } from '@mapstore/framework/actions/layers';
 import { LayoutSections } from "@js/utils/LayoutUtils";
@@ -26,6 +26,7 @@ export const gnUpdateLayerSettingsMapLayout = (action$, store) =>
         })
         .map(({ layout }) => {
             const mapLayout = getConfigProp('mapLayout') || { left: { sm: 300, md: 500, lg: 600 }, right: { md: 658 }, bottom: { sm: 30 } };
+            const boundingSidebarRect = boundingSidebarRectSelector(store.getState());
             const action = updateMapLayout({
                 ...mapLayoutSelector(store.getState()),
                 ...layout,
@@ -33,6 +34,10 @@ export const gnUpdateLayerSettingsMapLayout = (action$, store) =>
                 boundingMapRect: {
                     ...(layout?.boundingMapRect || {}),
                     left: mapLayout.left.sm
+                },
+                boundingSideBarReact: {
+                    ...boundingSidebarRect,
+                    ...layout.boundingSidebarRect
                 }
             });
             return { ...action, source: LayoutSections.PANEL }; // add an argument to avoid infinite loop.

--- a/geonode_mapstore_client/client/js/epics/visualstyleeditor.js
+++ b/geonode_mapstore_client/client/js/epics/visualstyleeditor.js
@@ -23,7 +23,7 @@ import tinycolor from 'tinycolor2';
 import { parseStyleName } from '@js/utils/ResourceUtils';
 import { getStyleProperties } from '@js/api/geonode/style';
 import { updateMapLayout, UPDATE_MAP_LAYOUT } from '@mapstore/framework/actions/maplayout';
-import { mapLayoutSelector } from '@mapstore/framework/selectors/maplayout';
+import { mapLayoutSelector, boundingSidebarRectSelector } from '@mapstore/framework/selectors/maplayout';
 import { getConfigProp } from "@mapstore/framework/utils/ConfigUtils";
 import { LayoutSections } from "@js/utils/LayoutUtils";
 
@@ -177,6 +177,7 @@ export const gnUpdateVisualStyleEditorMapLayout = (action$, store) =>
         })
         .map(({ layout }) => {
             const mapLayout = getConfigProp('mapLayout') || { left: { sm: 300, md: 500, lg: 600 }, right: { md: 658 }, bottom: { sm: 30 } };
+            const boundingSidebarRect = boundingSidebarRectSelector(store.getState());
             const action = updateMapLayout({
                 ...mapLayoutSelector(store.getState()),
                 ...layout,
@@ -184,6 +185,10 @@ export const gnUpdateVisualStyleEditorMapLayout = (action$, store) =>
                 boundingMapRect: {
                     ...(layout?.boundingMapRect || {}),
                     left: mapLayout.left.md
+                },
+                boundingSidebarRect: {
+                    ...boundingSidebarRect,
+                    ...layout.boundingSidebarRect
                 }
             });
             return { ...action, source: LayoutSections.PANEL }; // add an argument to avoid infinite loop.

--- a/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
@@ -35,6 +35,11 @@
     },
     {
       "name": "DrawerMenu",
+      "defaultConfig": {
+        "menuOptions": {
+          "width": 350
+        }
+      },
       "hidden": true
     },
     {


### PR DESCRIPTION
### Description
This PR fixes 
- Incorrect positioning of the panels and maplayout configurations
- Closing contradicting panels
- Drawer menu default width

### Issue
- #1730 

### [GIF](https://drive.google.com/file/d/1YNi3rbZEUtC-md1s8xZFcS5GQevNMEB1/view)

### Screenshot
[<img width="961" alt="Screenshot 2024-04-19 at 4 11 05 PM" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/b7a08298-ce60-452f-b8b8-f5f7c6b947ba">](https://drive.google.com/file/d/1YNi3rbZEUtC-md1s8xZFcS5GQevNMEB1/view)



