### PR TITLE
Fix #1813 Use sourcetpye instead of subtype for filtering remote resources

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/ResourcesGrid.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ResourcesGrid.jsx
@@ -353,6 +353,11 @@ function ResourcesGrid({
                     disableIf: '{!state("user")}'
                 },
                 {
+                    id: 'remote',
+                    labelId: 'gnhome.remote',
+                    type: 'filter'
+                },
+                {
                     id: 'dataset',
                     labelId: 'gnhome.datasets',
                     type: 'filter',
@@ -365,11 +370,6 @@ function ResourcesGrid({
                         {
                             id: 'store-raster',
                             labelId: 'gnhome.raster',
-                            type: 'filter'
-                        },
-                        {
-                            id: 'store-remote',
-                            labelId: 'gnhome.remote',
                             type: 'filter'
                         },
                         {

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -562,7 +562,6 @@
                                     "type": "plugin",
                                     "name": "DeleteResource",
                                     "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'delete_resourcebase')}"
-                                    
                                 }
                             ]
                         },
@@ -2099,14 +2098,14 @@
                 "name": "LayerSettings",
                 "mandatory": true,
                 "cfg": {
-                    "disablePluginIf":"{context.hasDefaultSettings(state('selectedLayer'))}"
+                    "disablePluginIf": "{context.hasDefaultSettings(state('selectedLayer'))}"
                 }
             },
             {
                 "name": "TOCItemsSettings",
                 "mandatory": true,
                 "cfg": {
-                    "disablePluginIf":"{!context.hasDefaultSettings(state('selectedLayer'))}"
+                    "disablePluginIf": "{!context.hasDefaultSettings(state('selectedLayer'))}"
                 }
             },
             {
@@ -2826,7 +2825,6 @@
                                     "type": "plugin",
                                     "name": "Save",
                                     "disableIf": "{!state('isNewResource') && !context.resourceHasPermission(state('gnResourceData'), 'change_resourcebase') && !context.canCopyResource(state('gnResourceData'), state('user'))}"
-
                                 },
                                 {
                                     "type": "plugin",
@@ -3606,80 +3604,80 @@
                         ],
                         "filtersFormItems": [
                             {
-                              "type": "search"
+                                "type": "search"
                             },
                             {
-                              "type": "group",
-                              "labelId": "gnhome.customFiltersTitle",
-                              "items": [
-                                {
-                                  "id": "my-resources",
-                                  "labelId": "gnhome.myResources",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "favorite",
-                                  "labelId": "gnhome.favorites",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "featured",
-                                  "labelId": "gnhome.featuredList",
-                                  "type": "filter"
-                                },
-                                {
-                                  "id": "unpublished",
-                                  "labelId": "gnhome.unpublished",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "pending-approval",
-                                  "labelId": "gnhome.pendingApproval",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                }
-                              ]
+                                "type": "group",
+                                "labelId": "gnhome.customFiltersTitle",
+                                "items": [
+                                    {
+                                        "id": "my-resources",
+                                        "labelId": "gnhome.myResources",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "favorite",
+                                        "labelId": "gnhome.favorites",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "featured",
+                                        "labelId": "gnhome.featuredList",
+                                        "type": "filter"
+                                    },
+                                    {
+                                        "id": "unpublished",
+                                        "labelId": "gnhome.unpublished",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "pending-approval",
+                                        "labelId": "gnhome.pendingApproval",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    }
+                                ]
                             },
                             {
-                              "type": "divider",
-                              "disableIf": "{!state('user')}"
+                                "type": "divider",
+                                "disableIf": "{!state('user')}"
                             },
                             {
-                              "type": "select",
-                              "facet": "category"
+                                "type": "select",
+                                "facet": "category"
                             },
                             {
-                              "type": "select",
-                              "facet": "keyword"
+                                "type": "select",
+                                "facet": "keyword"
                             },
                             {
-                              "type": "select",
-                              "facet": "place"
+                                "type": "select",
+                                "facet": "place"
                             },
                             {
-                              "type": "select",
-                              "facet": "user"
+                                "type": "select",
+                                "facet": "user"
                             },
                             {
-                              "type": "select",
-                              "facet": "group"
+                                "type": "select",
+                                "facet": "group"
                             },
                             {
-                              "type": "accordion",
-                              "style": "facet",
-                              "facet": "thesaurus"
+                                "type": "accordion",
+                                "style": "facet",
+                                "facet": "thesaurus"
                             },
                             {
-                              "type": "date-range",
-                              "filterKey": "date",
-                              "labelId": "gnviewer.dateFilter"
+                                "type": "date-range",
+                                "filterKey": "date",
+                                "labelId": "gnviewer.dateFilter"
                             },
                             {
-                              "labelId": "gnviewer.extent",
-                              "type": "extent"
+                                "labelId": "gnviewer.extent",
+                                "type": "extent"
                             }
                         ]
                     },
@@ -3688,186 +3686,191 @@
                             "resource": "document"
                         },
                         "menuItems": [
-                          {
-                            "disableIf": "{(state('settings') && state('settings').isMobile) || !(state('user') && state('user').perms && state('user').perms.includes('add_resource')) ? true : false}",
-                            "variant": "primary",
-                            "labelId": "gnhome.new",
-                            "value": "document",
-                            "type": "link",
-                            "href": "{context.getCataloguePath('/catalogue/#/upload/document')}"
-                          }
+                            {
+                                "disableIf": "{(state('settings') && state('settings').isMobile) || !(state('user') && state('user').perms && state('user').perms.includes('add_resource')) ? true : false}",
+                                "variant": "primary",
+                                "labelId": "gnhome.new",
+                                "value": "document",
+                                "type": "link",
+                                "href": "{context.getCataloguePath('/catalogue/#/upload/document')}"
+                            }
                         ],
                         "filtersFormItems": [
                             {
-                              "type": "search"
+                                "type": "search"
                             },
                             {
-                              "type": "group",
-                              "labelId": "gnhome.customFiltersTitle",
-                              "items": [
-                                {
-                                  "id": "my-resources",
-                                  "labelId": "gnhome.myResources",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "favorite",
-                                  "labelId": "gnhome.favorites",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "featured",
-                                  "labelId": "gnhome.featuredList",
-                                  "type": "filter"
-                                },
-                                {
-                                  "id": "unpublished",
-                                  "labelId": "gnhome.unpublished",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "pending-approval",
-                                  "labelId": "gnhome.pendingApproval",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                }
-                              ]
+                                "type": "group",
+                                "labelId": "gnhome.customFiltersTitle",
+                                "items": [
+                                    {
+                                        "id": "my-resources",
+                                        "labelId": "gnhome.myResources",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "favorite",
+                                        "labelId": "gnhome.favorites",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "featured",
+                                        "labelId": "gnhome.featuredList",
+                                        "type": "filter"
+                                    },
+                                    {
+                                        "id": "unpublished",
+                                        "labelId": "gnhome.unpublished",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "pending-approval",
+                                        "labelId": "gnhome.pendingApproval",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "remote",
+                                        "labelId": "gnhome.remote",
+                                        "type": "filter"
+                                    }
+                                ]
                             },
                             {
-                              "type": "divider",
-                              "disableIf": "{!state('user')}"
+                                "type": "divider",
+                                "disableIf": "{!state('user')}"
                             },
                             {
-                              "type": "select",
-                              "facet": "category"
+                                "type": "select",
+                                "facet": "category"
                             },
                             {
-                              "type": "select",
-                              "facet": "keyword"
+                                "type": "select",
+                                "facet": "keyword"
                             },
                             {
-                              "type": "select",
-                              "facet": "place"
+                                "type": "select",
+                                "facet": "place"
                             },
                             {
-                              "type": "select",
-                              "facet": "user"
+                                "type": "select",
+                                "facet": "user"
                             },
                             {
-                              "type": "select",
-                              "facet": "group"
+                                "type": "select",
+                                "facet": "group"
                             },
                             {
-                              "type": "accordion",
-                              "style": "facet",
-                              "facet": "thesaurus"
+                                "type": "accordion",
+                                "style": "facet",
+                                "facet": "thesaurus"
                             },
                             {
-                              "type": "date-range",
-                              "filterKey": "date",
-                              "labelId": "gnviewer.dateFilter"
+                                "type": "date-range",
+                                "filterKey": "date",
+                                "labelId": "gnviewer.dateFilter"
                             },
                             {
-                              "labelId": "gnviewer.extent",
-                              "type": "extent"
+                                "labelId": "gnviewer.extent",
+                                "type": "extent"
                             }
-                          ]
+                        ]
                     },
                     "dashboardsPage": {
                         "defaultQuery": {
                             "resource": "dashboard"
                         },
                         "menuItems": [
-                          {
-                            "disableIf": "{(state('settings') && state('settings').isMobile) || !(state('user') && state('user').perms && state('user').perms.includes('add_resource'))}",
-                            "variant": "primary",
-                            "labelId": "gnhome.new",
-                            "value": "dashboard",
-                            "type": "link",
-                            "href": "{context.getCataloguePath('/catalogue/#/dashboard/new')}"
-                          }
+                            {
+                                "disableIf": "{(state('settings') && state('settings').isMobile) || !(state('user') && state('user').perms && state('user').perms.includes('add_resource'))}",
+                                "variant": "primary",
+                                "labelId": "gnhome.new",
+                                "value": "dashboard",
+                                "type": "link",
+                                "href": "{context.getCataloguePath('/catalogue/#/dashboard/new')}"
+                            }
                         ],
                         "filtersFormItems": [
                             {
-                              "type": "search"
+                                "type": "search"
                             },
                             {
-                              "type": "group",
-                              "labelId": "gnhome.customFiltersTitle",
-                              "items": [
-                                {
-                                  "id": "my-resources",
-                                  "labelId": "gnhome.myResources",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "favorite",
-                                  "labelId": "gnhome.favorites",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "featured",
-                                  "labelId": "gnhome.featuredList",
-                                  "type": "filter"
-                                },
-                                {
-                                  "id": "unpublished",
-                                  "labelId": "gnhome.unpublished",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "pending-approval",
-                                  "labelId": "gnhome.pendingApproval",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                }
-                              ]
+                                "type": "group",
+                                "labelId": "gnhome.customFiltersTitle",
+                                "items": [
+                                    {
+                                        "id": "my-resources",
+                                        "labelId": "gnhome.myResources",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "favorite",
+                                        "labelId": "gnhome.favorites",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "featured",
+                                        "labelId": "gnhome.featuredList",
+                                        "type": "filter"
+                                    },
+                                    {
+                                        "id": "unpublished",
+                                        "labelId": "gnhome.unpublished",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "pending-approval",
+                                        "labelId": "gnhome.pendingApproval",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    }
+                                ]
                             },
                             {
-                              "type": "divider",
-                              "disableIf": "{!state('user')}"
+                                "type": "divider",
+                                "disableIf": "{!state('user')}"
                             },
                             {
-                              "type": "select",
-                              "facet": "category"
+                                "type": "select",
+                                "facet": "category"
                             },
                             {
-                              "type": "select",
-                              "facet": "keyword"
+                                "type": "select",
+                                "facet": "keyword"
                             },
                             {
-                              "type": "select",
-                              "facet": "place"
+                                "type": "select",
+                                "facet": "place"
                             },
                             {
-                              "type": "select",
-                              "facet": "user"
+                                "type": "select",
+                                "facet": "user"
                             },
                             {
-                              "type": "select",
-                              "facet": "group"
+                                "type": "select",
+                                "facet": "group"
                             },
                             {
-                              "type": "accordion",
-                              "style": "facet",
-                              "facet": "thesaurus"
+                                "type": "accordion",
+                                "style": "facet",
+                                "facet": "thesaurus"
                             },
                             {
-                              "type": "date-range",
-                              "filterKey": "date",
-                              "labelId": "gnviewer.dateFilter"
+                                "type": "date-range",
+                                "filterKey": "date",
+                                "labelId": "gnviewer.dateFilter"
                             },
                             {
-                              "labelId": "gnviewer.extent",
-                              "type": "extent"
+                                "labelId": "gnviewer.extent",
+                                "type": "extent"
                             }
-                          ]
+                        ]
                     },
                     "datasetsPage": {
                         "defaultQuery": {
@@ -3882,129 +3885,129 @@
                                 "responsive": true,
                                 "noCaret": true,
                                 "items": [
-                                  {
-                                    "labelId": "gnhome.uploadDataset",
-                                    "value": "layer",
-                                    "type": "link",
-                                    "href": "{context.getCataloguePath('/catalogue/#/upload/dataset')}"
-                                  },
-                                  {
-                                    "labelId": "gnhome.createDataset",
-                                    "value": "layer",
-                                    "type": "link",
-                                    "href": "/createlayer/",
-                                    "disableIf": "{!(state('settings') && state('settings').createLayer)}"
-                                  },
-                                  {
-                                    "labelId": "gnhome.remoteServices",
-                                    "value": "remote",
-                                    "type": "link",
-                                    "href": "/services/?limit=5"
-                                  }
+                                    {
+                                        "labelId": "gnhome.uploadDataset",
+                                        "value": "layer",
+                                        "type": "link",
+                                        "href": "{context.getCataloguePath('/catalogue/#/upload/dataset')}"
+                                    },
+                                    {
+                                        "labelId": "gnhome.createDataset",
+                                        "value": "layer",
+                                        "type": "link",
+                                        "href": "/createlayer/",
+                                        "disableIf": "{!(state('settings') && state('settings').createLayer)}"
+                                    },
+                                    {
+                                        "labelId": "gnhome.remoteServices",
+                                        "value": "remote",
+                                        "type": "link",
+                                        "href": "/services/?limit=5"
+                                    }
                                 ]
                             }
                         ],
                         "filtersFormItems": [
                             {
-                              "type": "search"
+                                "type": "search"
                             },
                             {
-                              "type": "group",
-                              "labelId": "gnhome.customFiltersTitle",
-                              "items": [
-                                {
-                                  "id": "my-resources",
-                                  "labelId": "gnhome.myResources",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "favorite",
-                                  "labelId": "gnhome.favorites",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "featured",
-                                  "labelId": "gnhome.featuredList",
-                                  "type": "filter"
-                                },
-                                {
-                                  "id": "unpublished",
-                                  "labelId": "gnhome.unpublished",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "pending-approval",
-                                  "labelId": "gnhome.pendingApproval",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                    "id": "store-vector",
-                                    "labelId": "gnhome.vector",
-                                    "type": "filter"
-                                  },
-                                  {
-                                    "id": "store-raster",
-                                    "labelId": "gnhome.raster",
-                                    "type": "filter"
-                                  },
-                                  {
-                                    "id": "store-remote",
-                                    "labelId": "gnhome.remote",
-                                    "type": "filter"
-                                  },
-                                  {
-                                    "id": "store-time-series",
-                                    "labelId": "gnhome.timeSeries",
-                                    "type": "filter"
-                                  },
-                                  {
-                                    "id": "3dtiles",
-                                    "labelId": "gnhome.3dtiles",
-                                    "type": "filter"
-                                  }
-                              ]
+                                "type": "group",
+                                "labelId": "gnhome.customFiltersTitle",
+                                "items": [
+                                    {
+                                        "id": "my-resources",
+                                        "labelId": "gnhome.myResources",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "favorite",
+                                        "labelId": "gnhome.favorites",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "featured",
+                                        "labelId": "gnhome.featuredList",
+                                        "type": "filter"
+                                    },
+                                    {
+                                        "id": "unpublished",
+                                        "labelId": "gnhome.unpublished",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "pending-approval",
+                                        "labelId": "gnhome.pendingApproval",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "remote",
+                                        "labelId": "gnhome.remote",
+                                        "type": "filter"
+                                    },
+                                    {
+                                        "id": "store-vector",
+                                        "labelId": "gnhome.vector",
+                                        "type": "filter"
+                                    },
+                                    {
+                                        "id": "store-raster",
+                                        "labelId": "gnhome.raster",
+                                        "type": "filter"
+                                    },
+                                    {
+                                        "id": "store-time-series",
+                                        "labelId": "gnhome.timeSeries",
+                                        "type": "filter"
+                                    },
+                                    {
+                                        "id": "3dtiles",
+                                        "labelId": "gnhome.3dtiles",
+                                        "type": "filter"
+                                    }
+                                ]
                             },
                             {
-                              "type": "divider",
-                              "disableIf": "{!state('user')}"
+                                "type": "divider",
+                                "disableIf": "{!state('user')}"
                             },
                             {
-                              "type": "select",
-                              "facet": "category"
+                                "type": "select",
+                                "facet": "category"
                             },
                             {
-                              "type": "select",
-                              "facet": "keyword"
+                                "type": "select",
+                                "facet": "keyword"
                             },
                             {
-                              "type": "select",
-                              "facet": "place"
+                                "type": "select",
+                                "facet": "place"
                             },
                             {
-                              "type": "select",
-                              "facet": "user"
+                                "type": "select",
+                                "facet": "user"
                             },
                             {
-                              "type": "select",
-                              "facet": "group"
+                                "type": "select",
+                                "facet": "group"
                             },
                             {
-                              "type": "accordion",
-                              "style": "facet",
-                              "facet": "thesaurus"
+                                "type": "accordion",
+                                "style": "facet",
+                                "facet": "thesaurus"
                             },
                             {
-                              "type": "date-range",
-                              "filterKey": "date",
-                              "labelId": "gnviewer.dateFilter"
+                                "type": "date-range",
+                                "filterKey": "date",
+                                "labelId": "gnviewer.dateFilter"
                             },
                             {
-                              "labelId": "gnviewer.extent",
-                              "type": "extent"
+                                "labelId": "gnviewer.extent",
+                                "type": "extent"
                             }
                         ]
                     },
@@ -4013,93 +4016,93 @@
                             "resource": "geostory"
                         },
                         "menuItems": [
-                          {
-                            "disableIf": "{(state('settings') && state('settings').isMobile) || !(state('user') && state('user').perms && state('user').perms.includes('add_resource'))}",
-                            "variant": "primary",
-                            "labelId": "gnhome.new",
-                            "value": "geostory",
-                            "type": "link",
-                            "href": "{context.getCataloguePath('/catalogue/#/geostory/new')}"
-                          }
+                            {
+                                "disableIf": "{(state('settings') && state('settings').isMobile) || !(state('user') && state('user').perms && state('user').perms.includes('add_resource'))}",
+                                "variant": "primary",
+                                "labelId": "gnhome.new",
+                                "value": "geostory",
+                                "type": "link",
+                                "href": "{context.getCataloguePath('/catalogue/#/geostory/new')}"
+                            }
                         ],
                         "filtersFormItems": [
                             {
-                              "type": "search"
+                                "type": "search"
                             },
                             {
-                              "type": "group",
-                              "labelId": "gnhome.customFiltersTitle",
-                              "items": [
-                                {
-                                  "id": "my-resources",
-                                  "labelId": "gnhome.myResources",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "favorite",
-                                  "labelId": "gnhome.favorites",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "featured",
-                                  "labelId": "gnhome.featuredList",
-                                  "type": "filter"
-                                },
-                                {
-                                  "id": "unpublished",
-                                  "labelId": "gnhome.unpublished",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                },
-                                {
-                                  "id": "pending-approval",
-                                  "labelId": "gnhome.pendingApproval",
-                                  "type": "filter",
-                                  "disableIf": "{!state('user')}"
-                                }
-                              ]
+                                "type": "group",
+                                "labelId": "gnhome.customFiltersTitle",
+                                "items": [
+                                    {
+                                        "id": "my-resources",
+                                        "labelId": "gnhome.myResources",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "favorite",
+                                        "labelId": "gnhome.favorites",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "featured",
+                                        "labelId": "gnhome.featuredList",
+                                        "type": "filter"
+                                    },
+                                    {
+                                        "id": "unpublished",
+                                        "labelId": "gnhome.unpublished",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    },
+                                    {
+                                        "id": "pending-approval",
+                                        "labelId": "gnhome.pendingApproval",
+                                        "type": "filter",
+                                        "disableIf": "{!state('user')}"
+                                    }
+                                ]
                             },
                             {
-                              "type": "divider",
-                              "disableIf": "{!state('user')}"
+                                "type": "divider",
+                                "disableIf": "{!state('user')}"
                             },
                             {
-                              "type": "select",
-                              "facet": "category"
+                                "type": "select",
+                                "facet": "category"
                             },
                             {
-                              "type": "select",
-                              "facet": "keyword"
+                                "type": "select",
+                                "facet": "keyword"
                             },
                             {
-                              "type": "select",
-                              "facet": "place"
+                                "type": "select",
+                                "facet": "place"
                             },
                             {
-                              "type": "select",
-                              "facet": "user"
+                                "type": "select",
+                                "facet": "user"
                             },
                             {
-                              "type": "select",
-                              "facet": "group"
+                                "type": "select",
+                                "facet": "group"
                             },
                             {
-                              "type": "accordion",
-                              "style": "facet",
-                              "facet": "thesaurus"
+                                "type": "accordion",
+                                "style": "facet",
+                                "facet": "thesaurus"
                             },
                             {
-                              "type": "date-range",
-                              "filterKey": "date",
-                              "labelId": "gnviewer.dateFilter"
+                                "type": "date-range",
+                                "filterKey": "date",
+                                "labelId": "gnviewer.dateFilter"
                             },
                             {
-                              "labelId": "gnviewer.extent",
-                              "type": "extent"
+                                "labelId": "gnviewer.extent",
+                                "type": "extent"
                             }
-                          ]
+                        ]
                     }
                 }
             },

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -87,6 +87,9 @@
             "pending-approval": {
                 "filter{is_approved}": false
             },
+            "remote": {
+                "filter{sourcetype.in}": "REMOTE"
+            },
             "dataset": {
                 "filter{resource_type.in}": "dataset"
             },


### PR DESCRIPTION
This PR remove the filter `filter{subtype.in}=remote` in favor of `filter{sourcetype.in}=REMOTE`. This new filter has been included also in the documents page