### PR TITLE
Fix #1847 Implement the client UI for the Resource management settings

### DIFF
--- a/geonode_mapstore_client/apps.py
+++ b/geonode_mapstore_client/apps.py
@@ -223,7 +223,9 @@ def run_setup_hooks(*args, **kwargs):
             "temporal_extent_start",
             "thumbnail_url",
             "title",
-            "uuid"
+            "uuid",
+            "metadata_uploaded_preserve",
+            "featured"
         ],
     }
     settings.REST_API_PRESETS["map_viewer"] = {

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsAssets.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsAssets.jsx
@@ -4,11 +4,11 @@ import FaIcon from '@js/components/FaIcon';
 function DetailsAssets({ fields }) {
     return (
         <div className="gn-details-assets">
-            {fields.map((field, idx) => {
-                const asset = field?.extras?.content || {};
-                return (
-                    <div key={idx} className="gn-details-info-fields">
-                        <div className="gn-details-info-row linked-resources">
+            <div className="gn-details-info-fields">
+                {fields.map((field, idx) => {
+                    const asset = field?.extras?.content || {};
+                    return (
+                        <div key={idx} className="gn-details-info-row gn-details-flex-field">
                             <FaIcon name="file" />
                             {asset.download_url ? <a
                                 download
@@ -17,9 +17,9 @@ function DetailsAssets({ fields }) {
                                 {asset.title}{' '}<FaIcon name="download" />
                             </a> : asset.title}
                         </div>
-                    </div>
-                );
-            })}
+                    );
+                })}
+            </div>
         </div>
     );
 }

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsInfo.jsx
@@ -12,11 +12,7 @@ import moment from 'moment';
 
 import Button from '@js/components/Button';
 import Tabs from '@js/components/Tabs';
-import DetailsAttributeTable from '@js/components/DetailsPanel/DetailsAttributeTable';
-import DetailsLinkedResources from '@js/components/DetailsPanel/DetailsLinkedResources';
 import Message from '@mapstore/framework/components/I18N/Message';
-import DetailsLocations from '@js/components/DetailsPanel/DetailsLocations';
-import DetailsAssets from '@js/components/DetailsPanel/DetailsAssets';
 
 const replaceTemplateString = (properties, str) => {
     return Object.keys(properties).reduce((updatedStr, key) => {
@@ -143,12 +139,8 @@ function DetailsInfoFields({ fields, formatHref }) {
     </div>);
 }
 
-const tabTypes = {
-    'attribute-table': DetailsAttributeTable,
-    'linked-resources': DetailsLinkedResources,
-    'locations': DetailsLocations,
-    'tab': DetailsInfoFields,
-    'assets': DetailsAssets
+const defaultTabComponents = {
+    'tab': DetailsInfoFields
 };
 
 const parseTabItems = (items) => {
@@ -160,15 +152,22 @@ const isDefaultTabType = (type) => type === 'tab';
 
 function DetailsInfo({
     tabs = [],
+    tabComponents: tabComponentsProp,
     ...props
 }) {
+
+    const tabComponents = {
+        ...tabComponentsProp,
+        ...defaultTabComponents
+    };
+
     const filteredTabs = tabs
         .filter((tab) => !tab?.disableIf)
         .map((tab) =>
             ({
                 ...tab,
                 items: isDefaultTabType(tab.type) ? parseTabItems(tab?.items) : tab?.items,
-                Component: tabTypes[tab.type] || tabTypes.tab
+                Component: tabComponents[tab.type] || tabComponents.tab
             }))
         .filter(tab => !isEmpty(tab?.items));
     const [selectedTabId, onSelect] = useState(filteredTabs?.[0]?.id);

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsLinkedResources.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsLinkedResources.jsx
@@ -14,19 +14,19 @@ import Message from '@mapstore/framework/components/I18N/Message';
 
 const DetailLinkedResource = ({resources, type}) => {
     return !isEmpty(resources) && (
-        <>
+        <div className="gn-details-info-fields">
             <Message msgId={`gnviewer.linkedResources.${type}`} />
             {resources.map((field, key) => {
-                return (<div key={key} className="gn-details-info-fields">
-                    <div className="gn-details-info-row linked-resources">
+                return (
+                    <div key={key} className="gn-details-info-row gn-details-flex-field">
                         {field.icon && <FaIcon name={field.icon} />}
                         <a key={field.pk} href={field.detail_url}>
                             {field.title}
                         </a>
                     </div>
-                </div>);
+                );
             })}
-        </>
+        </div>
     );
 };
 
@@ -54,7 +54,7 @@ const DetailsLinkedResources = ({ fields, resourceTypesInfo }) => {
     ];
 
     return (
-        <div className="linked-resources">
+        <div className="gn-details-linked-resources">
             {
                 linkedResources.map(({resources, type})=> <DetailLinkedResource resources={resources} type={type}/>)
             }

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsManagement.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsManagement.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Checkbox } from 'react-bootstrap';
+import Message from '@mapstore/framework/components/I18N/Message';
+import { RESOURCE_MANAGEMENT_PROPERTIES } from '@js/utils/ResourceUtils';
+
+function DetailsManagement({ resource, onChange }) {
+    const perms = resource?.perms || [];
+    return (
+        <div className="gn-details-management">
+            <div className="gn-details-info-fields">
+                <Message msgId={"gnviewer.resourceManagement"} />
+                {Object.keys(RESOURCE_MANAGEMENT_PROPERTIES).map((key) => {
+                    const { labelId, disabled } = RESOURCE_MANAGEMENT_PROPERTIES[key];
+                    return (
+                        <div key={key} className="gn-details-info-row gn-details-flex-field">
+                            <Checkbox
+                                style={{ margin: 0 }}
+                                disabled={disabled(perms)}
+                                checked={!!resource?.[key]}
+                                onChange={(event) => onChange({ [key]: !!event.target.checked })}
+                            >
+                                <Message msgId={labelId} />
+                            </Checkbox>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+export default DetailsManagement;

--- a/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
+++ b/geonode_mapstore_client/client/js/components/DetailsPanel/DetailsPanel.jsx
@@ -190,7 +190,8 @@ function DetailsPanel({
     tabs,
     pathname,
     toolbarItems,
-    onSetExtent
+    onSetExtent,
+    tabComponents
 }) {
     const detailsContainerNode = useRef();
     const [titleNodeRef, titleInView] = useInView();
@@ -292,7 +293,7 @@ function DetailsPanel({
                             : null}
                     </div>
                 </div>
-                <DetailsInfo tabs={tabs} formatHref={formatHref} allowEdit={activeEditMode} resourceTypesInfo={types} resource={resource} onSetExtent={onSetExtent}/>
+                <DetailsInfo tabs={tabs} tabComponents={tabComponents} formatHref={formatHref} allowEdit={activeEditMode} resourceTypesInfo={types} resource={resource} onSetExtent={onSetExtent}/>
             </section>
         </div>
     );

--- a/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
+++ b/geonode_mapstore_client/client/js/plugins/DetailViewer.jsx
@@ -47,6 +47,7 @@ import { mapSelector } from '@mapstore/framework/selectors/map';
 import { parsePluginConfigExpressions } from '@js/utils/MenuUtils';
 import usePluginItems from '@js/hooks/usePluginItems';
 import { getResourceTypesInfo } from '@js/utils/ResourceUtils';
+import tabComponents from '@js/plugins/detailviewer/tabComponents';
 
 const ConnectedDetailsPanel = connect(
     createSelector([
@@ -71,7 +72,8 @@ const ConnectedDetailsPanel = connect(
         initialBbox: mapData?.bbox,
         enableMapViewer: showMapThumbnail,
         downloading,
-        resourceId: resource.pk
+        resourceId: resource.pk,
+        tabComponents
     })),
     {
         closePanel: setControlProperty.bind(null, 'rightOverlay', 'enabled', false),

--- a/geonode_mapstore_client/client/js/plugins/ResourcesGrid.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ResourcesGrid.jsx
@@ -53,6 +53,7 @@ import FaIcon from '@js/components/FaIcon';
 import Button from '@js/components/Button';
 import useLocalStorage from '@js/hooks/useLocalStorage';
 import MainLoader from '@js/components/MainLoader';
+import tabComponents from '@js/plugins/detailviewer/tabComponents';
 
 const ConnectedDetailsPanel = connect(
     createSelector([
@@ -65,7 +66,8 @@ const ConnectedDetailsPanel = connect(
         favorite: favorite,
         downloading,
         canDownload: resourceHasPermission(resource, 'download_resourcebase'),
-        resourceId: resource?.pk
+        resourceId: resource?.pk,
+        tabComponents
     })),
     {
         onFavorite: setFavoriteResource,

--- a/geonode_mapstore_client/client/js/plugins/detailviewer/tabComponents.js
+++ b/geonode_mapstore_client/client/js/plugins/detailviewer/tabComponents.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { connect } from 'react-redux';
+import DetailsLocations from '@js/components/DetailsPanel/DetailsLocations';
+import DetailsAssets from '@js/components/DetailsPanel/DetailsAssets';
+import DetailsAttributeTable from '@js/components/DetailsPanel/DetailsAttributeTable';
+import DetailsLinkedResources from '@js/components/DetailsPanel/DetailsLinkedResources';
+import DetailsManagement from '@js/components/DetailsPanel/DetailsManagement';
+import { updateResourceProperties } from '@js/actions/gnresource';
+
+const tabComponents = {
+    'attribute-table': DetailsAttributeTable,
+    'linked-resources': DetailsLinkedResources,
+    'locations': DetailsLocations,
+    'assets': DetailsAssets,
+    'management': connect(() => ({}), { onChange: updateResourceProperties })(DetailsManagement)
+};
+
+export default tabComponents;

--- a/geonode_mapstore_client/client/js/selectors/resource.js
+++ b/geonode_mapstore_client/client/js/selectors/resource.js
@@ -12,7 +12,7 @@ import { compareMapChanges } from '@mapstore/framework/utils/MapUtils';
 import { currentStorySelector } from '@mapstore/framework/selectors/geostory';
 import { originalDataSelector } from '@mapstore/framework/selectors/dashboard';
 import { widgetsConfig } from '@mapstore/framework/selectors/widgets';
-import { ResourceTypes } from '@js/utils/ResourceUtils';
+import { ResourceTypes, RESOURCE_MANAGEMENT_PROPERTIES } from '@js/utils/ResourceUtils';
 import {
     getCurrentResourceDeleteLoading,
     getCurrentResourceCopyLoading
@@ -25,6 +25,9 @@ import pick from 'lodash/pick';
 import isEmpty from 'lodash/isEmpty';
 import get from 'lodash/get';
 import { generateContextResource } from '@mapstore/framework/selectors/contextcreator';
+
+const RESOURCE_MANAGEMENT_PROPERTIES_KEYS = Object.keys(RESOURCE_MANAGEMENT_PROPERTIES);
+
 /**
 * @module selectors/resource
 */
@@ -270,7 +273,7 @@ export const getResourceDirtyState = (state) => {
         return null;
     }
     const resourceType = state?.gnresource?.type;
-    const metadataKeys = ['title', 'abstract', 'data', 'extent'];
+    const metadataKeys = ['title', 'abstract', 'data', 'extent', ...RESOURCE_MANAGEMENT_PROPERTIES_KEYS];
     const { data: initialData = {}, ...resource } = pick(state?.gnresource?.initialResource || {}, metadataKeys);
     const { compactPermissions, geoLimits } = getPermissionsPayload(state);
     const currentData = JSON.parse(JSON.stringify(getDataPayload(state) || {})); // JSON stringify is needed to remove undefined values

--- a/geonode_mapstore_client/client/js/utils/PluginsContextUtils.js
+++ b/geonode_mapstore_client/client/js/utils/PluginsContextUtils.js
@@ -48,6 +48,12 @@ const hasDefaultSettings = (layer) => {
     return true;
 };
 
+const canManageResourceSettings = (resource) => {
+    const { perms } = resource || {};
+    const settingsPerms = ['feature_resourcebase', 'approve_resourcebase', 'publish_resourcebase'];
+    return !!(perms || []).find(perm => settingsPerms.includes(perm));
+};
+
 export const getPluginsContext = () => ({
     get,
     getMetadataUrl,
@@ -60,5 +66,6 @@ export const getPluginsContext = () => ({
     isDocumentExternalSource,
     getCataloguePath,
     getCreateNewMapLink,
-    hasDefaultSettings
+    hasDefaultSettings,
+    canManageResourceSettings
 });

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -52,6 +52,29 @@ export const GXP_PTYPES = {
     'GN_WMS': 'gxp_geonodecataloguesource'
 };
 
+export const RESOURCE_MANAGEMENT_PROPERTIES = {
+    'metadata_uploaded_preserve': {
+        labelId: 'gnviewer.preserveUploadedMetadata',
+        disabled: (perms = []) => !perms.includes('change_resourcebase')
+    },
+    'is_approved': {
+        labelId: 'gnviewer.approved',
+        disabled: (perms = []) => !perms.includes('approve_resourcebase')
+    },
+    'is_published': {
+        labelId: 'gnviewer.published',
+        disabled: (perms = []) => !perms.includes('publish_resourcebase')
+    },
+    'featured': {
+        labelId: 'gnviewer.featured',
+        disabled: (perms = []) => !perms.includes('feature_resourcebase')
+    },
+    'advertised': {
+        labelId: 'gnviewer.advertised',
+        disabled: (perms = []) => !perms.includes('change_resourcebase')
+    }
+};
+
 export const isDefaultDatasetSubtype = (subtype) => !subtype || ['vector', 'raster', 'remote', 'vector_time'].includes(subtype);
 
 export const FEATURE_INFO_FORMAT = 'TEMPLATE';

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -58,19 +58,19 @@ export const RESOURCE_MANAGEMENT_PROPERTIES = {
         disabled: (perms = []) => !perms.includes('change_resourcebase')
     },
     'is_approved': {
-        labelId: 'gnviewer.approved',
+        labelId: 'gnviewer.approveResource',
         disabled: (perms = []) => !perms.includes('approve_resourcebase')
     },
     'is_published': {
-        labelId: 'gnviewer.published',
+        labelId: 'gnviewer.publishResource',
         disabled: (perms = []) => !perms.includes('publish_resourcebase')
     },
     'featured': {
-        labelId: 'gnviewer.featured',
+        labelId: 'gnviewer.featureResource',
         disabled: (perms = []) => !perms.includes('feature_resourcebase')
     },
     'advertised': {
-        labelId: 'gnviewer.advertised',
+        labelId: 'gnviewer.advertiseResource',
         disabled: (perms = []) => !perms.includes('change_resourcebase')
     }
 };

--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -456,7 +456,7 @@
     }
     .tab-content {
         margin-top: 0.5rem;
-        .linked-resources {
+        .gn-details-flex-field {
             > span {
                 font-size: @font-size-small;
             }
@@ -506,10 +506,11 @@
                 white-space: nowrap;
             }
         }
-        &.linked-resources {
+        &.gn-details-flex-field {
             display: flex;
             align-items: center;
             gap: 10px;
+            padding: 0.25rem;
         }
         &.link {
             border-bottom: none;

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -833,6 +833,13 @@
                             "id": "assets",
                             "labelId": "gnviewer.assets",
                             "items": "{context.get(state('gnResourceData'), 'assets')}"
+                        },
+                        {
+                            "type": "management",
+                            "id": "management",
+                            "labelId": "gnviewer.management",
+                            "disableIf": "{!context.canManageResourceSettings(state('gnResourceData'))}",
+                            "items": [true]
                         }
                     ]
                 }
@@ -1733,6 +1740,13 @@
                             "id": "assets",
                             "labelId": "gnviewer.assets",
                             "items": "{context.get(state('gnResourceData'), 'assets')}"
+                        },
+                        {
+                            "type": "management",
+                            "id": "management",
+                            "labelId": "gnviewer.management",
+                            "disableIf": "{!context.canManageResourceSettings(state('gnResourceData'))}",
+                            "items": [true]
                         }
                     ]
                 }
@@ -2435,6 +2449,13 @@
                             "id": "assets",
                             "labelId": "gnviewer.assets",
                             "items": "{context.get(state('gnResourceData'), 'assets')}"
+                        },
+                        {
+                            "type": "management",
+                            "id": "management",
+                            "labelId": "gnviewer.management",
+                            "disableIf": "{!context.canManageResourceSettings(state('gnResourceData'))}",
+                            "items": [true]
                         }
                     ]
                 }
@@ -2776,6 +2797,13 @@
                             "id": "assets",
                             "labelId": "gnviewer.assets",
                             "items": "{context.get(state('gnResourceData'), 'assets')}"
+                        },
+                        {
+                            "type": "management",
+                            "id": "management",
+                            "labelId": "gnviewer.management",
+                            "disableIf": "{!context.canManageResourceSettings(state('gnResourceData'))}",
+                            "items": [true]
                         }
                     ]
                 }
@@ -3045,6 +3073,13 @@
                             "id": "assets",
                             "labelId": "gnviewer.assets",
                             "items": "{context.get(state('gnResourceData'), 'assets')}"
+                        },
+                        {
+                            "type": "management",
+                            "id": "management",
+                            "labelId": "gnviewer.management",
+                            "disableIf": "{!context.canManageResourceSettings(state('gnResourceData'))}",
+                            "items": [true]
                         }
                     ]
                 }
@@ -4367,6 +4402,13 @@
                             "id": "assets",
                             "labelId": "gnviewer.assets",
                             "items": "{context.get(state('gnResourceData'), 'assets')}"
+                        },
+                        {
+                            "type": "management",
+                            "id": "management",
+                            "labelId": "gnviewer.management",
+                            "disableIf": "{!context.canManageResourceSettings(state('gnResourceData'))}",
+                            "items": [true]
                         }
                     ]
                 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -412,7 +412,13 @@
                 }
             },
             "allResources": "All resources",
-            "assets": "Assets"
+            "assets": "Assets",
+            "management": "Verwaltung",
+            "resourceManagement": "Ressourcenverwaltung",
+            "preserveUploadedMetadata": "Hochgeladene Metadaten beibehalten",
+            "approved": "Genehmigt",
+            "featured": "Hervorgehoben",
+            "advertised": "Beworben"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -415,10 +415,11 @@
             "assets": "Assets",
             "management": "Verwaltung",
             "resourceManagement": "Ressourcenverwaltung",
-            "preserveUploadedMetadata": "Hochgeladene Metadaten beibehalten",
-            "approved": "Genehmigt",
-            "featured": "Hervorgehoben",
-            "advertised": "Beworben"
+            "preserveUploadedMetadata": "Behalte die hochgeladene ISO-Metadatendatei, anstatt sie zu generieren",
+            "approveResource": "Diese Ressource genehmigen (wird vom erweiterten Metadaten-Workflow verwendet)",
+            "publishResource": "Diese Ressource veröffentlichen (wird vom erweiterten Metadaten-Workflow verwendet)",
+            "featureResource": "Diese Ressource zu den vorgestellten Ressourcen hinzufügen",
+            "advertiseResource": "Diese Ressource durchsuchbar machen"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -416,8 +416,8 @@
             "management": "Verwaltung",
             "resourceManagement": "Ressourcenverwaltung",
             "preserveUploadedMetadata": "Behalte die hochgeladene ISO-Metadatendatei, anstatt sie zu generieren",
-            "approveResource": "Diese Ressource genehmigen (wird vom erweiterten Metadaten-Workflow verwendet)",
-            "publishResource": "Diese Ressource veröffentlichen (wird vom erweiterten Metadaten-Workflow verwendet)",
+            "approveResource": "Diese Ressource genehmigen (wird vom erweiterten Workflow verwendet)",
+            "publishResource": "Diese Ressource veröffentlichen (wird vom erweiterten Workflow verwendet)",
             "featureResource": "Diese Ressource zu den vorgestellten Ressourcen hinzufügen",
             "advertiseResource": "Diese Ressource durchsuchbar machen"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -416,8 +416,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced workflow)",
-            "publishResource": "Publish this resource (used by the Advanced workflow)",
+            "approveResource": "Approve this resource (used by the Advanced Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -415,10 +415,11 @@
             "assets": "Assets",
             "management": "Management",
             "resourceManagement": "Resource management",
-            "preserveUploadedMetadata": "Preserve uploaded metadata",
-            "approved": "Approved",
-            "featured": "Featured",
-            "advertised": "Advertised"
+            "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
+            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "featureResource": "Add this resource to featured resources",
+            "advertiseResource": "Make this resource searchable"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -412,7 +412,13 @@
                 }
             },
             "allResources": "All resources",
-            "assets": "Assets"
+            "assets": "Assets",
+            "management": "Management",
+            "resourceManagement": "Resource management",
+            "preserveUploadedMetadata": "Preserve uploaded metadata",
+            "approved": "Approved",
+            "featured": "Featured",
+            "advertised": "Advertised"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -416,8 +416,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
-            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "approveResource": "Approve this resource (used by the Advanced workflow)",
+            "publishResource": "Publish this resource (used by the Advanced workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -414,10 +414,11 @@
             "assets": "Assets",
             "management": "Gestión",
             "resourceManagement": "Gestión de recursos",
-            "preserveUploadedMetadata": "Conservar metadatos cargados",
-            "approved": "Aprobado",
-            "featured": "Destacado",
-            "advertised": "Anunciado"
+            "preserveUploadedMetadata": "Conservar el archivo de metadatos ISO cargado en lugar de generarlo",
+            "approveResource": "Aprobar este recurso (utilizado por el flujo de trabajo de metadatos avanzado)",
+            "publishResource": "Publicar este recurso (utilizado por el flujo de trabajo de metadatos avanzado)",
+            "featureResource": "Agregar este recurso a los recursos destacados",
+            "advertiseResource": "Hacer que este recurso sea buscable"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -411,7 +411,13 @@
                 }
             },
             "allResources": "All resources",
-            "assets": "Assets"
+            "assets": "Assets",
+            "management": "Gestión",
+            "resourceManagement": "Gestión de recursos",
+            "preserveUploadedMetadata": "Conservar metadatos cargados",
+            "approved": "Aprobado",
+            "featured": "Destacado",
+            "advertised": "Anunciado"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -415,8 +415,8 @@
             "management": "Gestión",
             "resourceManagement": "Gestión de recursos",
             "preserveUploadedMetadata": "Conservar el archivo de metadatos ISO cargado en lugar de generarlo",
-            "approveResource": "Aprobar este recurso (utilizado por el flujo de trabajo de metadatos avanzado)",
-            "publishResource": "Publicar este recurso (utilizado por el flujo de trabajo de metadatos avanzado)",
+            "approveResource": "Aprobar este recurso (utilizado por el flujo de trabajo avanzado)",
+            "publishResource": "Publicar este recurso (utilizado por el flujo de trabajo avanzado)",
             "featureResource": "Agregar este recurso a los recursos destacados",
             "advertiseResource": "Hacer que este recurso sea buscable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -381,7 +381,13 @@
                 }
             },
             "allResources": "All resources",
-            "assets": "Assets"
+            "assets": "Assets",
+            "management": "Management",
+            "resourceManagement": "Resource management",
+            "preserveUploadedMetadata": "Preserve uploaded metadata",
+            "approved": "Approved",
+            "featured": "Featured",
+            "advertised": "Advertised"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced workflow)",
-            "publishResource": "Publish this resource (used by the Advanced workflow)",
+            "approveResource": "Approve this resource (used by the Advanced Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
-            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "approveResource": "Approve this resource (used by the Advanced workflow)",
+            "publishResource": "Publish this resource (used by the Advanced workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -384,10 +384,11 @@
             "assets": "Assets",
             "management": "Management",
             "resourceManagement": "Resource management",
-            "preserveUploadedMetadata": "Preserve uploaded metadata",
-            "approved": "Approved",
-            "featured": "Featured",
-            "advertised": "Advertised"
+            "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
+            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "featureResource": "Add this resource to featured resources",
+            "advertiseResource": "Make this resource searchable"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -415,10 +415,11 @@
             "assets": "Assets",
             "management": "Gestion",
             "resourceManagement": "Gestion des ressources",
-            "preserveUploadedMetadata": "Conserver les métadonnées téléchargées",
-            "approved": "Approuvé",
-            "featured": "En vedette",
-            "advertised": "Annoncé"
+            "preserveUploadedMetadata": "Conserver le fichier de métadonnées ISO téléchargé au lieu de le générer",
+            "approveResource": "Approuver cette ressource (utilisée par le flux de travail des métadonnées avancées)",
+            "publishResource": "Publier cette ressource (utilisée par le flux de travail des métadonnées avancées)",
+            "featureResource": "Ajouter cette ressource aux ressources en vedette",
+            "advertiseResource": "Rendre cette ressource consultable"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -416,8 +416,8 @@
             "management": "Gestion",
             "resourceManagement": "Gestion des ressources",
             "preserveUploadedMetadata": "Conserver le fichier de métadonnées ISO téléchargé au lieu de le générer",
-            "approveResource": "Approuver cette ressource (utilisée par le flux de travail des métadonnées avancées)",
-            "publishResource": "Publier cette ressource (utilisée par le flux de travail des métadonnées avancées)",
+            "approveResource": "Approuver cette ressource (utilisé par le flux de travail avancé)",
+            "publishResource": "Publier cette ressource (utilisé par le flux de travail avancé)",
             "featureResource": "Ajouter cette ressource aux ressources en vedette",
             "advertiseResource": "Rendre cette ressource consultable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -412,7 +412,13 @@
                 }
             },
             "allResources": "All resources",
-            "assets": "Assets"
+            "assets": "Assets",
+            "management": "Gestion",
+            "resourceManagement": "Gestion des ressources",
+            "preserveUploadedMetadata": "Conserver les métadonnées téléchargées",
+            "approved": "Approuvé",
+            "featured": "En vedette",
+            "advertised": "Annoncé"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -381,7 +381,13 @@
                 }
             },
             "allResources": "All resources",
-            "assets": "Assets"
+            "assets": "Assets",
+            "management": "Management",
+            "resourceManagement": "Resource management",
+            "preserveUploadedMetadata": "Preserve uploaded metadata",
+            "approved": "Approved",
+            "featured": "Featured",
+            "advertised": "Advertised"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced workflow)",
-            "publishResource": "Publish this resource (used by the Advanced workflow)",
+            "approveResource": "Approve this resource (used by the Advanced Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
-            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "approveResource": "Approve this resource (used by the Advanced workflow)",
+            "publishResource": "Publish this resource (used by the Advanced workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -384,10 +384,11 @@
             "assets": "Assets",
             "management": "Management",
             "resourceManagement": "Resource management",
-            "preserveUploadedMetadata": "Preserve uploaded metadata",
-            "approved": "Approved",
-            "featured": "Featured",
-            "advertised": "Advertised"
+            "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
+            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "featureResource": "Add this resource to featured resources",
+            "advertiseResource": "Make this resource searchable"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -417,10 +417,11 @@
             "assets": "Assets",
             "management": "Gestione",
             "resourceManagement": "Gestione della risorsa",
-            "preserveUploadedMetadata": "Conserva i metadati caricati",
-            "approved": "Approvato",
-            "featured": "In evidenza",
-            "advertised": "Pubblicizzato"
+            "preserveUploadedMetadata": "Conserva il file dei metadati ISO caricato invece di generarlo",
+            "approveResource": "Approva questa risorsa (utilizzata dal flusso di lavoro dei metadati avanzati)",
+            "publishResource": "Pubblica questa risorsa (utilizzata dal flusso di lavoro dei metadati avanzati)",
+            "featureResource": "Aggiungi questa risorsa alle risorse in evidenza",
+            "advertiseResource": "Rendi questa risorsa ricercabile"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -414,7 +414,13 @@
                 }
             },
             "allResources": "All resources",
-            "assets": "Assets"
+            "assets": "Assets",
+            "management": "Gestione",
+            "resourceManagement": "Gestione della risorsa",
+            "preserveUploadedMetadata": "Conserva i metadati caricati",
+            "approved": "Approvato",
+            "featured": "In evidenza",
+            "advertised": "Pubblicizzato"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -418,8 +418,8 @@
             "management": "Gestione",
             "resourceManagement": "Gestione della risorsa",
             "preserveUploadedMetadata": "Conserva il file dei metadati ISO caricato invece di generarlo",
-            "approveResource": "Approva questa risorsa (utilizzata dal flusso di lavoro dei metadati avanzati)",
-            "publishResource": "Pubblica questa risorsa (utilizzata dal flusso di lavoro dei metadati avanzati)",
+            "approveResource": "Approva questa risorsa (utilizzata dall' Advanced Workflow)",
+            "publishResource": "Pubblica questa risorsa (utilizzata dall' Advanced Workflow)",
             "featureResource": "Aggiungi questa risorsa alle risorse in evidenza",
             "advertiseResource": "Rendi questa risorsa ricercabile"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -381,7 +381,13 @@
                 }
             },
             "allResources": "All resources",
-            "assets": "Assets"
+            "assets": "Assets",
+            "management": "Management",
+            "resourceManagement": "Resource management",
+            "preserveUploadedMetadata": "Preserve uploaded metadata",
+            "approved": "Approved",
+            "featured": "Featured",
+            "advertised": "Advertised"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced workflow)",
-            "publishResource": "Publish this resource (used by the Advanced workflow)",
+            "approveResource": "Approve this resource (used by the Advanced Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
-            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "approveResource": "Approve this resource (used by the Advanced workflow)",
+            "publishResource": "Publish this resource (used by the Advanced workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -384,10 +384,11 @@
             "assets": "Assets",
             "management": "Management",
             "resourceManagement": "Resource management",
-            "preserveUploadedMetadata": "Preserve uploaded metadata",
-            "approved": "Approved",
-            "featured": "Featured",
-            "advertised": "Advertised"
+            "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
+            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "featureResource": "Add this resource to featured resources",
+            "advertiseResource": "Make this resource searchable"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -381,7 +381,13 @@
                 }
             },
             "allResources": "All resources",
-            "assets": "Assets"
+            "assets": "Assets",
+            "management": "Management",
+            "resourceManagement": "Resource management",
+            "preserveUploadedMetadata": "Preserve uploaded metadata",
+            "approved": "Approved",
+            "featured": "Featured",
+            "advertised": "Advertised"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced workflow)",
-            "publishResource": "Publish this resource (used by the Advanced workflow)",
+            "approveResource": "Approve this resource (used by the Advanced Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
-            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "approveResource": "Approve this resource (used by the Advanced workflow)",
+            "publishResource": "Publish this resource (used by the Advanced workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -384,10 +384,11 @@
             "assets": "Assets",
             "management": "Management",
             "resourceManagement": "Resource management",
-            "preserveUploadedMetadata": "Preserve uploaded metadata",
-            "approved": "Approved",
-            "featured": "Featured",
-            "advertised": "Advertised"
+            "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
+            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "featureResource": "Add this resource to featured resources",
+            "advertiseResource": "Make this resource searchable"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -381,7 +381,13 @@
                 }
             },
             "allResources": "All resources",
-            "assets": "Assets"
+            "assets": "Assets",
+            "management": "Management",
+            "resourceManagement": "Resource management",
+            "preserveUploadedMetadata": "Preserve uploaded metadata",
+            "approved": "Approved",
+            "featured": "Featured",
+            "advertised": "Advertised"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced workflow)",
-            "publishResource": "Publish this resource (used by the Advanced workflow)",
+            "approveResource": "Approve this resource (used by the Advanced Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
-            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "approveResource": "Approve this resource (used by the Advanced workflow)",
+            "publishResource": "Publish this resource (used by the Advanced workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -384,10 +384,11 @@
             "assets": "Assets",
             "management": "Management",
             "resourceManagement": "Resource management",
-            "preserveUploadedMetadata": "Preserve uploaded metadata",
-            "approved": "Approved",
-            "featured": "Featured",
-            "advertised": "Advertised"
+            "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
+            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "featureResource": "Add this resource to featured resources",
+            "advertiseResource": "Make this resource searchable"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -385,10 +385,11 @@
             "assets": "Assets",
             "management": "Management",
             "resourceManagement": "Resource management",
-            "preserveUploadedMetadata": "Preserve uploaded metadata",
-            "approved": "Approved",
-            "featured": "Featured",
-            "advertised": "Advertised"
+            "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
+            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "featureResource": "Add this resource to featured resources",
+            "advertiseResource": "Make this resource searchable"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -386,8 +386,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced workflow)",
-            "publishResource": "Publish this resource (used by the Advanced workflow)",
+            "approveResource": "Approve this resource (used by the Advanced Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -382,7 +382,13 @@
                 }
             },
             "allResources": "All resources",
-            "assets": "Assets"
+            "assets": "Assets",
+            "management": "Management",
+            "resourceManagement": "Resource management",
+            "preserveUploadedMetadata": "Preserve uploaded metadata",
+            "approved": "Approved",
+            "featured": "Featured",
+            "advertised": "Advertised"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -386,8 +386,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
-            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "approveResource": "Approve this resource (used by the Advanced workflow)",
+            "publishResource": "Publish this resource (used by the Advanced workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -381,7 +381,13 @@
                 }
             },
             "allResources": "All resources",
-            "assets": "Assets"
+            "assets": "Assets",
+            "management": "Management",
+            "resourceManagement": "Resource management",
+            "preserveUploadedMetadata": "Preserve uploaded metadata",
+            "approved": "Approved",
+            "featured": "Featured",
+            "advertised": "Advertised"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced workflow)",
-            "publishResource": "Publish this resource (used by the Advanced workflow)",
+            "approveResource": "Approve this resource (used by the Advanced Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
-            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "approveResource": "Approve this resource (used by the Advanced workflow)",
+            "publishResource": "Publish this resource (used by the Advanced workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -384,10 +384,11 @@
             "assets": "Assets",
             "management": "Management",
             "resourceManagement": "Resource management",
-            "preserveUploadedMetadata": "Preserve uploaded metadata",
-            "approved": "Approved",
-            "featured": "Featured",
-            "advertised": "Advertised"
+            "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
+            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "featureResource": "Add this resource to featured resources",
+            "advertiseResource": "Make this resource searchable"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -381,7 +381,13 @@
                 }
             },
             "allResources": "All resources",
-            "assets": "Assets"
+            "assets": "Assets",
+            "management": "Management",
+            "resourceManagement": "Resource management",
+            "preserveUploadedMetadata": "Preserve uploaded metadata",
+            "approved": "Approved",
+            "featured": "Featured",
+            "advertised": "Advertised"
         }
     }
 }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced workflow)",
-            "publishResource": "Publish this resource (used by the Advanced workflow)",
+            "approveResource": "Approve this resource (used by the Advanced Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -385,8 +385,8 @@
             "management": "Management",
             "resourceManagement": "Resource management",
             "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
-            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
-            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "approveResource": "Approve this resource (used by the Advanced workflow)",
+            "publishResource": "Publish this resource (used by the Advanced workflow)",
             "featureResource": "Add this resource to featured resources",
             "advertiseResource": "Make this resource searchable"
         }

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -384,10 +384,11 @@
             "assets": "Assets",
             "management": "Management",
             "resourceManagement": "Resource management",
-            "preserveUploadedMetadata": "Preserve uploaded metadata",
-            "approved": "Approved",
-            "featured": "Featured",
-            "advertised": "Advertised"
+            "preserveUploadedMetadata": "Keep the uploaded ISO metadata file instead of generating it",
+            "approveResource": "Approve this resource (used by the Advanced Metadata Workflow)",
+            "publishResource": "Publish this resource (used by the Advanced Metadata Workflow)",
+            "featureResource": "Add this resource to featured resources",
+            "advertiseResource": "Make this resource searchable"
         }
     }
 }


### PR DESCRIPTION
This PR adds a new tab called **Management** inside the resource panel with the following checkboxes:

- Preserve uploaded metadata
- Approved
- Published
- Featured
- Advertised

Once one of the above checkbox is changes a user need to save the resource to persist the change

![image](https://github.com/user-attachments/assets/ba25815e-8828-476c-8594-0e8f04884f62)

