### PR TITLE
Fix: Custom schema field are not respecting readOnly property

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/MetadataEditor/components/_fields/SchemaField.jsx
+++ b/geonode_mapstore_client/client/js/plugins/MetadataEditor/components/_fields/SchemaField.jsx
@@ -116,7 +116,7 @@ const SchemaField = (props) => {
             valueKey,
             helpTitleIcon: true,
             description: helpText ?? description ?? schema.description, // Help text is preferred over description and displayed as a tooltip
-            disabled: disabled || props?.readonly,
+            disabled: disabled || props?.readonly || schema?.readOnly,
             style,
             required,
             onChange: (selected) => {


### PR DESCRIPTION
### Description
This PR fixes the readOnly prop not respected by custom schema field

### Screenshot
owner is set readOnly

<img width="559" alt="image" src="https://github.com/user-attachments/assets/146e4a00-9e9f-4f45-8eaf-ba44b559b811" />

