### PR TITLE
#1756 - Fix: Viewer of map is manageable when user lacks permission

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -627,7 +627,6 @@ export const gnManageLinkedResource = (action$, store) =>
                 observable$ = resourceObservable?.removeLinkedResourceObservable;
                 linkedResourceFn = removeLinkedResourcesByPk;
             }
-            if (!observable$) Observable.empty();
             return Observable.concat(
                 ...(isLinkResource ? [Observable.of(setResourcePathParameters({ ...params, pk: target}))] : []),
                 Observable.defer(() => linkedResourceFn(source, target))
@@ -639,10 +638,10 @@ export const gnManageLinkedResource = (action$, store) =>
                                     title: "gnviewer.linkedResource.title",
                                     message: `gnviewer.linkedResource.message.success.${processType}`}
                                 ))
-                        ).catch(() => Observable.of(errorNotification({
+                        )).catch(() => Observable.of(errorNotification({
                             title: "gnviewer.linkedResource.title",
                             message: `gnviewer.linkedResource.message.failure.${processType}`
-                        }))))
+                        })))
                     .let(wrapStartStop(
                         setControlProperty(processType, 'loading', true),
                         setControlProperty(processType, 'loading', false)

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -1559,7 +1559,7 @@
                                 },
                                 {
                                     "type": "plugin",
-                                    "disableIf": "{!state('resourceParams')?.appPk || !context.resourceHasPermission(state('gnResourceLinkedViewer'), 'change_resourcebase')}",
+                                    "disableIf": "{!state('resourceParams')?.appPk || !context.resourceHasPermission(state('gnResourceData'), 'delete_resourcebase') || !context.resourceHasPermission(state('gnResourceLinkedViewer'), 'delete_resourcebase')}",
                                     "name": "RemoveMapViewer"
                                 }
                             ]

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -81,6 +81,10 @@
             "path": "gnresource.params"
         },
         {
+            "name": "gnResourceLinkedViewer",
+            "path": "gnresource.viewerLinkedResource"
+        },
+        {
             "name": "layers",
             "path": "layers"
         }
@@ -1535,7 +1539,8 @@
                                     "labelId": "gnviewer.editMetadata"
                                 },
                                 {
-                                    "type": "divider"
+                                    "type": "divider",
+                                    "disableIf": "{state('resourceParams')?.appPk}"
                                 },
                                 {
                                     "type": "link",
@@ -1544,13 +1549,17 @@
                                     "labelId": "gnviewer.addViewerConfiguration"
                                 },
                                 {
-                                    "type": "plugin",
-                                    "name": "EditMapViewer",
-                                    "disableIf": "{!state('resourceParams')?.appPk}"
+                                    "type": "divider",
+                                    "disableIf": "{!state('resourceParams')?.appPk || !context.resourceHasPermission(state('gnResourceLinkedViewer'), 'change_resourcebase')}"
                                 },
                                 {
                                     "type": "plugin",
-                                    "disableIf": "{!state('resourceParams')?.appPk}",
+                                    "disableIf": "{!state('resourceParams')?.appPk || !context.resourceHasPermission(state('gnResourceLinkedViewer'), 'change_resourcebase')}",
+                                    "name": "EditMapViewer"
+                                },
+                                {
+                                    "type": "plugin",
+                                    "disableIf": "{!state('resourceParams')?.appPk || !context.resourceHasPermission(state('gnResourceLinkedViewer'), 'change_resourcebase')}",
                                     "name": "RemoveMapViewer"
                                 }
                             ]


### PR DESCRIPTION
### Description
This PR fixes the viewer of map becomes manageable when user lacks permission to viewer but has permission of the map
- `Delete viewer` shown when user has manage permission to both map and viewer
- `Edit viewer` shown when user has edit permission to both map and viewer

### Issue
- #1756 