### PR TITLE
[Backport 4.3.x] Fix #1784 Dashboard doesn't have any CSW catalog (#1792)

### DIFF
--- a/geonode_mapstore_client/apps.py
+++ b/geonode_mapstore_client/apps.py
@@ -268,6 +268,19 @@ def run_setup_hooks(*args, **kwargs):
         "pnts",
     )
 
+    GEONODE_CATALOGUE_SERVICE = getattr(settings, "GEONODE_CATALOGUE_SERVICE", None)
+    MAPSTORE_DASHBOARD_CATALOGUE_SERVICES = {}
+    MAPSTORE_DASHBOARD_CATALOGUE_SELECTED_SERVICE = ""
+
+    if GEONODE_CATALOGUE_SERVICE:
+        MAPSTORE_DASHBOARD_CATALOGUE_SERVICES[list(list(GEONODE_CATALOGUE_SERVICE.keys()))[0]] = GEONODE_CATALOGUE_SERVICE[
+            list(list(GEONODE_CATALOGUE_SERVICE.keys()))[0]
+        ]  # noqa
+        MAPSTORE_DASHBOARD_CATALOGUE_SELECTED_SERVICE = list(list(GEONODE_CATALOGUE_SERVICE.keys()))[0]
+
+    setattr(settings, "MAPSTORE_DASHBOARD_CATALOGUE_SELECTED_SERVICE", MAPSTORE_DASHBOARD_CATALOGUE_SELECTED_SERVICE)
+    setattr(settings, "MAPSTORE_DASHBOARD_CATALOGUE_SERVICES", MAPSTORE_DASHBOARD_CATALOGUE_SERVICES)
+
 
 def connect_geoserver_style_visual_mode_signal():
     from geonode.geoserver.signals import geoserver_automatic_default_style_set

--- a/geonode_mapstore_client/context_processors.py
+++ b/geonode_mapstore_client/context_processors.py
@@ -25,6 +25,10 @@ def resource_urls(request):
         "CATALOGUE_SELECTED_SERVICE": getattr(
             settings, "MAPSTORE_CATALOGUE_SELECTED_SERVICE", None
         ),
+        "DASHBOARD_CATALOGUE_SERVICES": getattr(settings, "MAPSTORE_DASHBOARD_CATALOGUE_SERVICES", {}),
+        "DASHBOARD_CATALOGUE_SELECTED_SERVICE": getattr(
+            settings, "MAPSTORE_DASHBOARD_CATALOGUE_SELECTED_SERVICE", None
+        ),
         "CREATE_LAYER": getattr(settings, "CREATE_LAYER", False),
         "DEFAULT_MAP_CENTER_X": getattr(settings, "DEFAULT_MAP_CENTER_X", 0),
         "DEFAULT_MAP_CENTER_Y": getattr(settings, "DEFAULT_MAP_CENTER_Y", 0),

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -3034,8 +3034,8 @@
                 "cfg": {
                     "disablePluginIf": "{state('gnResourceData') && state('gnResourceData').perms && state('gnResourceData').perms.indexOf('change_resourcebase') === -1 ? true : false}",
                     "containerPosition": "leftColumn",
-                    "selectedService": "{state('settings') && state('settings').catalogueSelectedService ? state('settings').catalogueSelectedService : ''}",
-                    "services": "{state('settings') && state('settings').catalogueServices ? state('settings').catalogueServices : {}}",
+                    "selectedService": "{state('settings') && state('settings').dashboardCatalogueSelectedService ? state('settings').dashboardCatalogueSelectedService : ''}",
+                    "services": "{state('settings') && state('settings').dashboardCatalogueServices ? state('settings').dashboardCatalogueServices : {}}",
                     "disableEmptyMap": true
                 }
             },

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -57,6 +57,8 @@
         let defaultLayerFormat = geoNodeSettings.DEFAULT_LAYER_FORMAT || 'image/png';
         let catalogueServices = geoNodeSettings.CATALOGUE_SERVICES || {};
         let catalogueSelectedService = geoNodeSettings.CATALOGUE_SELECTED_SERVICE || '';
+        let dashboardCatalogueServices = geoNodeSettings.DASHBOARD_CATALOGUE_SERVICES || {};
+        let dashboardCatalogueSelectedService = geoNodeSettings.DASHBOARD_CATALOGUE_SELECTED_SERVICE || '';
         let createLayer = geoNodeSettings.CREATE_LAYER || false
         let timeEnabled = geoNodeSettings.TIME_ENABLED || false;
         let allowedDocumentTypes = geoNodeSettings.ALLOWED_DOCUMENT_TYPES || [];
@@ -183,6 +185,8 @@
                 geoNodeSettings: {
                     catalogueSelectedService: catalogueSelectedService,
                     catalogueServices: catalogueServices,
+                    dashboardCatalogueServices: dashboardCatalogueServices,
+                    dashboardCatalogueSelectedService: dashboardCatalogueSelectedService,
                     createLayer: createLayer,
                     geonodeUrl: siteUrl,
                     geoserverUrl: geoServerPublicLocation,


### PR DESCRIPTION
This PR introduces support for the following variables needed to set the dashabord catalog:

- `MAPSTORE_DASHBOARD_CATALOGUE_SERVICES`
- `MAPSTORE_DASHBOARD_CATALOGUE_SELECTED_SERVICE`