### PR TITLE
#2000: Fix - Metadata download filenames broken

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gndownload.js
+++ b/geonode_mapstore_client/client/js/epics/gndownload.js
@@ -19,7 +19,7 @@ export const gnDownloadMetaData = (action$, store) =>
         .switchMap((action) => {
             const state = store.getState();
             const url = state.gnresource?.data?.links?.find((link) => link.name === action.link).url;
-            const resourceTitle = state.gnresource?.data?.title;
+            const resourceTitle = state.gnresource?.data?.title?.replace(/[\.\s]/g, '_');
 
             return Observable
                 .defer(() => axios.get(url).then((data) => data))

--- a/geonode_mapstore_client/client/themes/geonode/less/_menu.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_menu.less
@@ -129,6 +129,9 @@ nav.hide-navigation#gn-topbar {
         text-align: left;
         padding: 3px 20px;
     }
+    .dropdown-menu li a.btn {
+        text-align: left;
+    }
 
     &.gn-menu-symmetric {
         .gn-menu-content-left,


### PR DESCRIPTION
### Description
This PR fixes the metadata downloads files are broken when filename has dot it in treating the content after dot as extension resulting in a generic file. After this fix, files are downloaded correctly with the proper extension, even when filenames contain multiple dots or spaces

### Issue
- #2000 
