### PR TITLE
Fixing Favorites URL in the user menu

### DIFF
--- a/geonode_mapstore_client/templatetags/get_menu_json.py
+++ b/geonode_mapstore_client/templatetags/get_menu_json.py
@@ -108,7 +108,7 @@ def get_user_menu(context):
             },
             {
                 "type": "link",
-                "href": "/catalogue/#/search/?f=favorite",
+                "href": "/catalogue/search/#/?f=favorite",
                 "label": "Favorites",
             },
             {"type": "link", "href": "/messages/inbox/", "label": "Inbox"},


### PR DESCRIPTION
This PR was created according to this issue: #2052 
The issue came from a typo in the `Favorites` URL search in the `get_menu_json.py` file.