### PR TITLE
Fix #1856 Do not send is_approved, is_published and is_featured send the POST that creates a new map

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnsave.js
+++ b/geonode_mapstore_client/client/js/epics/gnsave.js
@@ -149,7 +149,9 @@ export const gnSaveContent = (action$, store) =>
             const body = {
                 'title': action.metadata.name,
                 ...(RESOURCE_MANAGEMENT_PROPERTIES_KEYS.reduce((acc, key) => {
-                    acc[key] = !!currentResource?.[key];
+                    if (currentResource?.[key] !== undefined) {
+                        acc[key] = !!currentResource[key];
+                    }
                     return acc;
                 }, {})),
                 ...(action.metadata.description && { 'abstract': action.metadata.description }),


### PR DESCRIPTION
This PR adds review how the `RESOURCE_MANAGEMENT_PROPERTIES_KEYS` are passed during the saving process. If they are undefined they will not be included