### PR TITLE
Homepage filters

### DIFF
--- a/geonode_mapstore_client/client/js/actions/gnsearch.js
+++ b/geonode_mapstore_client/client/js/actions/gnsearch.js
@@ -21,6 +21,7 @@ export const GET_FACET_ITEMS = 'GEONODE:GET_FACET_ITEMS';
 export const SET_FACET_ITEMS = 'GEONODE:SET_FACET_ITEMS';
 export const GET_FACET_FILTERS = 'GEONODE:GET_FACET_FILTERS';
 export const SET_FILTERS = "SET_FILTERS";
+export const SHOW_FILTER_FORM = "GEONODE:SHOW_FILTER_FORM";
 
 /**
 * Actions for GeoNode resource featured items
@@ -140,6 +141,13 @@ export function setFilters(filters) {
     };
 }
 
+export function showFilterForm(show) {
+    return {
+        type: SHOW_FILTER_FORM,
+        show
+    };
+}
+
 export default {
     SEARCH_RESOURCES,
     searchResources,
@@ -151,5 +159,7 @@ export default {
     requestResource,
     setFeaturedResources,
     SET_SEARCH_CONFIG,
-    setSearchConfig
+    setSearchConfig,
+    SHOW_FILTER_FORM,
+    showFilterForm
 };

--- a/geonode_mapstore_client/client/js/components/FiltersMenu/FiltersMenu.jsx
+++ b/geonode_mapstore_client/client/js/components/FiltersMenu/FiltersMenu.jsx
@@ -32,7 +32,8 @@ const FiltersMenu = forwardRef(({
     loading,
     hideCardLayoutButton,
     cardLayoutStyle,
-    setCardLayoutStyle
+    setCardLayoutStyle,
+    disableFilters
 }, ref) => {
 
     const { isMobile } = getConfigProp('geoNodeSettings');
@@ -50,22 +51,24 @@ const FiltersMenu = forwardRef(({
             <div className="gn-menu-container">
                 <div className="gn-menu-content">
                     <div className="gn-menu-fill">
-                        {totalFilters > 0 ? <ButtonWithTooltip
-                            variant="primary"
-                            size="sm"
-                            onClick={onClick}
-                            className="gn-success-changes-icon"
-                            tooltip={<Message msgId="gnhome.filterApplied" msgParams={{ count: totalFilters }}/>}
-                        >
-                            {isMobile ? <FaIcon name="filter" /> : <Message msgId="gnhome.filter"/>}
-                        </ButtonWithTooltip> : <Button
-                            variant="primary"
-                            size="sm"
-                            onClick={onClick}
-                        >
-                            {isMobile ? <FaIcon name="filter" /> : <Message msgId="gnhome.filter"/>}
-                        </Button>}
-                        {' '}
+                        {!disableFilters && <>
+                            {totalFilters > 0 ? <ButtonWithTooltip
+                                variant="primary"
+                                size="sm"
+                                onClick={onClick}
+                                className="gn-success-changes-icon"
+                                tooltip={<Message msgId="gnhome.filterApplied" msgParams={{ count: totalFilters }}/>}
+                            >
+                                {isMobile ? <FaIcon name="filter" /> : <Message msgId="gnhome.filter"/>}
+                            </ButtonWithTooltip> : <Button
+                                variant="primary"
+                                size="sm"
+                                onClick={onClick}
+                            >
+                                {isMobile ? <FaIcon name="filter" /> : <Message msgId="gnhome.filter"/>}
+                            </Button>}
+                            {' '}
+                        </>}
                         {loading ? <span className="resources-count-loading"><Spinner /></span> : <Badge>
                             <span className="resources-count"> <Message msgId="gnhome.resourcesFound" msgParams={{ count: totalResources }}/> </span>
                         </Badge>}

--- a/geonode_mapstore_client/client/js/plugins/ResourcesGrid.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ResourcesGrid.jsx
@@ -30,8 +30,8 @@ import {
 import { withResizeDetector } from 'react-resize-detector';
 import { userSelector } from '@mapstore/framework/selectors/security';
 import ConnectedCardGrid from '@js/plugins/resourcesgrid/ConnectedCardGrid';
-import { getTotalResources, getFacetsItems } from '@js/selectors/search';
-import { searchResources, setSearchConfig, getFacetItems, setFilters as setFiltersAction } from '@js/actions/gnsearch';
+import { getTotalResources, getFacetsItems, getShowFilterForm } from '@js/selectors/search';
+import { searchResources, setSearchConfig, getFacetItems, setFilters as setFiltersAction, showFilterForm as showFilterFormAction } from '@js/actions/gnsearch';
 
 import gnsearch from '@js/reducers/gnsearch';
 import gnresource from '@js/reducers/gnresource';
@@ -541,8 +541,13 @@ function ResourcesGrid({
     onGetFacets,
     facets,
     filters,
-    setFilters
+    setFilters,
+    showFilterForm: showFilterFormProp,
+    setShowFilterForm
 }, context) {
+
+    const showDetail = !isEmpty(resource);
+    const showFilterForm = showFilterFormProp && !showDetail;
 
     const [_cardLayoutStyleState, setCardLayoutStyle] = useLocalStorage('layoutCardsStyle', defaultCardLayoutStyle);
     const cardLayoutStyleState = cardLayoutStyle || _cardLayoutStyleState; // Force style when `cardLayoutStyle` is configured
@@ -590,10 +595,6 @@ function ResourcesGrid({
         replaceQuery: true,
         excludeQueryKeys: []
     });
-
-    const [_showFilterForm, setShowFilterForm] = useState(false);
-    const showDetail = !isEmpty(resource);
-    const showFilterForm = _showFilterForm && !showDetail;
 
     const handleShowFilterForm = (show) => {
         if (!isEmpty(resource)) {
@@ -858,8 +859,9 @@ const ResourcesGridPlugin = connect(
         state => getMonitoredState(state, getConfigProp('monitorState')),
         state => state?.gnsearch?.error,
         getFacetsItems,
-        state => state?.gnsearch?.filters
-    ], (params, user, totalResources, loading, location, resource, monitoredState, error, facets, filters) => ({
+        state => state?.gnsearch?.filters,
+        getShowFilterForm
+    ], (params, user, totalResources, loading, location, resource, monitoredState, error, facets, filters, showFilterForm) => ({
         params,
         user,
         totalResources,
@@ -869,13 +871,15 @@ const ResourcesGridPlugin = connect(
         monitoredState,
         error,
         facets,
-        filters
+        filters,
+        showFilterForm
     })),
     {
         onSearch: searchResources,
         onInit: setSearchConfig,
         onGetFacets: getFacetItems,
-        setFilters: setFiltersAction
+        setFilters: setFiltersAction,
+        setShowFilterForm: showFilterFormAction
     }
 )(withResizeDetector(withPageConfig(ResourcesGrid)));
 

--- a/geonode_mapstore_client/client/js/reducers/gnsearch.js
+++ b/geonode_mapstore_client/client/js/reducers/gnsearch.js
@@ -18,7 +18,8 @@ import {
     INCREASE_TOTAL_COUNT,
     SET_SEARCH_CONFIG,
     SET_FACET_ITEMS,
-    SET_FILTERS
+    SET_FILTERS,
+    SHOW_FILTER_FORM
 } from '@js/actions/gnsearch';
 
 import { UPDATE_SINGLE_RESOURCE } from '@js/actions/gnresource';
@@ -131,6 +132,11 @@ function gnsearch(state = defaultState, action) {
         return {
             ...state,
             filters: {...state.filters, ...action.filters}
+        };
+    case SHOW_FILTER_FORM:
+        return {
+            ...state,
+            showFilterForm: !!action.show
         };
     default:
         return state;

--- a/geonode_mapstore_client/client/js/selectors/search.js
+++ b/geonode_mapstore_client/client/js/selectors/search.js
@@ -42,3 +42,4 @@ export const getTotalResources = (state) => {
 };
 
 export const getFacetsItems = state => state?.gnsearch?.facetItems;
+export const getShowFilterForm = state => state?.gnsearch?.showFilterForm;

--- a/geonode_mapstore_client/client/js/utils/AppRoutesUtils.js
+++ b/geonode_mapstore_client/client/js/utils/AppRoutesUtils.js
@@ -186,10 +186,6 @@ export const CATALOGUE_ROUTES = [
         name: 'catalogue',
         path: [
             '/',
-            '/search/',
-            '/search/filter',
-            '/detail/:pk',
-            '/detail/:ctype/:pk',
             '/:page'
         ],
         component: appRouteComponentTypes.CATALOGUE

--- a/geonode_mapstore_client/client/js/utils/__tests__/AppRoutesUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/AppRoutesUtils-test.js
@@ -103,10 +103,6 @@ describe('Test App Routes Utils', () => {
         expect(mapViewerRoute.shouldNotRequestResources).toEqual(true);
         expect(catalogueRoute.path).toEqual([
             '/',
-            '/search/',
-            '/search/filter',
-            '/detail/:pk',
-            '/detail/:ctype/:pk',
             '/:page'
         ]);
         expect(catalogueRoute.name).toEqual('catalogue');

--- a/geonode_mapstore_client/client/themes/geonode/less/_base.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_base.less
@@ -167,9 +167,6 @@ body {
         z-index: 0;
         overflow: hidden;
     }
-    .gn-card-grid {
-        padding-top: 0;
-    }
     .gn-filters-menu {
         top: 0 !important;
         margin-bottom: 0;

--- a/geonode_mapstore_client/client/themes/geonode/less/_card-grid.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_card-grid.less
@@ -50,7 +50,6 @@
 // **************
 
 .gn-card-grid {
-    padding-top: 20px;
     .gn-card-grid-container {
         position: relative;
         max-width: @gn-page-max-width;
@@ -74,6 +73,7 @@
         max-width: @gn-page-max-width;
         margin: auto;
         width: 100%;
+        align-content: flex-start;
         li {
             padding: 0;
             margin: 0;

--- a/geonode_mapstore_client/client/themes/geonode/less/_home-container.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_home-container.less
@@ -77,4 +77,5 @@
 
 #gn-home-resources-grid {
     position: relative;
+    padding-bottom: 2rem;
 }

--- a/geonode_mapstore_client/client/themes/geonode/less/_menu.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_menu.less
@@ -259,6 +259,9 @@ nav.hide-navigation#gn-topbar {
     position: sticky;
     top: 0px;
     z-index: 10;
+    .gn-menu-container {
+        padding-top: 0.35rem;
+    }
 }
 
 .gn-action-navbar-title {

--- a/geonode_mapstore_client/client/themes/geonode/less/_resources-grid.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_resources-grid.less
@@ -131,6 +131,11 @@
             max-width: 100%;
         }
     }
+    &:not(.gn-panel) {
+        .gn-card-list {
+            min-height: 100vh;
+        }
+    }
     .gn-card-grid-container {
         .gn-menu {
             .gn-menu-container {

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/brand_navbar.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/brand_navbar.html
@@ -81,6 +81,29 @@
             }
             window.addEventListener('DOMContentLoaded', manageUrlChange);
             window.addEventListener('hashchange', manageUrlChange, false);
+
+            window.addEventListener('mapstore:ready', function(event) {
+                const msAPI = event.detail;
+                msAPI.onAction('@@router/LOCATION_CHANGE', (action) => {
+                    const hashPathname = action?.payload?.location?.pathname || '';
+                    const parts = hashPathname.split('/');
+                    const page = parts[parts.length - 1];
+                    // Remove previous highlighted menu
+                    const menuHighlighted = document.querySelector('#gn-topbar .highlight-menu');
+                    if (menuHighlighted) {
+                        menuHighlighted.classList.remove('highlight-menu');
+                    }
+                    // add new highlight
+                    // exclude number
+                    if (page && isNaN(parseFloat(page))) {
+                        const topBarMenu = document.querySelector(`#gn-topbar #${page}`);
+                        if (topBarMenu) {
+                            topBarMenu.classList.add('highlight-menu');
+                        }
+                    }
+                });
+            });
+
         })();
     </script>
 {% endblock extra_script %}

--- a/geonode_mapstore_client/templates/index.html
+++ b/geonode_mapstore_client/templates/index.html
@@ -58,26 +58,21 @@
 
                 <script>
                     window.addEventListener('mapstore:ready', function(event) {
-                        const catalogPagePath = window.__GEONODE_CONFIG__.localConfig.geoNodeSettings.catalogPagePath;
-                        const pagePath = catalogPagePath ? catalogPagePath : '/catalogue/';
                         const msAPI = event.detail;
                         msAPI.setPluginsConfig([
                             {
                                 name: 'FeaturedResourcesGrid',
                                 cfg: {
                                     targetSelector: '#gn-home-featured-resources-grid',
-                                    pagePath: pagePath
+                                    pagePath: ''
                                 }
                             },
                             {
                                 name: 'ResourcesGrid',
                                 cfg: {
                                     targetSelector: '#gn-home-resources-grid',
-                                    containerSelector: '#gn-home-resources-grid',
-                                    pagination: false,
-                                    pagePath: pagePath,
-                                    disableFilters: true,
-                                    disableDetailPanel: true,
+                                    pagination: true,
+                                    pagePath: '',
                                     enableGeoNodeCardsMenuItems: true
                                 }
                             },

--- a/geonode_mapstore_client/templates/index.html
+++ b/geonode_mapstore_client/templates/index.html
@@ -57,22 +57,24 @@
                 {% endblock %}
 
                 <script>
-                    window.addEventListener('mapstore:ready', function(event) {
+                    window.addEventListener('mapstore:ready', function (event) {
+                        const catalogPagePath = window.__GEONODE_CONFIG__.localConfig.geoNodeSettings.catalogPagePath;
+                        const pagePath = catalogPagePath ? catalogPagePath : '/catalogue/';
                         const msAPI = event.detail;
                         msAPI.setPluginsConfig([
                             {
                                 name: 'FeaturedResourcesGrid',
                                 cfg: {
                                     targetSelector: '#gn-home-featured-resources-grid',
-                                    pagePath: ''
+                                    pagePath: pagePath
                                 }
                             },
                             {
                                 name: 'ResourcesGrid',
                                 cfg: {
                                     targetSelector: '#gn-home-resources-grid',
+                                    pagePath: pagePath,
                                     pagination: true,
-                                    pagePath: '',
                                     enableGeoNodeCardsMenuItems: true
                                 }
                             },
@@ -83,7 +85,7 @@
                         ]);
                     });
                 </script>
-    
+
                 {% block ms_scripts %}
                     <script id="gn-script" src="{% static 'mapstore/dist/js/gn-components.js' %}?{% client_version %}"></script>
                 {% endblock %}


### PR DESCRIPTION
This PR introduces the possibility to open filters in homepage and introduces following changes:
- Remove deprecated hash path and related logic ('/search/', '/search/filter',  '/detail/:pk',  '/detail/:ctype/:pk')
- Review ResourcesGrid plugin removing and externalizing not related logic
- Review homepage configuration for resources grid

![image](https://github.com/user-attachments/assets/4a7bd4fc-cbbd-46bc-87c2-e1330f38d22d)
