### PR TITLE
#1986: Restrict dataset API calls to layers from GeoNode’s catalog

### DIFF
--- a/geonode_mapstore_client/client/js/epics/__tests__/gnsave-test.js
+++ b/geonode_mapstore_client/client/js/epics/__tests__/gnsave-test.js
@@ -141,7 +141,7 @@ describe('gnsave epics', () => {
         mockAxios.onGet().reply(() => [200,
             {datasets: [{perms: ['change_dataset_style', 'change_dataset_data'], alternate: "testLayer"}]}]);
         const NUM_ACTIONS = 1;
-        testEpic(gnSetDatasetsPermissions, NUM_ACTIONS, addLayer({name: "testLayer", pk: "1"}), (actions) => {
+        testEpic(gnSetDatasetsPermissions, NUM_ACTIONS, addLayer({name: "testLayer", pk: "1", extenderParams: {pk: "1"}}), (actions) => {
             try {
                 expect(actions.map(({type}) => type)).toEqual(["UPDATE_NODE"]);
                 done();

--- a/geonode_mapstore_client/client/js/epics/__tests__/gnsave-test.js
+++ b/geonode_mapstore_client/client/js/epics/__tests__/gnsave-test.js
@@ -126,7 +126,7 @@ describe('gnsave epics', () => {
         mockAxios.onGet().reply(() => [200,
             {datasets: [{perms: ['change_dataset_style', 'change_dataset_data'], alternate: "testLayer"}]}]);
         const NUM_ACTIONS = 1;
-        testEpic(gnSetDatasetsPermissions, NUM_ACTIONS, configureMap({map: {layers: [{name: "testLayer", id: "test_id"}]}}), (actions) => {
+        testEpic(gnSetDatasetsPermissions, NUM_ACTIONS, configureMap({map: {layers: [{name: "testLayer", id: "test_id", extendedParams: {pk: "1"}}]}}), (actions) => {
             try {
                 expect(actions.map(({type}) => type)).toEqual(["UPDATE_NODE"]);
                 done();
@@ -141,7 +141,7 @@ describe('gnsave epics', () => {
         mockAxios.onGet().reply(() => [200,
             {datasets: [{perms: ['change_dataset_style', 'change_dataset_data'], alternate: "testLayer"}]}]);
         const NUM_ACTIONS = 1;
-        testEpic(gnSetDatasetsPermissions, NUM_ACTIONS, addLayer({name: "testLayer"}), (actions) => {
+        testEpic(gnSetDatasetsPermissions, NUM_ACTIONS, addLayer({name: "testLayer", pk: "1"}), (actions) => {
             try {
                 expect(actions.map(({type}) => type)).toEqual(["UPDATE_NODE"]);
                 done();

--- a/geonode_mapstore_client/client/js/epics/__tests__/gnsave-test.js
+++ b/geonode_mapstore_client/client/js/epics/__tests__/gnsave-test.js
@@ -141,7 +141,7 @@ describe('gnsave epics', () => {
         mockAxios.onGet().reply(() => [200,
             {datasets: [{perms: ['change_dataset_style', 'change_dataset_data'], alternate: "testLayer"}]}]);
         const NUM_ACTIONS = 1;
-        testEpic(gnSetDatasetsPermissions, NUM_ACTIONS, addLayer({name: "testLayer", pk: "1", extenderParams: {pk: "1"}}), (actions) => {
+        testEpic(gnSetDatasetsPermissions, NUM_ACTIONS, addLayer({name: "testLayer", pk: "1", extendedParams: {pk: "1"}}), (actions) => {
             try {
                 expect(actions.map(({type}) => type)).toEqual(["UPDATE_NODE"]);
                 done();

--- a/geonode_mapstore_client/client/js/epics/index.js
+++ b/geonode_mapstore_client/client/js/epics/index.js
@@ -113,7 +113,7 @@ export const gnSetDatasetsPermissions = (actions$, { getState = () => {}} = {}) 
             }
 
             // skip layers of non-geonode origin
-            if (!action.layer?.pk) return Rx.Observable.empty();
+            if (!action.layer?.extendedParams?.pk) return Rx.Observable.empty();
 
             return Rx.Observable.defer(() => getDatasetByName(action.layer?.name))
                 .switchMap((layer = {}) => {

--- a/geonode_mapstore_client/client/js/epics/index.js
+++ b/geonode_mapstore_client/client/js/epics/index.js
@@ -96,7 +96,9 @@ export const gnSetDatasetsPermissions = (actions$, { getState = () => {}} = {}) 
     actions$.ofType(MAP_CONFIG_LOADED, ADD_LAYER)
         .switchMap((action) => {
             if (action.type === MAP_CONFIG_LOADED) {
-                const layerNames = action.config?.map?.layers?.filter((l) => l?.group !== "background")?.map((l) => l.name) ?? [];
+                let layerNames = action.config?.map?.layers?.filter((l) =>
+                    l?.group !== "background" && !!l?.extendedParams?.pk // skip layers of non-geonode origin
+                )?.map((l) => l.name) ?? [];
                 if (layerNames.length === 0) {
                     return Rx.Observable.empty();
                 }
@@ -109,6 +111,10 @@ export const gnSetDatasetsPermissions = (actions$, { getState = () => {}} = {}) 
                         return Rx.Observable.of(...stateLayers.map((l) => updateNode(l.id, 'layer', {perms: l.perms || []}) ));
                     });
             }
+
+            // skip layers of non-geonode origin
+            if (!action.layer?.pk) return Rx.Observable.empty();
+
             return Rx.Observable.defer(() => getDatasetByName(action.layer?.name))
                 .switchMap((layer = {}) => {
                     const layerId = layersSelector(getState())?.find((la) => la.name === layer.alternate)?.id;


### PR DESCRIPTION
### Description
This PR restricts the dataset API calls for perms to layers from geonode catalog

### Issue
- #1986 