### PR TITLE
Updates to improve templates customizations

### DIFF
--- a/geonode_mapstore_client/client/js/components/CardGrid/CardGrid.jsx
+++ b/geonode_mapstore_client/client/js/components/CardGrid/CardGrid.jsx
@@ -11,17 +11,14 @@ import Spinner from '@js/components/Spinner';
 import HTML from '@mapstore/framework/components/I18N/HTML';
 import FaIcon from '@js/components/FaIcon';
 import ResourceCard from '@js/components/ResourceCard';
-import {withResizeDetector} from 'react-resize-detector';
 import useInfiniteScroll from '@js/hooks/useInfiniteScroll';
 import {getResourceStatuses} from '@js/utils/ResourceUtils';
 import MainLoader from '@js/components/MainLoader';
 
-const Cards = withResizeDetector(({
+const Cards = ({
     resources,
     formatHref,
     isCardActive,
-    containerWidth,
-    width: detectedWidth,
     buildHrefByTemplate,
     options,
     downloading,
@@ -30,70 +27,17 @@ const Cards = withResizeDetector(({
     children
 }) => {
 
-    const width = containerWidth || detectedWidth;
-    const margin = 24;
-    const size = 320;
-    const count = Math.floor(width / (size + margin));
-    const cardWidth = width >= size + margin * 2
-        ? Math.floor((width - margin * count) / count)
-        : '100%';
-
-    const ulPadding = Math.floor(margin / 2);
-    const isSingleCard = count === 0 || count === 1;
-
-    const gridLayoutSpace = (idx) => {
-        return isSingleCard
-            ? {
-                width: width - margin,
-                margin: ulPadding
-            }
-            : {
-                width: cardWidth,
-                marginRight: (idx + 1) % count === 0 ? 0 : margin,
-                marginTop: margin
-            };
-    };
-
-    const listLayoutSpace = {
-        width: '100%',
-        margin: ulPadding / 2
-    };
-
-
-    const layoutSpace = (idx) => {
-        let cardContainerSpace;
-        switch (cardLayoutStyle) {
-        case 'list':
-            cardContainerSpace = listLayoutSpace;
-            break;
-        default:
-            cardContainerSpace = gridLayoutSpace(idx);
-        }
-        return cardContainerSpace;
-    };
-
-    const containerStyle = isSingleCard
-        ? {
-            paddingBottom: margin
-        }
-        : {
-            paddingLeft: ulPadding,
-            paddingBottom: margin
-        };
     return (
         <ul
-            className={'gn-card-list'}
-            style={{...(cardLayoutStyle === 'list' ? {} : containerStyle)}}
+            className={`gn-card-list gn-cards-type-${cardLayoutStyle}`}
         >
-            {resources.map((resource, idx) => {
+            {resources.map((resource) => {
                 const { isProcessing } = getResourceStatuses(resource);
                 // enable allowedOptions (menu cards)
                 const allowedOptions =  !isProcessing ? options : [];
-
                 return (
                     <li
                         key={resource.pk2 || resource.pk} // pk2 exists on clones to avoid duplicate keys
-                        style={(layoutSpace(idx))}
                     >
                         <ResourceCard
                             active={isCardActive(resource)}
@@ -113,7 +57,7 @@ const Cards = withResizeDetector(({
             {children}
         </ul>
     );
-});
+};
 
 const InfiniteScrollCardGrid = ({
     resources,
@@ -147,37 +91,30 @@ const InfiniteScrollCardGrid = ({
 
     return (
         <div className="gn-card-grid">
-            <div style={{
-                display: 'flex',
-                width: '100%'
-            }}>
-                <div style={{ flex: 1, width: '100%' }}>
-                    <div className="gn-card-grid-container" style={containerStyle}>
-                        {header}
-                        {children}
-                        {messageId && <div className="gn-card-grid-message">
-                            <h1><HTML msgId={`gnhome.${messageId}Title`}/></h1>
-                            <p>
-                                <HTML msgId={`gnhome.${messageId}Content`}/>
-                            </p>
-                        </div>}
-                        <Cards
-                            resources={resources}
-                            formatHref={formatHref}
-                            getDetailHref={getDetailHref}
-                            isCardActive={isCardActive}
-                            options={cardOptions}
-                            buildHrefByTemplate={buildHrefByTemplate}
-                            downloading={downloading}
-                            cardLayoutStyle={cardLayoutStyle}
-                        />
-                        <div className="gn-card-grid-pagination">
-                            {loading && <Spinner animation="border" role="status">
-                                <span className="sr-only">Loading...</span>
-                            </Spinner>}
-                            {hasResources && !isNextPageAvailable && !loading && <FaIcon name="dot-circle-o" />}
-                        </div>
-                    </div>
+            <div className="gn-card-grid-container" style={containerStyle}>
+                {header}
+                {children}
+                {messageId && <div className="gn-card-grid-message">
+                    <h1><HTML msgId={`gnhome.${messageId}Title`}/></h1>
+                    <p>
+                        <HTML msgId={`gnhome.${messageId}Content`}/>
+                    </p>
+                </div>}
+                <Cards
+                    resources={resources}
+                    formatHref={formatHref}
+                    getDetailHref={getDetailHref}
+                    isCardActive={isCardActive}
+                    options={cardOptions}
+                    buildHrefByTemplate={buildHrefByTemplate}
+                    downloading={downloading}
+                    cardLayoutStyle={cardLayoutStyle}
+                />
+                <div className="gn-card-grid-pagination">
+                    {loading && <Spinner animation="border" role="status">
+                        <span className="sr-only">Loading...</span>
+                    </Spinner>}
+                    {hasResources && !isNextPageAvailable && !loading && <FaIcon name="dot-circle-o" />}
                 </div>
             </div>
         </div>
@@ -203,36 +140,29 @@ const FixedCardGrid = ({
 }) => {
     return (
         <div className="gn-card-grid">
-            <div style={{
-                display: 'flex',
-                width: '100%'
-            }}>
-                <div style={{ flex: 1, width: '100%' }}>
-                    <div className="gn-card-grid-container" style={containerStyle}>
-                        {header}
-                        {children}
-                        {messageId && <div className="gn-card-grid-message">
-                            <h1><HTML msgId={`gnhome.${messageId}Title`}/></h1>
-                            <p>
-                                <HTML msgId={`gnhome.${messageId}Content`}/>
-                            </p>
-                        </div>}
-                        <Cards
-                            resources={resources}
-                            formatHref={formatHref}
-                            getDetailHref={getDetailHref}
-                            isCardActive={isCardActive}
-                            options={cardOptions}
-                            buildHrefByTemplate={buildHrefByTemplate}
-                            downloading={downloading}
-                            onSelect={onSelect}
-                            cardLayoutStyle={cardLayoutStyle}
-                        >
-                            {loading && resources.length > 0 ? <MainLoader className="gn-cards-loader"/> : null}
-                        </Cards>
-                        {footer}
-                    </div>
-                </div>
+            <div className="gn-card-grid-container" style={containerStyle}>
+                {header}
+                {children}
+                {messageId && <div className="gn-card-grid-message">
+                    <h1><HTML msgId={`gnhome.${messageId}Title`}/></h1>
+                    <p>
+                        <HTML msgId={`gnhome.${messageId}Content`}/>
+                    </p>
+                </div>}
+                <Cards
+                    resources={resources}
+                    formatHref={formatHref}
+                    getDetailHref={getDetailHref}
+                    isCardActive={isCardActive}
+                    options={cardOptions}
+                    buildHrefByTemplate={buildHrefByTemplate}
+                    downloading={downloading}
+                    onSelect={onSelect}
+                    cardLayoutStyle={cardLayoutStyle}
+                >
+                    {loading && resources.length > 0 ? <MainLoader className="gn-cards-loader"/> : null}
+                </Cards>
+                {footer}
             </div>
         </div>
     );

--- a/geonode_mapstore_client/client/js/components/FeaturedList/Cards.jsx
+++ b/geonode_mapstore_client/client/js/components/FeaturedList/Cards.jsx
@@ -6,9 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import ResourceCard from '@js/components/ResourceCard';
-import { withResizeDetector } from 'react-resize-detector';
 import { getResourceStatuses } from '@js/utils/ResourceUtils';
 
 const Cards = ({
@@ -16,62 +15,20 @@ const Cards = ({
     formatHref,
     isCardActive,
     buildHrefByTemplate,
-    containerWidth,
-    width: detectedWidth,
     options,
-    onResize,
     downloading,
     getDetailHref
 }) => {
-    const width = detectedWidth || containerWidth;
-    const margin = 24;
-    const size = 320;
-    const countNum = Math.floor(width / (size + margin));
-    const count = countNum > 4 ? 4 : countNum; // limit count in order not to request for more than 4 per page
-    const cardWidth = width >= size + margin * 2
-        ? Math.floor((width - margin * count) / count)
-        : '100%';
-    useEffect(() => {
-        onResize(count);
-    }, [count]);
-    const ulPadding = Math.floor(margin / 2);
-    const isSingleCard = count === 0 || count === 1;
-
-    const gridLayoutSpace = (idx) => {
-
-        const gridSpace = isSingleCard
-            ? {
-                width: width - margin,
-                margin: ulPadding
-            }
-            : {
-                width: cardWidth,
-                marginRight: (idx + 1) % count === 0 ? 0 : margin,
-                marginTop: 8
-            };
-
-        return gridSpace;
-    };
-
-    const containerStyle = isSingleCard
-        ? {
-            paddingBottom: 0
-        }
-        : {
-            paddingLeft: ulPadding,
-            paddingBottom: 0
-        };
-    return (detectedWidth ?
+    return (
         <ul
-            style={containerStyle}
+            className={`gn-card-list gn-cards-type-grid`}
         >
-            {resources.map((resource, idx) => {
+            {resources.map((resource) => {
                 const { isProcessing } = getResourceStatuses(resource);
 
                 return (
                     <li
                         key={resource?.pk}
-                        style={(gridLayoutSpace(idx))}
                     >
                         <ResourceCard
                             active={isCardActive(resource)}
@@ -89,8 +46,8 @@ const Cards = ({
                     </li>
                 );
             })}
-        </ul> : <div />
+        </ul>
     );
 };
 
-export default withResizeDetector(Cards);
+export default Cards;

--- a/geonode_mapstore_client/client/js/components/FeaturedList/FeaturedList.jsx
+++ b/geonode_mapstore_client/client/js/components/FeaturedList/FeaturedList.jsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
 import Button from '@js/components/Button';
 import Spinner from '@js/components/Spinner';
 import HTML from '@mapstore/framework/components/I18N/HTML';
@@ -28,10 +28,9 @@ const FeaturedList = withResizeDetector(({
     onLoad,
     width,
     downloading,
-    getDetailHref
+    getDetailHref,
+    cardsCount = 4
 }) => {
-
-    const [count, setCount] = useState();
 
     const nextIconStyles = {
         fontSize: '1rem',
@@ -43,48 +42,42 @@ const FeaturedList = withResizeDetector(({
         ...(!isPreviousPageAvailable || loading ? { color: 'grey', cursor: 'not-allowed' } : { cursor: 'pointer' })
     };
 
+    useEffect(() => {
+        onLoad(undefined, cardsCount);
+    }, [cardsCount]);
+
     return (
         <div className="gn-card-grid" style={resources.length === 0 ? { display: 'none' } : {}}>
             {header}
-            <div style={{
-                display: 'flex', width: '100%'
-            }}>
-                <div style={{ flex: 1, width: '100%' }}>
-                    <div className="gn-card-grid-container" style={containerStyle}>
-                        <h3><HTML msgId={`gnhome.featuredList`}/></h3>
-                        <Cards
-                            featured
-                            resources={resources}
-                            formatHref={formatHref}
-                            isCardActive={isCardActive}
-                            buildHrefByTemplate={buildHrefByTemplate}
-                            containerWidth={width}
-                            onResize={(cardsCount) => {
-                                !isNaN(cardsCount) && onLoad(undefined, cardsCount);
-                                setCount(cardsCount);
-                            }}
-                            downloading={downloading}
-                            getDetailHref={getDetailHref}
-                        />
-                        <div className="gn-card-grid-pagination featured-list">
+            <div className="gn-card-grid-container" style={containerStyle}>
+                <h3><HTML msgId={`gnhome.featuredList`}/></h3>
+                <Cards
+                    featured
+                    resources={resources}
+                    formatHref={formatHref}
+                    isCardActive={isCardActive}
+                    buildHrefByTemplate={buildHrefByTemplate}
+                    containerWidth={width}
+                    downloading={downloading}
+                    getDetailHref={getDetailHref}
+                />
+                <div className="gn-card-grid-pagination featured-list">
 
-                            <Button size="sm" onClick={() => loadFeaturedResources("previous", count)} disabled={!isPreviousPageAvailable || loading}
-                                aria-hidden="true">
-                                <FaIcon  style={previousIconStyles} name="caret-left"/>
-                            </Button>
+                    <Button size="sm" onClick={() => loadFeaturedResources("previous", cardsCount)} disabled={!isPreviousPageAvailable || loading}
+                        aria-hidden="true">
+                        <FaIcon  style={previousIconStyles} name="caret-left"/>
+                    </Button>
 
-                            <div>
-                                { loading && <Spinner size="sm"  animation="border" role="status">
-                                    <span className="sr-only">Loading...</span>
-                                </Spinner>}
-                            </div>
-                            <Button size="sm" onClick={() => loadFeaturedResources("next", count)} disabled={!isNextPageAvailable || loading}
-                                aria-hidden="true">
-                                <FaIcon style={nextIconStyles} name="caret-right"/>
-
-                            </Button>
-                        </div>
+                    <div>
+                        { loading && <Spinner size="sm"  animation="border" role="status">
+                            <span className="sr-only">Loading...</span>
+                        </Spinner>}
                     </div>
+                    <Button size="sm" onClick={() => loadFeaturedResources("next", cardsCount)} disabled={!isNextPageAvailable || loading}
+                        aria-hidden="true">
+                        <FaIcon style={nextIconStyles} name="caret-right"/>
+
+                    </Button>
                 </div>
             </div>
         </div>

--- a/geonode_mapstore_client/client/js/components/FiltersMenu/FiltersMenu.jsx
+++ b/geonode_mapstore_client/client/js/components/FiltersMenu/FiltersMenu.jsx
@@ -21,25 +21,60 @@ const ButtonWithTooltip = tooltip(Button);
 
 const FiltersMenu = forwardRef(({
     formatHref,
-    orderOptions,
     order,
     cardsMenu,
     style,
     onClick,
-    defaultLabelId,
     totalResources,
     totalFilters,
     loading,
     hideCardLayoutButton,
     cardLayoutStyle,
-    setCardLayoutStyle
+    setCardLayoutStyle,
+    orderConfig
 }, ref) => {
+
+    const {
+        defaultLabelId,
+        options: orderOptions,
+        variant: orderVariant,
+        align: orderAlign = 'right'
+    } = orderConfig;
 
     const { isMobile } = getConfigProp('geoNodeSettings');
     const selectedSort = orderOptions.find(({ value }) => order === value);
     function handleToggleCardLayoutStyle() {
         setCardLayoutStyle(cardLayoutStyle === 'grid' ? 'list' : 'grid');
     }
+
+    const orderButtonNode = orderOptions.length > 0 &&
+        <Dropdown pullRight={orderAlign === 'right'} id="sort-dropdown">
+            <Dropdown.Toggle
+                bsStyle={orderVariant || 'default'}
+                bsSize="sm"
+                noCaret
+            >
+                <Message msgId={selectedSort?.labelId || defaultLabelId} />
+            </Dropdown.Toggle>
+            <Dropdown.Menu>
+                {orderOptions.map(({ labelId, value }) => {
+                    return (
+                        <Dropdown.Item
+                            key={value}
+                            active={value === selectedSort?.value}
+                            href={formatHref({
+                                query: {
+                                    sort: [value]
+                                },
+                                replaceQuery: true
+                            })}
+                        >
+                            <Message msgId={labelId} />
+                        </Dropdown.Item>
+                    );
+                })}
+            </Dropdown.Menu>
+        </Dropdown>;
 
     return (
         <div
@@ -65,7 +100,7 @@ const FiltersMenu = forwardRef(({
                         >
                             {isMobile ? <FaIcon name="filter" /> : <Message msgId="gnhome.filter"/>}
                         </Button>}
-                        {' '}
+                        {orderAlign === 'left' ? orderButtonNode : null}
                         {loading ? <span className="resources-count-loading"><Spinner /></span> : <Badge>
                             <span className="resources-count"> <Message msgId="gnhome.resourcesFound" msgParams={{ count: totalResources }}/> </span>
                         </Badge>}
@@ -83,34 +118,7 @@ const FiltersMenu = forwardRef(({
                     >
                         <FaIcon name={cardLayoutStyle === 'grid' ? 'list' : 'th'} />
                     </Button>}
-                    {orderOptions.length > 0 &&
-                    <Dropdown pullRight id="sort-dropdown">
-                        <Dropdown.Toggle
-                            bsStyle="default"
-                            bsSize="sm"
-                            noCaret
-                        >
-                            <Message msgId={selectedSort?.labelId || defaultLabelId} />
-                        </Dropdown.Toggle>
-                        <Dropdown.Menu>
-                            {orderOptions.map(({ labelId, value }) => {
-                                return (
-                                    <Dropdown.Item
-                                        key={value}
-                                        active={value === selectedSort?.value}
-                                        href={formatHref({
-                                            query: {
-                                                sort: [value]
-                                            },
-                                            replaceQuery: true
-                                        })}
-                                    >
-                                        <Message msgId={labelId} />
-                                    </Dropdown.Item>
-                                );
-                            })}
-                        </Dropdown.Menu>
-                    </Dropdown>}
+                    {orderAlign === 'right' ? orderButtonNode : null}
                 </div>
             </div>
         </div>

--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -442,11 +442,12 @@ export const gnViewerRequestNewResourceConfig = (action$, store) =>
             const { newResourceObservable } = resourceTypes[action.resourceType] || {};
             const state = store.getState();
             if (!canAddResource(state)) {
+                const pathname = state?.router?.location?.pathname;
                 const formattedUrl = url.format({
                     ...window.location,
                     pathname: '/account/login/',
                     hash: '',
-                    search: `?next=${getCataloguePath('/catalogue')}`
+                    search: `?next=${getCataloguePath('/catalogue')}${pathname ? `/#${pathname}` : ''}`
                 });
                 window.location.href = formattedUrl;
                 window.reload();

--- a/geonode_mapstore_client/client/js/plugins/ResourcesGrid.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ResourcesGrid.jsx
@@ -781,8 +781,7 @@ function ResourcesGrid({
                                         order={query?.sort}
                                         onClear={handleClear}
                                         onClick={handleShowFilterForm.bind(null, true)}
-                                        orderOptions={parsedConfig.order?.options}
-                                        defaultLabelId={parsedConfig.order?.defaultLabelId}
+                                        orderConfig={parsedConfig.order}
                                         totalResources={totalResources}
                                         totalFilters={queryFilters.length}
                                         filtersActive={!!(queryFilters.length > 0)}

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -337,8 +337,7 @@ export const getResourceTypesInfo = () => ({
         name: 'Dataset',
         formatMetadataUrl: (resource) => isDefaultDatasetSubtype(resource?.subtype)
             ? `/datasets/${resource.store ? resource.store + ":" : ''}${resource.alternate}/metadata`
-            : `/resources/${resource.pk}/metadata`,
-        catalogPageUrl: '/datasets'
+            : `/resources/${resource.pk}/metadata`
     },
     [ResourceTypes.MAP]: {
         icon: 'map',
@@ -348,8 +347,7 @@ export const getResourceTypesInfo = () => ({
             config: 'map_preview'
         })),
         formatDetailUrl: (resource) => resource?.detail_url && parseDevHostname(resource.detail_url),
-        formatMetadataUrl: (resource) => (`/maps/${resource.pk}/metadata`),
-        catalogPageUrl: '/maps'
+        formatMetadataUrl: (resource) => (`/maps/${resource.pk}/metadata`)
     },
     [ResourceTypes.DOCUMENT]: {
         icon: 'file',
@@ -359,8 +357,7 @@ export const getResourceTypesInfo = () => ({
         formatEmbedUrl: (resource) => isDocumentExternalSource(resource) ? undefined : resource?.embed_url && parseDevHostname(resource.embed_url),
         formatDetailUrl: (resource) => resource?.detail_url && parseDevHostname(resource.detail_url),
         formatMetadataUrl: (resource) => (`/documents/${resource.pk}/metadata`),
-        metadataPreviewUrl: (resource) => (`/documents/${resource.pk}/metadata_detail?preview`),
-        catalogPageUrl: '/documents'
+        metadataPreviewUrl: (resource) => (`/documents/${resource.pk}/metadata_detail?preview`)
     },
     [ResourceTypes.GEOSTORY]: {
         icon: 'book',
@@ -368,8 +365,7 @@ export const getResourceTypesInfo = () => ({
         canPreviewed: (resource) => resourceHasPermission(resource, 'view_resourcebase'),
         formatEmbedUrl: (resource) => resource?.embed_url && parseDevHostname(resource.embed_url),
         formatDetailUrl: (resource) => resource?.detail_url && parseDevHostname(resource.detail_url),
-        formatMetadataUrl: (resource) => (`/apps/${resource.pk}/metadata`),
-        catalogPageUrl: '/geostories'
+        formatMetadataUrl: (resource) => (`/apps/${resource.pk}/metadata`)
     },
     [ResourceTypes.DASHBOARD]: {
         icon: 'dashboard',
@@ -377,8 +373,7 @@ export const getResourceTypesInfo = () => ({
         canPreviewed: (resource) => resourceHasPermission(resource, 'view_resourcebase'),
         formatEmbedUrl: (resource) => resource?.embed_url && parseDevHostname(resource.embed_url),
         formatDetailUrl: (resource) => resource?.detail_url && parseDevHostname(resource.detail_url),
-        formatMetadataUrl: (resource) => (`/apps/${resource.pk}/metadata`),
-        catalogPageUrl: '/dashboards'
+        formatMetadataUrl: (resource) => (`/apps/${resource.pk}/metadata`)
     },
     [ResourceTypes.VIEWER]: {
         icon: 'cogs',
@@ -386,8 +381,7 @@ export const getResourceTypesInfo = () => ({
         canPreviewed: (resource) => resourceHasPermission(resource, 'view_resourcebase'),
         formatEmbedUrl: () => false,
         formatDetailUrl: (resource) => resource?.detail_url && parseDevHostname(resource.detail_url),
-        formatMetadataUrl: (resource) => (`/apps/${resource.pk}/metadata`),
-        catalogPageUrl: '/all'
+        formatMetadataUrl: (resource) => (`/apps/${resource.pk}/metadata`)
     }
 });
 
@@ -831,14 +825,6 @@ export const getResourceAdditionalProperties = (_resource = {}) => {
     };
 };
 
-export const onDeleteRedirectTo = (resources = []) => {
-    let redirectUrl = '/';
-    if (!isEmpty(resources) && resources?.length === 1) {
-        const types = getResourceTypesInfo();
-        const { catalogPageUrl } = types[resources[0].resource_type] ?? {};
-        if (catalogPageUrl) {
-            redirectUrl = catalogPageUrl;
-        }
-    }
-    return redirectUrl;
+export const onDeleteRedirectTo = () => {
+    return '/';
 };

--- a/geonode_mapstore_client/client/themes/geonode/less/_card-grid.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_card-grid.less
@@ -51,6 +51,8 @@
 
 .gn-card-grid {
     padding-top: 20px;
+    container-name: card-grid;
+    container-type: inline-size;
     .gn-card-grid-container {
         position: relative;
         max-width: @gn-page-max-width;
@@ -74,9 +76,13 @@
         max-width: @gn-page-max-width;
         margin: auto;
         width: 100%;
-        li {
+        > li {
             padding: 0;
-            margin: 0;
+            width: calc(100% - 1rem);
+            margin: 0.5rem;
+        }
+        &.gn-cards-type-grid > li {
+            width: calc(25% - 1rem);
         }
         .gn-cards-loader {
             z-index: 2;
@@ -125,6 +131,17 @@
             outline: none !important;
         }
 
+    }
+}
+
+@container card-grid (width < 1100px) {
+    .gn-card-grid .gn-card-grid-container>ul.gn-cards-type-grid > li {
+        width: calc(50% - 1rem);
+    }
+}
+@container card-grid (width < 600px) {
+    .gn-card-grid .gn-card-grid-container>ul.gn-cards-type-grid > li {
+        width: calc(100% - 1rem);
     }
 }
 

--- a/geonode_mapstore_client/client/themes/geonode/less/_menu.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_menu.less
@@ -259,6 +259,9 @@ nav.hide-navigation#gn-topbar {
     position: sticky;
     top: 0px;
     z-index: 10;
+    .gn-menu-fill {
+        gap: 0.25rem;
+    }
 }
 
 .gn-action-navbar-title {

--- a/geonode_mapstore_client/templates/documents/document_embed.html
+++ b/geonode_mapstore_client/templates/documents/document_embed.html
@@ -4,20 +4,13 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+        {% include 'geonode-mapstore-client/snippets/head.html' %}
         {% if TWITTER_CARD %}
             {% include "base/_resourcebase_twittercard.html" %}
         {% endif %}
         {% if OPENGRAPH_ENABLED %}
             {% include "base/_resourcebase_opengraph.html" %}
         {% endif %}
-        <link rel="preconnect" href="https://fonts.gstatic.com">
-        <link href="/static/fonts/montserrat.css" rel="stylesheet">
-        <link href="{% static 'mapstore/dist/themes/geonode.css' %}?{% client_version %}" rel="stylesheet" />
-        <title>{{ SITE_NAME }}</title>
-        <link rel="shortcut icon" href="{% static 'geonode/img/favicon.ico' %}" />
         {% include 'geonode-mapstore-client/snippets/loader_style.html' %}
 
         {% block custom_theme %}

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/catalogue.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/catalogue.html
@@ -4,14 +4,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="preconnect" href="https://fonts.gstatic.com">
-        <link href="/static/fonts/montserrat.css" rel="stylesheet">
-        <link href="{% static 'mapstore/dist/themes/geonode.css' %}?{% client_version %}" rel="stylesheet" />
-        <title>{{ SITE_NAME }}</title>
-        <link rel="shortcut icon" href="{% static 'geonode/img/favicon.ico' %}" />
+        {% include './snippets/head.html' %}
         {% include './snippets/loader_style.html' %}
 
         {% block custom_theme %}

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/dashboard_embed.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/dashboard_embed.html
@@ -4,14 +4,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="preconnect" href="https://fonts.gstatic.com">
-        <link href="/static/fonts/montserrat.css" rel="stylesheet">
-        <link href="{% static 'mapstore/dist/themes/geonode.css' %}?{% client_version %}" rel="stylesheet" />
-        <title>{{ SITE_NAME }}</title>
-        <link rel="shortcut icon" href="{% static 'geonode/img/favicon.ico' %}" />
+        {% include './snippets/head.html' %}
         {% include './snippets/loader_style.html' %}
 
         {% block custom_theme %}

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/dataset_embed.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/dataset_embed.html
@@ -4,20 +4,13 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+        {% include './snippets/head.html' %}
         {% if TWITTER_CARD %}
             {% include "base/_resourcebase_twittercard.html" %}
         {% endif %}
         {% if OPENGRAPH_ENABLED %}
             {% include "base/_resourcebase_opengraph.html" %}
         {% endif %}
-        <link rel="preconnect" href="https://fonts.gstatic.com">
-        <link href="/static/fonts/montserrat.css" rel="stylesheet">
-        <link href="{% static 'mapstore/dist/themes/geonode.css' %}?{% client_version %}" rel="stylesheet" />
-        <title>{{ SITE_NAME }}</title>
-        <link rel="shortcut icon" href="{% static 'geonode/img/favicon.ico' %}" />
         {% include './snippets/loader_style.html' %}
 
         {% block custom_theme %}

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/geostory_embed.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/geostory_embed.html
@@ -4,14 +4,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="preconnect" href="https://fonts.gstatic.com">
-        <link href="/static/fonts/montserrat.css" rel="stylesheet">
-        <link href="{% static 'mapstore/dist/themes/geonode.css' %}?{% client_version %}" rel="stylesheet" />
-        <title>{{ SITE_NAME }}</title>
-        <link rel="shortcut icon" href="{% static 'geonode/img/favicon.ico' %}" />
+        {% include './snippets/head.html' %}
         {% include './snippets/loader_style.html' %}
 
         {% block custom_theme %}

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/map_embed.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/map_embed.html
@@ -4,14 +4,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="preconnect" href="https://fonts.gstatic.com">
-        <link href="https://fonts.googleapis.com/css2?family=Lato&display=swap" rel="stylesheet">
-        <link href="{% static 'mapstore/dist/themes/geonode.css' %}?{% client_version %}" rel="stylesheet" />
-        <title>{{ SITE_NAME }}</title>
-        <link rel="shortcut icon" href="{% static 'geonode/img/favicon.ico' %}" />
+        {% include './snippets/head.html' %}
         {% include './snippets/loader_style.html' %}
 
         {% block custom_theme %}

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/head.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/head.html
@@ -1,0 +1,21 @@
+{% load static %}
+{% load client_lib_tags %}
+{% load client_version %}
+
+<meta charset="UTF-8">
+<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+{%block font%}
+    <link href="{% static 'fonts/montserrat.css' %}" rel="stylesheet">
+{%endblock font %}
+
+<link href="{% static 'mapstore/dist/themes/geonode.css' %}?{% client_version %}" rel="stylesheet" />
+<title>{{ SITE_NAME }}</title>
+
+{%block favicon%}
+    <link rel="shortcut icon" href="{% static 'geonode/img/favicon.ico' %}" />
+{%endblock favicon%}
+
+{%block extras%}
+{%endblock extras%}

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/menu_item.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/menu_item.html
@@ -3,7 +3,7 @@
     {% if menu_item.type == 'link' %}
         <li>
             <a
-                id={{ menu_item.label | slugify }}
+                id={{ menu_item.id|default:menu_item.label|slugify }}
                 href="{{ menu_item.href }}"
                 target="{{ menu_item.target }}"
                 class="nav-link btn btn-{{variant|default:'default'}}"

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/resource_card.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/resource_card.html
@@ -1,0 +1,57 @@
+{% load i18n %}
+<div class="gn-resource-card gn-card-type-grid">
+    {% if params.detail_panel_url %}
+        <a class="gn-resource-card-link" href="{{ params.detail_panel_url }}"></a>
+    {% else %}
+        <a class="gn-resource-card-link" href="{{ params.detail_url }}"></a>
+    {% endif %}
+    <div class="card-resource-grid">
+        {% if params.thumbnail_url %}
+            <img
+                class="card-img-top"
+                src="{{ params.thumbnail_url }}"
+            >
+        {% else %}
+            <div class="card-img-top card-img-placeholder"><i class="fa fa-{{ params.icon_name }}"></i></div>
+        {% endif %}
+        <div class="gn-resource-card-body-wrapper">
+            <div class="card-body">
+                <div class="card-title">
+                    <div>
+                        <i class="fa fa-{{ params.icon_name }}"></i>
+                        <span class="gn-card-title">
+                            {% trans params.title %}
+                        </span>
+                        <p class="card-text gn-card-description grid">{% trans params.description  %}</p>
+                    </div>
+                    <div>
+                        <p class="gn-resource-status-text"></p>
+                    </div>
+                </div>
+            </div>
+            <div class="gn-footer-wrapper">
+                <div class="gn-card-footer" style="padding: 0px 0.5rem;">
+                    <p class="card-text gn-card-user">
+                        {% if params.avatar %}
+                            <img class="gn-card-author-image" src="{{params.avatar}}">
+                        {% endif %}
+                        <span>{{ params.username }}</span>
+                    </p>
+                    {% if params.detail_url and params.detail_panel_url %}
+                        <div class="gn-card-actions">
+                            <div class="gn-card-view-editor">
+                                <a
+                                    href={{ params.detail_url }}
+                                    rel="noopener noreferrer"
+                                    class="btn btn-primary"
+                                >
+                                    <span>{% trans "View" %}</span>
+                                </a>
+                            </div>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/resources_grid.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/resources_grid.html
@@ -1,0 +1,37 @@
+{% load i18n %}
+<div class="gn-resources-grid gn-row">
+    <div class="gn-grid-container">
+        <div class="gn-card-grid">
+            <div class="gn-card-grid-container" style="min-height:auto;">
+                {%if not params.hide_filter_menu %}
+                    <div class="gn-filters-menu gn-menu gn-default">
+                        <div class="gn-menu-container">
+                            <div class="gn-menu-content">
+                                <div class="gn-menu-fill">
+                                    {% for item in params.left_menu_items %}
+                                        <a class="btn btn-sm btn-{{item.variant}}" href={{item.href}}>{{item.label}}</a>
+                                    {% endfor %}
+                                    <span class="badge">
+                                        <span class="resources-count"> <span>{{ params.count }} {% trans "Resource found" %}</span> </span>
+                                    </span>
+                                </div>
+                                <ul class="gn-menu-list">
+                                    {% for item in params.right_menu_items %}
+                                        <li><a class="btn btn-sm btn-{{item.variant}}" href={{item.href}}>{{item.label}}</a></li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                {%endif%}
+                <ul class="gn-card-list gn-cards-type-grid">
+                    {% for resource in params.resources %}
+                        <li>
+                            {% include './resource_card.html' with params=resource %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>

--- a/geonode_mapstore_client/templates/index.html
+++ b/geonode_mapstore_client/templates/index.html
@@ -3,13 +3,7 @@
 <!DOCTYPE html>
 <html class="msgapi">
     <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link href="/static/fonts/montserrat.css" rel="stylesheet">
-        <link href="{% static 'mapstore/dist/themes/geonode.css' %}?{% client_version %}" rel="stylesheet" />
-        <title>{{ SITE_NAME }}</title>
-        <link rel="shortcut icon" href="{% static 'geonode/img/favicon.ico' %}" />
+        {% include './geonode-mapstore-client/snippets/head.html' %}
         {% include './geonode-mapstore-client/snippets/loader_style.html' %}
 
         {% block custom_theme %}

--- a/geonode_mapstore_client/templates/page.html
+++ b/geonode_mapstore_client/templates/page.html
@@ -3,13 +3,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link href="/static/fonts/montserrat.css" rel="stylesheet">
-        <link href="{% static 'mapstore/dist/themes/geonode.css' %}?{% client_version %}" rel="stylesheet" />
-        <title>{{ SITE_NAME }}</title>
-        <link rel="shortcut icon" href="{% static 'geonode/img/favicon.ico' %}" />
+        {% include './geonode-mapstore-client/snippets/head.html' %}
         {% include './geonode-mapstore-client/snippets/loader_style.html' %}
 
         {% block custom_theme %}


### PR DESCRIPTION
This PR introduces following updates:

- centralize head tags in a new snippet (head.html) to override favicon or fonts
- introduction of two new snippets reasource_card.html and resources_grid.html to replicate the resource grid in django templates
- remove all the js logic to resize resources grid card in favor of [CSS container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries). This simplify the js code and align styles between react and django templates
- include the possibility to move order button of the resource grid to the left
- featured resources in homepage will show always four cards following the same layout of resources grid
- update the authentication redirect including also the hash path when available