### PR TITLE
#1774: Removed catalogService config from map config

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/map.json
+++ b/geonode_mapstore_client/static/mapstore/configs/map.json
@@ -1,19 +1,5 @@
 {
     "version": 2,
-    "catalogServices": {
-        "selectedService": "GeoNode Catalogue",
-        "services": {
-            "GeoNode Catalogue": {
-                "autoload": true,
-                "layerOptions": {
-                    "tileSize": 512
-                },
-                "title": "GeoNode Catalogue",
-                "type": "csw",
-                "url": "/catalogue/csw"
-            }
-        }
-    },
     "map": {
         "projection": "EPSG:900913",
         "units": "m",


### PR DESCRIPTION
### Description
This PR removes the catalogService configuration from the map config file. However the service is applied from geonodeSettings `CATALOGUE_SERVICES`, when configured in the backend.

### 
- #1774

