### PR TITLE
#2002: Metadata editor error enhancements

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/MetadataEditor/containers/MetadataEditor.jsx
+++ b/geonode_mapstore_client/client/js/plugins/MetadataEditor/containers/MetadataEditor.jsx
@@ -14,7 +14,6 @@ import { Alert } from 'react-bootstrap';
 import isEmpty from 'lodash/isEmpty';
 
 import { getMetadataByPk } from '@js/api/geonode/v2/metadata';
-import Message from '@mapstore/framework/components/I18N/Message';
 import widgets from '../components/_widgets';
 import templates from '../components/_templates';
 import fields from '../components/_fields';
@@ -78,8 +77,16 @@ function MetadataEditor({
         }
     }, [pk]);
 
+    useEffect(() => {
+        return () => {
+            // reset all errors
+            setUpdateError(null);
+            setExtraErrors({});
+        };
+    }, []);
+
     function handleChange(formData) {
-        setUpdateError(false);
+        setUpdateError(null);
         setMetadata(formData);
     }
 
@@ -98,8 +105,8 @@ function MetadataEditor({
     return (
         <div className="gn-metadata">
             <div className="gn-metadata-header">
-                {updateError && <Alert bsStyle="danger" style={{ margin: '0.25rem 0' }}>
-                    <Message msgId="gnviewer.metadataUpdateError" />
+                {!isEmpty(updateError) && <Alert bsStyle="danger" style={{ margin: '0.25rem 0' }}>
+                    {updateError}
                     {!isEmpty(rootErrors) && <ul>{rootErrors.map((_error, idx) => <li key={idx}>{_error}</li>)}</ul>}
                 </Alert>}
             </div>

--- a/geonode_mapstore_client/client/js/plugins/MetadataEditor/containers/MetadataUpdateButton.jsx
+++ b/geonode_mapstore_client/client/js/plugins/MetadataEditor/containers/MetadataUpdateButton.jsx
@@ -37,7 +37,7 @@ function MetadataUpdateButton({
                 setExtraErrors(get(error, 'data.extraErrors', {}));
                 setUpdateError(get(error, 'data.message', null));
                 if (error?.status === 422) {
-                    // partially successful. Reinitialize metadata to allow user to correct errors
+                    // Partially successful. So reset pending metadata changes and allow user to fix error(s)
                     setInitialMetadata(metadata);
                 }
             })

--- a/geonode_mapstore_client/client/js/plugins/MetadataEditor/containers/MetadataUpdateButton.jsx
+++ b/geonode_mapstore_client/client/js/plugins/MetadataEditor/containers/MetadataUpdateButton.jsx
@@ -27,7 +27,7 @@ function MetadataUpdateButton({
 
     function handleUpdate() {
         setUpdating(true);
-        setUpdateError(false);
+        setUpdateError(null);
         updateMetadata(pk, metadata)
             .then((response) => {
                 setInitialMetadata(metadata);
@@ -35,7 +35,11 @@ function MetadataUpdateButton({
             })
             .catch((error) => {
                 setExtraErrors(get(error, 'data.extraErrors', {}));
-                setUpdateError(true);
+                setUpdateError(get(error, 'data.message', null));
+                if (error?.status === 422) {
+                    // partially successful. Reinitialize metadata to allow user to correct errors
+                    setInitialMetadata(metadata);
+                }
             })
             .finally(() => {
                 setUpdating(false);


### PR DESCRIPTION
### Description
This PR enhances the metadata editor error display
- On error shows content in `message`
- Handles 422 cases to show error and reset initial data so the user can work on the errors
- Resets error state on redirection from metadata editor

### Issue
- #2002 
