### PR TITLE
Add missing chart-switcher css class

### DIFF
--- a/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/ms-theme.less
@@ -366,7 +366,8 @@ div#mapstore-globalspinner {
                 .mapstore-widget-options {
                     .em(margin-top, 4);
                     .em(margin-bottom, 4);
-                    .map-switcher {
+                    .map-switcher, 
+                    .chart-switcher{
                         .em(width, 200);
                     }
                 }


### PR DESCRIPTION
Fixes #1782  by adding a missing chart-switcher style. 
Same way as defined in mapstore :  https://github.com/geosolutions-it/MapStore2/blob/bf8efddfe477b775699fd0eb222ed8d313f9f6c3/web/client/themes/default/less/widget.less#L343