### PR TITLE
Fix #1818 Missing connection between map and viewer

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -215,7 +215,7 @@ const resourceTypes = {
                 getNewMapConfiguration(),
                 getMapByPk(pk)
                     .then((resource) => {
-                        const mapViewers = get(resource, 'linkedResources.linkedTo', [])
+                        const mapViewers = get(resource, 'linked_resources.linked_to', [])
                             .find(({ resource_type: type } = {}) => type === ResourceTypes.VIEWER);
                         return mapViewers?.pk
                             ? axios.all([{...resource}, getGeoAppByPk(mapViewers?.pk, {api_preset: 'catalog_list', include: ['data', 'linked_resources']})])


### PR DESCRIPTION
The updates introduced in #1819 were missing the refactor of map viewer linked resources property.
The map workflow was still using the parsed linked resources instead the resources one (the difference is in the variable case style)