### PR TITLE
Fix: Resource menu overlap by viewer content

### DIFF
--- a/geonode_mapstore_client/client/themes/geonode/less/_base.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_base.less
@@ -177,6 +177,7 @@ body {
     .gn-viewer-layout-center {
         overflow-y: auto;
         overflow-x: hidden;
+        z-index: 1;
     }
 }
 


### PR DESCRIPTION
### Description
This PR fixes the resource dropdown menu hidden by viewer content (Dashboard)

### Screenshot
<img width="306" alt="image" src="https://github.com/user-attachments/assets/f8916c3f-ade2-474c-8d99-a9877acc6a85" />
