### PR TITLE
Fix #2027 Filter button for Datasets should be active only if the WFS link is available

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/actionnavbar/buttons.jsx
+++ b/geonode_mapstore_client/client/js/plugins/actionnavbar/buttons.jsx
@@ -131,15 +131,19 @@ export const LayerDownloadActionButton = connect(
 
 export const FilterLayerActionButton = connect(
     (state) => ({
-        active: !!getSelectedLayer(state)?.layerFilter
+        layer: getSelectedLayer(state)
     }),
     { onClick: openQueryBuilder }
 )(({
     onClick,
     variant,
     size,
-    active
+    layer
 }) => {
+    const active = !!layer?.layerFilter;
+    if (!layer?.search) {
+        return null;
+    }
     return (
         <Button
             variant={variant}


### PR DESCRIPTION
Improve visibility control of filter button in dataset pages. Now the filter button is visible only for layer with the search parameter (WFS)