### PR TITLE
#2006: Allow label configuration of upload operation action buttons

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/Operation/components/ExecutionRequestTable.jsx
+++ b/geonode_mapstore_client/client/js/plugins/Operation/components/ExecutionRequestTable.jsx
@@ -17,14 +17,13 @@ import { getUploadErrorMessageFromCode } from '@js/utils/ErrorUtils';
 import { getCataloguePath } from '@js/utils/ResourceUtils';
 
 function ExecutionRequestTable({
-    viewResource = true,
-    editMetadata = false,
     titleMsgId = '',
     descriptionMsgId = '',
     iconName = '',
     requests: requestsProp,
     onReload,
-    onDelete
+    onDelete,
+    ...props
 }) {
 
     const [deleted, setDeleted] = useState([]);
@@ -65,6 +64,7 @@ function ExecutionRequestTable({
         </Button>
     );
 
+    const { viewResource = true, editMetadata, viewResourceLabelId, editMetadataLabelId } = props;
     return (
         <div className="gn-upload-processing">
             <div className="gn-upload-processing-list">
@@ -97,12 +97,12 @@ function ExecutionRequestTable({
                                             ? <div className="gn-upload-processing-actions">
                                                 {viewResource && <RenderActionButton
                                                     request={request}
-                                                    msgId={'gnviewer.view'}
+                                                    msgId={viewResourceLabelId ?? 'gnviewer.view'}
                                                     href={detailUrls.length === 1 ? detailUrls[0] : getCataloguePath('/catalogue/#/all')}
                                                 /> }
                                                 {editMetadata && <RenderActionButton
                                                     request={request}
-                                                    msgId={'gnviewer.editMetadata'}
+                                                    msgId={editMetadataLabelId ?? 'gnviewer.fillMetadata'}
                                                     href={detailUrls.length === 1 ? detailUrls[0].replace(/\/[^/]+\/(\d+)$/, "/metadata/$1")
                                                         : getCataloguePath('/catalogue/#/all')}
                                                 />}

--- a/geonode_mapstore_client/client/js/plugins/UploadResource.jsx
+++ b/geonode_mapstore_client/client/js/plugins/UploadResource.jsx
@@ -15,6 +15,8 @@ import UploadDocument from "@js/routes/UploadDocument";
  * @prop {object} cfg.resourceType the type of the resource to upload (dataset or document)
  * @prop {object} cfg.viewResource flag to show view resource button
  * @prop {object} cfg.editMetadata flag to show edit metadata button of the resource
+ * @prop {object} cfg.viewResourceLabelId label translation string for the resource button
+ * @prop {object} cfg.editMetadataLabelId label translation string for the metadata button
  * @name UploadResource
  * @memberof plugins
  */

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -173,6 +173,7 @@
             "exportData": "Daten exportieren",
             "editInfo": "Informationen anzeigen",
             "editMetadata": "Metadaten bearbeiten",
+            "fillMetadata": "Metadaten ausfüllen",
             "editStyle": "Stil bearbeiten",
             "editData": "Daten bearbeiten",
             "view": "Anzeigen",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -173,6 +173,7 @@
             "exportData": "Export Data",
             "editInfo": "Edit Info",
             "editMetadata": "Edit Metadata",
+            "fillMetadata": "Fill Metadata",
             "editStyle": "Edit Style",
             "editData": "Edit Data",
             "view": "View",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -173,6 +173,7 @@
             "exportData": "Exportar datos",
             "editInfo": "Editar información",
             "editMetadata": "Editar Metadatos",
+            "fillMetadata": "Rellenar metadatos",
             "editStyle": "Editar Estilo",
             "editData": "Editar Datos",
             "view": "Ver",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -171,6 +171,7 @@
             "exportData": "Export Data",
             "editInfo": "Edit Info",
             "editMetadata": "Edit Metadata",
+            "fillMetadata": "Fill Metadata",
             "editStyle": "Edit Style",
             "editData": "Edit Data",
             "view": "View",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -172,6 +172,7 @@
             "export": "Exportation",
             "exportData": "Exporter les données",
             "editMetadata": "Modifier les Métadonnées",
+            "fillMetadata": "Remplir les métadonnées",
             "view": "Vue",
             "viewMetadata": "Afficher les métadonnées",
             "viewData":  "Afficher les données",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -171,6 +171,7 @@
             "exportData": "Export Data",
             "editInfo": "Edit Info",
             "editMetadata": "Edit Metadata",
+            "fillMetadata": "Fill Metadata",
             "editStyle": "Edit Style",
             "editData": "Edit Data",
             "view": "View",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -174,6 +174,7 @@
             "export": "Esporta",
             "exportData": "Esporta Dati",
             "editMetadata": "Modifica Metadati",
+            "fillMetadata": "Compila Metadati",
             "view": "Visualizza",
             "viewMetadata": "Visualizza i metadati",
             "viewData": "Visualizza i dati",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -171,6 +171,7 @@
             "exportData": "Export Data",
             "editInfo": "Edit Info",
             "editMetadata": "Edit Metadata",
+            "fillMetadata": "Fill Metadata",
             "editStyle": "Edit Style",
             "editData": "Edit Data",
             "view": "View",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -171,6 +171,7 @@
             "exportData": "Export Data",
             "editInfo": "Edit Info",
             "editMetadata": "Edit Metadata",
+            "fillMetadata": "Fill Metadata",
             "editStyle": "Edit Style",
             "editData": "Edit Data",
             "view": "View",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -171,6 +171,7 @@
             "exportData": "Export Data",
             "editInfo": "Edit Info",
             "editMetadata": "Edit Metadata",
+            "fillMetadata": "Fill Metadata",
             "editStyle": "Edit Style",
             "editData": "Edit Data",
             "view": "View",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -172,6 +172,7 @@
             "exportData": "Export Data",
             "editInfo": "Edit Info",
             "editMetadata": "Edit Metadata",
+            "fillMetadata": "Fill Metadata",
             "editStyle": "Edit Style",
             "editData": "Edit Data",
             "view": "View",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -171,6 +171,7 @@
             "exportData": "Export Data",
             "editInfo": "Edit Info",
             "editMetadata": "Edit Metadata",
+            "fillMetadata": "Fill Metadata",
             "editStyle": "Edit Style",
             "editData": "Edit Data",
             "view": "View",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -171,6 +171,7 @@
             "exportData": "Export Data",
             "editInfo": "Edit Info",
             "editMetadata": "Edit Metadata",
+            "fillMetadata": "Fill Metadata",
             "editStyle": "Edit Style",
             "editData": "Edit Data",
             "view": "View",


### PR DESCRIPTION
### Description
This PR adds possibility to configure label for the upload operation action buttons. when `editMetadata: true` , by default the label is `Fill Metadata`

### Issue
- #2006 