### PR TITLE
[Backport 4.3.x] Fix #1827 Infinite loading for dataset embed (#1828)

### DIFF
--- a/geonode_mapstore_client/client/js/api/geonode/user/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/user/index.js
@@ -16,7 +16,7 @@ import { getGeoNodeLocalConfig, parseDevHostname } from "@js/utils/APIUtils";
 
 export const getUserInfo = (apikey) => {
     const endpointV1 = getGeoNodeLocalConfig('geoNodeApi.endpointV1', '/api');
-    return axios.get(`${parseDevHostname(endpointV1)}/o/v4/userinfo`, {
+    return axios.get(parseDevHostname(`${endpointV1}/o/v4/userinfo`), {
         params: {
             ...(apikey && { apikey })
         }

--- a/geonode_mapstore_client/client/js/routes/Viewer.jsx
+++ b/geonode_mapstore_client/client/js/routes/Viewer.jsx
@@ -81,7 +81,7 @@ function ViewerRoute({
         pluginsConfig
     });
 
-    const viewer = useRef({ requestedPk: '', prevPluginsLength: null });
+    const viewer = useRef({ requestedPk: undefined, prevPluginsLength: null });
     const { requestedPk, prevPluginsLength } = viewer.current ?? {};
     useEffect(() => {
         if (!prevPluginsLength || pluginsCfgLength === 0) {


### PR DESCRIPTION
This PR fixes the primary key comparison in the Viewer component that was causing the infinite loading of dataset