### PR TITLE
#2110: Fix - Pending prompt inside viewer

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/ResourceDetails/ResourceDetails.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ResourceDetails/ResourceDetails.jsx
@@ -11,7 +11,7 @@ import { createPlugin } from '@mapstore/framework/utils/PluginsUtils';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import PropTypes from 'prop-types';
-import { requestResource } from '@js/actions/gnresource';
+import { requestResource, setResource } from '@js/actions/gnresource';
 import controls from '@mapstore/framework/reducers/controls';
 import config from '@mapstore/framework/reducers/config';
 import gnresource from '@js/reducers/gnresource';
@@ -261,11 +261,13 @@ function ResourceDetailsPanel({
     enablePreview,
     editingOverlay,
     closeOnClickOut,
-    showViewerButton
+    showViewerButton,
+    onClearResource
 }, context) {
 
     const [confirmModal, setConfirmModal] = useState(false);
     const editing = canEdit && editable;
+    const isViewer = !resource?.['@ms-detail'];
 
     const {
         stickyTop,
@@ -282,10 +284,11 @@ function ResourceDetailsPanel({
     function handleConfirm() {
         onShow(false);
         onClose(null);
+        !isViewer && onClearResource(null);
     }
 
     function handleClose() {
-        if (pendingChanges) {
+        if (pendingChanges && !isViewer) {
             setConfirmModal(true);
         } else {
             handleConfirm();
@@ -305,7 +308,6 @@ function ResourceDetailsPanel({
             handleClose();
         }
     });
-
 
     const { loadedPlugins } = context;
     const configuredItems = usePluginItems({ items, loadedPlugins }, [resource?.pk]);
@@ -377,7 +379,8 @@ const ResourceDetailsPlugin = connect(
     }),
     {
         onShow: setShowDetails,
-        onClose: setSelectedResource
+        onClose: setSelectedResource,
+        onClearResource: setResource
     }
 )(ResourceDetails);
 


### PR DESCRIPTION
### Description
This PR fixes the behavior of pending prompt inside viewer. 
- The prompt is not shown when closing the detail panel with pending changes in viewer, as the user hasn't navigated away from viewer 
- The resource is cleared on confirming pending prompt when in resource grid page as we don't want the changes to be persisted

### Issue
- #2110 