### PR TITLE
Fixes #1854 (no linebreak in Firefox)

### DIFF
--- a/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_details-panel.less
@@ -504,6 +504,7 @@
             &> a {
                 margin-right: 0.5rem;
                 white-space: nowrap;
+                display: inline-block;
             }
         }
         &.gn-details-flex-field {


### PR DESCRIPTION
This PR addresses issue [#1854.](https://github.com/GeoNode/geonode-mapstore-client/issues/1854) 
 
My best guess is that there is a difference between Firefox and Chrome in how they handle linebreaking for inline elements that have white-space: nowrap property. 
 
Apparantly Chrome allows line breaks between inline elements within a container if the container's width is insufficient to accommodate them on a single line, while Firefox renders it differently and no linebreak occurs with that same property value. If the nowrap value is removed, behaviour would be consistent across those two browsers and wrapping happens. 
 
However, I think this property serves a purpose, it was introduced in [this fix](https://github.com/GeoNode/geonode-mapstore-client/pull/1515) for [this issue](https://github.com/GeoNode/geonode-mapstore-client/issues/1514). If the property is removed, regions and keywords would be wrapped on white space, potentially splitting phrases that are only meaningful together onto two lines, which is probably undesirable. 
 
Therefore, my proposed fix makes those elements inline-block, which allows them to wrap as separate boxes and respect the container’s width.