### PR TITLE
[Backport 4.3.x] Fix #Request to rest/geostore in latest version when loading dashboard (#1814)

### DIFF
--- a/geonode_mapstore_client/client/js/apps/gn-catalogue.js
+++ b/geonode_mapstore_client/client/js/apps/gn-catalogue.js
@@ -78,7 +78,7 @@ import gnsearchEpics from '@js/epics/gnsearch';
 import favoriteEpics from '@js/epics/favorite';
 import maplayout from '@mapstore/framework/reducers/maplayout';
 
-import pluginsDefinition, { storeEpicsNamesToExclude } from '@js/plugins/index';
+import pluginsDefinition, { storeEpicsNamesToExclude, cleanEpics } from '@js/plugins/index';
 import ReactSwipe from 'react-swipeable-views';
 import SwipeHeader from '@mapstore/framework/components/data/identify/SwipeHeader';
 
@@ -138,7 +138,7 @@ getEndpoints()
                     const mapLayout = getConfigProp('mapLayout') || {};
                     setConfigProp('mapLayout', mapLayout[query.theme] || mapLayout.viewer);
 
-                    const appEpics = {
+                    const appEpics = cleanEpics({
                         ...standardEpics,
                         ...configEpics,
                         gnCheckSelectedDatasetPermissions,
@@ -151,7 +151,7 @@ getEndpoints()
                         updateMapLayoutEpic,
                         // needed to initialize the correct time range
                         ...timelineEpics
-                    };
+                    });
 
                     storeEpicsNamesToExclude(appEpics);
 

--- a/geonode_mapstore_client/client/js/apps/gn-components.js
+++ b/geonode_mapstore_client/client/js/apps/gn-components.js
@@ -22,7 +22,7 @@ import {
     getPluginsConfiguration,
     getPluginsConfigOverride
 } from '@js/utils/AppUtils';
-import pluginsDefinition, { storeEpicsNamesToExclude } from '@js/plugins/index';
+import pluginsDefinition, { storeEpicsNamesToExclude, cleanEpics } from '@js/plugins/index';
 import StandardApp from '@mapstore/framework/components/app/StandardApp';
 import withExtensions from '@mapstore/framework/components/app/withExtensions';
 import gnsettings from '@js/reducers/gnsettings';
@@ -62,9 +62,9 @@ document.addEventListener('DOMContentLoaded', function() {
                         settings
                     }) => {
 
-                        const appEpics = {
+                        const appEpics = cleanEpics({
                             ...configEpics
-                        };
+                        });
 
                         storeEpicsNamesToExclude(appEpics);
 

--- a/geonode_mapstore_client/client/js/apps/gn-dashboard.js
+++ b/geonode_mapstore_client/client/js/apps/gn-dashboard.js
@@ -30,7 +30,7 @@ import {
     getPluginsConfigOverride
 } from '@js/utils/AppUtils';
 import { ResourceTypes } from '@js/utils/ResourceUtils';
-import pluginsDefinition, { storeEpicsNamesToExclude } from '@js/plugins/index';
+import pluginsDefinition, { storeEpicsNamesToExclude, cleanEpics } from '@js/plugins/index';
 import ReactSwipe from 'react-swipeable-views';
 import SwipeHeader from '@mapstore/framework/components/data/identify/SwipeHeader';
 import { requestResourceConfig } from '@js/actions/gnresource';
@@ -77,10 +77,10 @@ document.addEventListener('DOMContentLoaded', function() {
                         settings
                     }) => {
 
-                        const appEpics = {
+                        const appEpics = cleanEpics({
                             ...configEpics,
                             ...gnresourceEpics
-                        };
+                        });
 
                         storeEpicsNamesToExclude(appEpics);
 

--- a/geonode_mapstore_client/client/js/apps/gn-document.js
+++ b/geonode_mapstore_client/client/js/apps/gn-document.js
@@ -26,7 +26,7 @@ import {
     getPluginsConfigOverride
 } from '@js/utils/AppUtils';
 import { ResourceTypes } from '@js/utils/ResourceUtils';
-import pluginsDefinition, { storeEpicsNamesToExclude } from '@js/plugins/index';
+import pluginsDefinition, { storeEpicsNamesToExclude, cleanEpics } from '@js/plugins/index';
 import ReactSwipe from 'react-swipeable-views';
 import SwipeHeader from '@mapstore/framework/components/data/identify/SwipeHeader';
 import { requestResourceConfig } from '@js/actions/gnresource';
@@ -71,10 +71,10 @@ document.addEventListener('DOMContentLoaded', function() {
                         settings
                     }) => {
 
-                        const appEpics = {
+                        const appEpics = cleanEpics({
                             ...configEpics,
                             ...gnresourceEpics
-                        };
+                        });
 
                         storeEpicsNamesToExclude(appEpics);
 

--- a/geonode_mapstore_client/client/js/apps/gn-geostory.js
+++ b/geonode_mapstore_client/client/js/apps/gn-geostory.js
@@ -32,7 +32,7 @@ import {
     getPluginsConfigOverride
 } from '@js/utils/AppUtils';
 import { ResourceTypes } from '@js/utils/ResourceUtils';
-import pluginsDefinition, { storeEpicsNamesToExclude } from '@js/plugins/index';
+import pluginsDefinition, { storeEpicsNamesToExclude, cleanEpics } from '@js/plugins/index';
 import ReactSwipe from 'react-swipeable-views';
 import SwipeHeader from '@mapstore/framework/components/data/identify/SwipeHeader';
 const requires = {
@@ -80,10 +80,10 @@ document.addEventListener('DOMContentLoaded', function() {
                         settings
                     }) => {
 
-                        const appEpics = {
+                        const appEpics = cleanEpics({
                             ...configEpics,
                             ...gnresourceEpics
-                        };
+                        });
 
                         storeEpicsNamesToExclude(appEpics);
 

--- a/geonode_mapstore_client/client/js/apps/gn-map.js
+++ b/geonode_mapstore_client/client/js/apps/gn-map.js
@@ -67,7 +67,7 @@ import maplayout from '@mapstore/framework/reducers/maplayout';
 import 'react-widgets/dist/css/react-widgets.css';
 import 'react-select/dist/react-select.css';
 
-import pluginsDefinition, { storeEpicsNamesToExclude } from '@js/plugins/index';
+import pluginsDefinition, { storeEpicsNamesToExclude, cleanEpics } from '@js/plugins/index';
 import ReactSwipe from 'react-swipeable-views';
 import SwipeHeader from '@mapstore/framework/components/data/identify/SwipeHeader';
 const requires = {
@@ -120,7 +120,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
                         const resourceId = geoNodePageConfig.resourceId;
 
-                        const appEpics = {
+                        const appEpics = cleanEpics({
                             ...standardEpics,
                             ...configEpics,
                             updateMapLayoutEpic,
@@ -130,7 +130,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             ...pluginsDefinition.epics,
                             // needed to initialize the correct time range
                             ...timelineEpics
-                        };
+                        });
 
                         storeEpicsNamesToExclude(appEpics);
 

--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -21,7 +21,8 @@ let epicsNamesToExclude = [
     'loadGeostoryEpic',
     'reloadGeoStoryOnLoginLogout',
     'loadStoryOnHistoryPop',
-    'saveGeoStoryResource'
+    'saveGeoStoryResource',
+    'storeDetailsInfoDashboardEpic'
 ];
 
 // we need to exclude epics that have been initialized already at app level
@@ -32,7 +33,7 @@ export const storeEpicsNamesToExclude = (epics) => {
     epicsNamesToExclude = uniq(epicsNamesToExclude);
 };
 
-function cleanEpics(epics, excludedNames = []) {
+export function cleanEpics(epics, excludedNames = epicsNamesToExclude) {
     const containsExcludedEpic = !!excludedNames.find((epicName) => epics[epicName]);
     if (containsExcludedEpic) {
         return omit(epics, excludedNames);


### PR DESCRIPTION
This storeDetailsInfoDashboardEpic introduced in latest version of mapstore should not be used by geonode because includes actions related to geostore the default MapStore backend.
This PR removes storeDetailsInfoDashboardEpic from the epic included in geonode because it's adding a not needed  request 