### PR TITLE
#1941: Remove allowedRoles constraints from CRSSelector config

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
@@ -595,9 +595,6 @@
         "filterAllowedCRS": [
           "EPSG:4326",
           "EPSG:3857"
-        ],
-        "allowedRoles": [
-          "ADMIN"
         ]
       }
     },


### PR DESCRIPTION
### Description
This PR removes allowedRoles props from default config in the CRSSelector plugin (context)

### Issue
- #1941 

