### PR TITLE
[Fixes #2055] Add compile:dev script using MAPSTORE_COMPILE_DEV=true for debug-friendly production builds

### DIFF
--- a/geonode_mapstore_client/client/package.json
+++ b/geonode_mapstore_client/client/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "compile": "mapstore-project compile && node postCompile",
+    "compiledev": "MAPSTORE_DEV=true mapstore-project compile && node postCompile",
     "start": "mapstore-project start",
     "test": "mapstore-project test",
     "test:watch": "mapstore-project test:watch",

--- a/geonode_mapstore_client/client/package.json
+++ b/geonode_mapstore_client/client/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "compile": "mapstore-project compile && node postCompile",
-    "compiledev": "MAPSTORE_DEV=true mapstore-project compile && node postCompile",
+    "compiledev": "MAPSTORE_COMPILE_DEV=true mapstore-project compile && node postCompile",
     "start": "mapstore-project start",
     "test": "mapstore-project test",
     "test:watch": "mapstore-project test:watch",

--- a/geonode_mapstore_client/client/package.json
+++ b/geonode_mapstore_client/client/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "compile": "mapstore-project compile && node postCompile",
-    "compiledev": "MAPSTORE_COMPILE_DEV=true mapstore-project compile && node postCompile",
+    "compile:dev": "MAPSTORE_COMPILE_DEV=true mapstore-project compile && node postCompile",
     "start": "mapstore-project start",
     "test": "mapstore-project test",
     "test:watch": "mapstore-project test:watch",


### PR DESCRIPTION
This PR adds a new script to `package.json` to support hybrid builds using the `MAPSTORE_COMPILE_DEV=true` flag now supported by `mapstore-project`. See geosolutions-it/mapstore-project#27 in the mapstore-project repository for details on this.

**Changes:**
Adds a new NPM script:

```json
"compile:dev": "MAPSTORE_COMPILE_DEV=true mapstore-project compile && node postCompile"
```

This allows the MapStore client to be built with:
- Source maps
- Development Webpack mode
- All production assets (themes, translations, configs)

**Why:**
This is useful for deploying builds to staging/QA environments where full production content is needed but debugging (e.g., via browser DevTools and source maps) is still required.

**Example usage:**
```sh
npm run compile:dev
```

This will produce a fully deployable client that is easier to debug in non-local environments.

Closes geonode/geonode-mapstore-client#2055