### PR TITLE
[Backport 4.3.x] Fix #1811 Dataset viewer breaks when clicking a linked dataset (#1816)

### DIFF
--- a/geonode_mapstore_client/client/js/routes/Viewer.jsx
+++ b/geonode_mapstore_client/client/js/routes/Viewer.jsx
@@ -81,8 +81,8 @@ function ViewerRoute({
         pluginsConfig
     });
 
-    const viewer = useRef({ resourceLoaded: false, prevPluginsLength: null });
-    const { resourceLoaded, prevPluginsLength } = viewer.current ?? {};
+    const viewer = useRef({ requestedPk: '', prevPluginsLength: null });
+    const { requestedPk, prevPluginsLength } = viewer.current ?? {};
     useEffect(() => {
         if (!prevPluginsLength || pluginsCfgLength === 0) {
             // to ensure and prevent loading and requesting of resource configurations
@@ -93,8 +93,8 @@ function ViewerRoute({
 
     const pluginLoading = prevPluginsLength !== null && prevPluginsLength !== pluginsCfgLength ? false : pending;
     useEffect(() => {
-        if (!pluginLoading && !resourceLoaded && pk !== undefined) {
-            viewer.current.resourceLoaded = true;
+        if (!pluginLoading && pk !== requestedPk) {
+            viewer.current.requestedPk = pk;
             if (pk === 'new') {
                 onCreate(resourceType, {
                     params: match.params

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -175,7 +175,7 @@ export const resourceToLayerConfig = (resource) => {
     }
 };
 
-function updateUrlQueryParameter(requestUrl, query) {
+function updateUrlQueryParameter(requestUrl = '', query) {
     const parsedUrl = url.parse(requestUrl, true);
     return url.format({
         ...parsedUrl,


### PR DESCRIPTION
This PR improve the Viewer route checks to allows resource update for the same resource_type