### PR TITLE
#1732: Fix - Chart widget header style

### DIFF
--- a/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
@@ -358,7 +358,7 @@ div#mapstore-globalspinner {
                 }
             }
         }
-        .map-widget-view {
+        .map-widget-view, .chart-widget-view  {
             .widget-icons, .widget-title {
                 .em(margin-bottom, 6);
             }


### PR DESCRIPTION
### Description
This PR fixes the chart widget header's style

### Issue
- #1732 

### Screenshot
<img width="547" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/15398933-1cd5-4302-a9a9-65acc77871e6">
