### PR TITLE
Fix #1789 Add action to return back to the All resources page from a viewer

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/ActionNavbar.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ActionNavbar.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect, createPlugin } from '@mapstore/framework/utils/PluginsUtils';
 import { createSelector } from 'reselect';
@@ -84,6 +84,30 @@ function ActionNavbarPlugin(
     const rightItems = reduceArrayRecursive(rightMenuItemsPlugins, (menuItem) =>
         checkResourcePerms(menuItem, resourcePerms)
     );
+
+    useEffect(() => {
+        // set the correct height of navbar
+        const mainHeader = document.querySelector('.gn-main-header');
+        const mainHeaderPlaceholder = document.querySelector('.gn-main-header-placeholder');
+        const topbar = document.querySelector('#gn-topbar');
+        function resize() {
+            if (mainHeaderPlaceholder && mainHeader) {
+                mainHeaderPlaceholder.style.height = mainHeader.clientHeight + 'px';
+            }
+            if (topbar && mainHeader) {
+                topbar.style.top = mainHeader.clientHeight + 'px';
+            }
+        }
+        // hide the navigation bar if a resource is being viewed
+        document.getElementById('gn-topbar')?.classList.add('hide-navigation');
+        document.getElementById('gn-brand-navbar-bottom')?.classList.add('hide-search-bar');
+        resize();
+        return () => {
+            document.getElementById('gn-topbar')?.classList.remove('hide-navigation');
+            document.getElementById('gn-brand-navbar-bottom')?.classList.remove('hide-search-bar');
+            resize();
+        };
+    }, []);
 
     return (
         <ActionNavbar

--- a/geonode_mapstore_client/client/js/routes/Viewer.jsx
+++ b/geonode_mapstore_client/client/js/routes/Viewer.jsx
@@ -113,32 +113,6 @@ function ViewerRoute({
     const Loader = loaderComponent;
     const className = `page-${resourceType}-viewer`;
 
-    useEffect(() => {
-        // set the correct height of navbar
-        const mainHeader = document.querySelector('.gn-main-header');
-        const mainHeaderPlaceholder = document.querySelector('.gn-main-header-placeholder');
-        const topbar = document.querySelector('#gn-topbar');
-        function resize() {
-            if (mainHeaderPlaceholder && mainHeader) {
-                mainHeaderPlaceholder.style.height = mainHeader.clientHeight + 'px';
-            }
-            if (topbar && mainHeader) {
-                topbar.style.top = mainHeader.clientHeight + 'px';
-            }
-        }
-        // hide the navigation bar if a resource is being viewed
-        if (!loading) {
-            document.getElementById('gn-topbar')?.classList.add('hide-navigation');
-            document.getElementById('gn-brand-navbar-bottom')?.classList.add('hide-search-bar');
-            resize();
-        }
-        return () => {
-            document.getElementById('gn-topbar')?.classList.remove('hide-navigation');
-            document.getElementById('gn-brand-navbar-bottom')?.classList.remove('hide-search-bar');
-            resize();
-        };
-    }, [loading]);
-
     return (
         <>
             {resource && <MetaTags

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -530,6 +530,12 @@
                     "containerPosition": "header",
                     "leftMenuItems": [
                         {
+                            "type": "link",
+                            "size": "md",
+                            "href": "#/all",
+                            "labelId": "gnviewer.allResources"
+                        },
+                        {
                             "type": "plugin",
                             "size": "md",
                             "name": "DetailViewerButton"
@@ -1476,6 +1482,12 @@
                     "containerPosition": "header",
                     "leftMenuItems": [
                         {
+                            "type": "link",
+                            "size": "md",
+                            "href": "#/all",
+                            "labelId": "gnviewer.allResources"
+                        },
+                        {
                             "type": "plugin",
                             "size": "md",
                             "name": "DetailViewerButton"
@@ -2206,6 +2218,12 @@
                     "containerPosition": "header",
                     "leftMenuItems": [
                         {
+                            "type": "link",
+                            "size": "md",
+                            "href": "#/all",
+                            "labelId": "gnviewer.allResources"
+                        },
+                        {
                             "type": "plugin",
                             "size": "md",
                             "name": "DetailViewerButton"
@@ -2528,6 +2546,12 @@
                     "containerPosition": "header",
                     "leftMenuItems": [
                         {
+                            "type": "link",
+                            "size": "md",
+                            "href": "#/all",
+                            "labelId": "gnviewer.allResources"
+                        },
+                        {
                             "type": "plugin",
                             "size": "md",
                             "name": "DetailViewerButton"
@@ -2778,6 +2802,12 @@
                 "cfg": {
                     "containerPosition": "header",
                     "leftMenuItems": [
+                        {
+                            "type": "link",
+                            "size": "md",
+                            "href": "#/all",
+                            "labelId": "gnviewer.allResources"
+                        },
                         {
                             "type": "plugin",
                             "size": "md",
@@ -4083,6 +4113,13 @@
                 "cfg": {
                     "containerPosition": "header",
                     "leftMenuItems": [
+                        {
+                            "type": "link",
+                            "size": "md",
+                            "href": "#/all",
+                            "labelId": "gnviewer.allResources",
+                            "disableIf": "{!!state('resourceParams')?.mapPk}"
+                        },
                         {
                             "type": "link",
                             "href": "{'#/map/' + state('resourceParams')?.mapPk}",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -404,7 +404,8 @@
                         "linkResource": "Die verknüpfte Ressource konnte nicht gespeichert werden"
                     }
                 }
-            }
+            },
+            "allResources": "All resources"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -404,7 +404,8 @@
                         "linkResource": "Failed to save linked resource"
                     }
                 }
-            }
+            },
+            "allResources": "All resources"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -403,7 +403,8 @@
                         "linkResource": "No se pudo guardar el recurso vinculado"
                     }
                 }
-            }
+            },
+            "allResources": "All resources"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -373,7 +373,8 @@
                         "linkResource": "Failed to save linked resource"
                     }
                 }
-            }
+            },
+            "allResources": "All resources"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -404,7 +404,8 @@
                         "linkResource": "Échec de l'enregistrement de la ressource liée"
                     }
                 }
-            }
+            },
+            "allResources": "All resources"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -373,7 +373,8 @@
                         "linkResource": "Failed to save linked resource"
                     }
                 }
-            }
+            },
+            "allResources": "All resources"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -406,7 +406,8 @@
                         "linkResource": "Impossibile salvare la risorsa collegata"
                     }
                 }
-            }
+            },
+            "allResources": "All resources"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -373,7 +373,8 @@
                         "linkResource": "Failed to save linked resource"
                     }
                 }
-            }
+            },
+            "allResources": "All resources"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -373,7 +373,8 @@
                         "linkResource": "Failed to save linked resource"
                     }
                 }
-            }
+            },
+            "allResources": "All resources"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -373,7 +373,8 @@
                         "linkResource": "Failed to save linked resource"
                     }
                 }
-            }
+            },
+            "allResources": "All resources"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -374,7 +374,8 @@
                         "linkResource": "Failed to save linked resource"
                     }
                 }
-            }
+            },
+            "allResources": "All resources"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -373,7 +373,8 @@
                         "linkResource": "Failed to save linked resource"
                     }
                 }
-            }
+            },
+            "allResources": "All resources"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -373,7 +373,8 @@
                         "linkResource": "Failed to save linked resource"
                     }
                 }
-            }
+            },
+            "allResources": "All resources"
         }
     }
 }


### PR DESCRIPTION
This PR introduces following changes:

- Add the `All resources` button to all viewers
- Move the hidden topbar logic from the route page to the action navbar to avoid double tobbar glitch