### PR TITLE
Fix - Missing translation for document creation date

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/ResourceDetails/ResourceDetails.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ResourceDetails/ResourceDetails.jsx
@@ -110,7 +110,7 @@ function ResourceDetailsPanel({
                 {
                     "type": "date",
                     "format": "YYYY-MM-DD HH:mm",
-                    "labelId": "{'gnviewer.'+context.get(state('gnResourceData'), 'date_type')}",
+                    "labelId": "{'gnviewer.'+context.get(state('gnResourceData'), 'date_type').toLowerCase()}",
                     "value": "{context.get(state('gnResourceData'), 'date')}"
                 },
                 {

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -2059,7 +2059,7 @@
                                 {
                                     "type": "date",
                                     "format": "YYYY-MM-DD HH:mm",
-                                    "labelId": "{'gnviewer.'+context.get(state('gnResourceSelectedLayerDataset'), 'date_type')}",
+                                    "labelId": "{'gnviewer.'+context.get(state('gnResourceSelectedLayerDataset'), 'date_type').toLowerCase()}",
                                     "value": "{context.get(state('gnResourceSelectedLayerDataset'), 'date')}"
                                 },
                                 {


### PR DESCRIPTION
### Description
This PR fixes missing translation for document creation date

### Issue
- #1935 

### Screenshot
<img width="639" alt="image" src="https://github.com/user-attachments/assets/f1f3ae8a-91b0-4b1d-8e01-698cf59434d9" />
