### PR TITLE
Fix #1857 After saving a resource the resource information must be refreshed

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnsave.js
+++ b/geonode_mapstore_client/client/js/epics/gnsave.js
@@ -171,7 +171,8 @@ export const gnSaveContent = (action$, store) =>
                         saveSuccess(resource),
                         setResource({
                             ...currentResource,
-                            ...body
+                            ...body,
+                            ...resource
                         }),
                         updateResource(resource),
                         ...(action.showNotifications


### PR DESCRIPTION
This PR includes refresh the content of the resource with the payload returned by the save workflow