### PR TITLE
#1772: Add MapStore catalog plugin by default for maps

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -2190,6 +2190,12 @@
             },
             {
                 "name": "SidebarMenu"
+            },
+            {
+                "name": "MetadataExplorer",
+                "cfg": {
+                    "wrap": true
+                }
             }
         ],
         "geostory_viewer": [


### PR DESCRIPTION
### Description
This PR updated configuration of map to show catalog plugin in default map view

### Issue
- #1772 

### Screenshot
<img width="961" alt="image" src="https://github.com/GeoNode/geonode-mapstore-client/assets/26929983/a3daa3ea-ee91-4b0c-8552-35970c0c132d">
