### PR TITLE
#1979 - Allow to edit metadata after resource creation

### DIFF
--- a/geonode_mapstore_client/client/js/apps/gn-catalogue.js
+++ b/geonode_mapstore_client/client/js/apps/gn-catalogue.js
@@ -38,8 +38,7 @@ import context from '@mapstore/framework/reducers/context';
 // end
 
 import ViewerRoute from '@js/routes/Viewer';
-import UploadDatasetRoute from '@js/routes/UploadDataset';
-import UploadDocumentRoute from '@js/routes/UploadDocument';
+import ComponentsRoute from '@js/routes/Components';
 import CatalogueRoute from '@js/routes/Catalogue';
 import MapViewerRoute from '@js/routes/MapViewer';
 
@@ -105,8 +104,8 @@ const ConnectedRouter = connect(
 const viewers = {
     [appRouteComponentTypes.VIEWER]: ViewerRoute,
     [appRouteComponentTypes.CATALOGUE]: CatalogueRoute,
-    [appRouteComponentTypes.DATASET_UPLOAD]: UploadDatasetRoute,
-    [appRouteComponentTypes.DOCUMENT_UPLOAD]: UploadDocumentRoute,
+    [appRouteComponentTypes.DATASET_UPLOAD]: ComponentsRoute,
+    [appRouteComponentTypes.DOCUMENT_UPLOAD]: ComponentsRoute,
     [appRouteComponentTypes.MAP_VIEWER]: MapViewerRoute
 };
 

--- a/geonode_mapstore_client/client/js/plugins/Operation/components/ExecutionRequestTable.jsx
+++ b/geonode_mapstore_client/client/js/plugins/Operation/components/ExecutionRequestTable.jsx
@@ -98,12 +98,13 @@ function ExecutionRequestTable({
                                                 {viewResource && <RenderActionButton
                                                     request={request}
                                                     msgId={'gnviewer.view'}
-                                                    href={detailUrls.length === 1 ? detailUrls[0] : getCataloguePath('/catalogue/#/search/?f=dataset')}
+                                                    href={detailUrls.length === 1 ? detailUrls[0] : getCataloguePath('/catalogue/#/all')}
                                                 /> }
                                                 {editMetadata && <RenderActionButton
                                                     request={request}
                                                     msgId={'gnviewer.editMetadata'}
-                                                    href={detailUrls.length === 1 ? detailUrls[0].replace(/\/[^/]+\/(\d+)$/, "/metadata/$1") : getCataloguePath('/catalogue/#/search/?f=document')}
+                                                    href={detailUrls.length === 1 ? detailUrls[0].replace(/\/[^/]+\/(\d+)$/, "/metadata/$1")
+                                                        : getCataloguePath('/catalogue/#/all')}
                                                 />}
                                             </div>
                                             : null}

--- a/geonode_mapstore_client/client/js/plugins/Operation/components/ExecutionRequestTable.jsx
+++ b/geonode_mapstore_client/client/js/plugins/Operation/components/ExecutionRequestTable.jsx
@@ -17,6 +17,8 @@ import { getUploadErrorMessageFromCode } from '@js/utils/ErrorUtils';
 import { getCataloguePath } from '@js/utils/ResourceUtils';
 
 function ExecutionRequestTable({
+    viewResource = true,
+    editMetadata = true,
     titleMsgId = '',
     descriptionMsgId = '',
     iconName = '',
@@ -51,6 +53,18 @@ function ExecutionRequestTable({
         );
     }
 
+    const RenderActionButton = ({request, href, msgId}) => (
+        <Button
+            variant="primary"
+            onClick={() => handleDelete(request.exec_id)}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            <Message msgId={msgId} />
+        </Button>
+    );
+
     return (
         <div className="gn-upload-processing">
             <div className="gn-upload-processing-list">
@@ -80,15 +94,18 @@ function ExecutionRequestTable({
                                             />
                                             : null}
                                         {!onReload && request.status === 'finished' && detailUrls?.[0]
-                                            ? <Button
-                                                variant="primary"
-                                                onClick={() => handleDelete(request.exec_id)}
-                                                href={detailUrls.length === 1 ? detailUrls[0] : getCataloguePath('/catalogue/#/search/?f=dataset')}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                            >
-                                                <Message msgId={'gnviewer.view'} />
-                                            </Button>
+                                            ? <div className="gn-upload-processing-actions">
+                                                {viewResource && <RenderActionButton
+                                                    request={request}
+                                                    msgId={'gnviewer.view'}
+                                                    href={detailUrls.length === 1 ? detailUrls[0] : getCataloguePath('/catalogue/#/search/?f=dataset')}
+                                                /> }
+                                                {editMetadata && <RenderActionButton
+                                                    request={request}
+                                                    msgId={'gnviewer.editMetadata'}
+                                                    href={detailUrls.length === 1 ? detailUrls[0].replace(/\/[^/]+\/(\d+)$/, "/metadata/$1") : getCataloguePath('/catalogue/#/search/?f=document')}
+                                                />}
+                                            </div>
                                             : null}
                                         {!onReload && request.status === 'finished' && !detailUrls?.[0]
                                             ? <FaIcon name="check" />

--- a/geonode_mapstore_client/client/js/plugins/Operation/components/ExecutionRequestTable.jsx
+++ b/geonode_mapstore_client/client/js/plugins/Operation/components/ExecutionRequestTable.jsx
@@ -18,7 +18,7 @@ import { getCataloguePath } from '@js/utils/ResourceUtils';
 
 function ExecutionRequestTable({
     viewResource = true,
-    editMetadata = true,
+    editMetadata = false,
     titleMsgId = '',
     descriptionMsgId = '',
     iconName = '',

--- a/geonode_mapstore_client/client/js/plugins/UploadOperation.jsx
+++ b/geonode_mapstore_client/client/js/plugins/UploadOperation.jsx
@@ -10,6 +10,11 @@ import { createPlugin } from "@mapstore/framework/utils/PluginsUtils";
 import UploadDataset from "@js/routes/UploadDataset";
 import UploadDocument from "@js/routes/UploadDocument";
 
+/**
+ * Upload operation plugin
+ * @name UploadOperation
+ * @memberof plugins
+ */
 const UploadOperation = ({ resourceType, ...uploadConfig }) => {
     const Component =  resourceType === "dataset" ? UploadDataset : UploadDocument;
     return (

--- a/geonode_mapstore_client/client/js/plugins/UploadOperation.jsx
+++ b/geonode_mapstore_client/client/js/plugins/UploadOperation.jsx
@@ -12,6 +12,9 @@ import UploadDocument from "@js/routes/UploadDocument";
 
 /**
  * Upload operation plugin
+ * @prop {object} cfg.resourceType the type of the resource to upload
+ * @prop {object} cfg.viewResource flag to show view resource button
+ * @prop {object} cfg.editMetadata flag to show edit metadata button of the resource
  * @name UploadOperation
  * @memberof plugins
  */

--- a/geonode_mapstore_client/client/js/plugins/UploadOperation.jsx
+++ b/geonode_mapstore_client/client/js/plugins/UploadOperation.jsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import { createPlugin } from "@mapstore/framework/utils/PluginsUtils";
+import UploadDataset from "@js/routes/UploadDataset";
+import UploadDocument from "@js/routes/UploadDocument";
+
+const UploadOperation = ({ resourceType, ...uploadConfig }) => {
+    const Component =  resourceType === "dataset" ? UploadDataset : UploadDocument;
+    return (
+        <div className="gn-upload-container">
+            <Component uploadConfig={uploadConfig}/>
+        </div>
+    );
+};
+
+export default createPlugin('UploadOperation', {
+    component: UploadOperation,
+    containers: {},
+    epics: {},
+    reducers: {}
+});

--- a/geonode_mapstore_client/client/js/plugins/UploadResource.jsx
+++ b/geonode_mapstore_client/client/js/plugins/UploadResource.jsx
@@ -11,14 +11,14 @@ import UploadDataset from "@js/routes/UploadDataset";
 import UploadDocument from "@js/routes/UploadDocument";
 
 /**
- * Upload operation plugin
- * @prop {object} cfg.resourceType the type of the resource to upload
+ * Upload resource plugin
+ * @prop {object} cfg.resourceType the type of the resource to upload (dataset or document)
  * @prop {object} cfg.viewResource flag to show view resource button
  * @prop {object} cfg.editMetadata flag to show edit metadata button of the resource
- * @name UploadOperation
+ * @name UploadResource
  * @memberof plugins
  */
-const UploadOperation = ({ resourceType, ...uploadConfig }) => {
+const UploadResource = ({ resourceType, ...uploadConfig }) => {
     const Component =  resourceType === "dataset" ? UploadDataset : UploadDocument;
     return (
         <div className="gn-upload-container">
@@ -27,8 +27,8 @@ const UploadOperation = ({ resourceType, ...uploadConfig }) => {
     );
 };
 
-export default createPlugin('UploadOperation', {
-    component: UploadOperation,
+export default createPlugin('UploadResource', {
+    component: UploadResource,
     containers: {},
     epics: {},
     reducers: {}

--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -467,9 +467,9 @@ export const plugins = {
         'PrintCopyright',
         () => import(/* webpackChunkName: 'plugins/print-copyright' */ '@js/plugins/Print/Copyright')
     ),
-    UploadOperationPlugin: toModulePlugin(
-        'UploadOperation',
-        () => import(/* webpackChunkName: 'plugins/upload-operation' */ '@js/plugins/UploadOperation')
+    UploadResourcePlugin: toModulePlugin(
+        'UploadResource',
+        () => import(/* webpackChunkName: 'plugins/upload-operation' */ '@js/plugins/UploadResource')
     )
 };
 

--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -466,6 +466,10 @@ export const plugins = {
     PrintCopyrightPlugin: toModulePlugin(
         'PrintCopyright',
         () => import(/* webpackChunkName: 'plugins/print-copyright' */ '@js/plugins/Print/Copyright')
+    ),
+    UploadOperationPlugin: toModulePlugin(
+        'UploadOperation',
+        () => import(/* webpackChunkName: 'plugins/upload-operation' */ '@js/plugins/UploadOperation')
     )
 };
 

--- a/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
+++ b/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
@@ -28,7 +28,8 @@ import {
 } from '@js/api/geonode/v2/constants';
 
 function UploadDataset({
-    refreshTime = 3000
+    refreshTime = 3000,
+    uploadConfig
 }) {
 
     const api = {
@@ -113,6 +114,7 @@ function UploadDataset({
                 descriptionMsgId="gnviewer.dragAndDropFile"
                 requests={requests}
                 onDelete={deleteRequest}
+                {...uploadConfig}
             />
         </UploadPanel>
     );

--- a/geonode_mapstore_client/client/js/routes/UploadDocument.jsx
+++ b/geonode_mapstore_client/client/js/routes/UploadDocument.jsx
@@ -23,7 +23,7 @@ import {
     getUploadFileName
 } from '@js/utils/UploadUtils';
 
-function UploadDocument({}) {
+function UploadDocument({uploadConfig}) {
 
     const [requests, setRequests] = useState([]);
 
@@ -104,6 +104,7 @@ function UploadDocument({}) {
                 onDelete={(deleteId) => {
                     setRequests(prevRequests => prevRequests.filter(request => request.exec_id !== deleteId));
                 }}
+                {...uploadConfig}
             />
         </UploadPanel>
     );

--- a/geonode_mapstore_client/client/themes/geonode/less/_upload.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_upload.less
@@ -286,6 +286,10 @@
                 font-size: @font-size-lg;
             }
         }
+        .gn-upload-processing-actions {
+            display: flex;
+            gap: 10px;
+        }
     }
 
     &:has(:not(.gn-upload-processing-header)) {
@@ -314,4 +318,14 @@
 
 .gn-failed-upload {
     display: inline-block;
+}
+
+.gn-upload-container {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
 }

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -4825,6 +4825,22 @@
             {
                 "name": "MetadataViewer"
             }
-        ] 
+        ],
+        "upload_dataset": [
+            {
+                "name": "UploadOperation",
+                "cfg": {
+                    "resourceType": "dataset"
+                }
+            }
+        ],
+        "upload_document": [
+            {
+                "name": "UploadOperation",
+                "cfg": {
+                    "resourceType": "document"
+                }
+            }
+        ]
     }
 }

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -4828,7 +4828,7 @@
         ],
         "upload_dataset": [
             {
-                "name": "UploadOperation",
+                "name": "UploadResource",
                 "cfg": {
                     "resourceType": "dataset"
                 }
@@ -4836,7 +4836,7 @@
         ],
         "upload_document": [
             {
-                "name": "UploadOperation",
+                "name": "UploadResource",
                 "cfg": {
                     "resourceType": "document"
                 }


### PR DESCRIPTION
### Description
This PR allow possibility to configure action button after upload of the resource is complete. By default only `View` resource button is visible

### Issue
- #1979 

### Screenshot
<img width="1917" alt="image" src="https://github.com/user-attachments/assets/4a0c972d-b6e3-4a04-a992-1226dc780df3" />
