### PR TITLE
Hide resource properties button on a new resource viewer

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/ResourceDetails/ResourceDetails.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ResourceDetails/ResourceDetails.jsx
@@ -390,7 +390,9 @@ export default createPlugin('ResourceDetails', {
     containers: {
         ActionNavbar: {
             name: 'ResourceDetailsButton',
-            Component: connect(() => ({}), { onShow: setShowDetails })(({ component, resourcesGridId, onShow }) => {
+            Component: connect((state) => ({resource: getResourceData(state)}), { onShow: setShowDetails })(({ component, resourcesGridId, onShow, resource }) => {
+                if (!resource?.pk) return null;
+
                 const Component = component;
                 function handleClick() {
                     onShow(true, resourcesGridId);


### PR DESCRIPTION
### Description
This PR hides the properties button from the action navbar on the new resource viewer page

### Screenshot
<img width="677" alt="image" src="https://github.com/user-attachments/assets/7caeeb59-8869-4a95-b09f-eb5e07945d43" />
