### PR TITLE
#2113: Fix - Incorrect url formation on copy resource url in resource grid page

### DIFF
--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -780,11 +780,11 @@ export const getDownloadUrlInfo = (resource) => {
 };
 
 export const formatResourceLinkUrl = (resource) => {
-    let href = window.location.href;
+    let href = window.location.origin;
     if (resource?.uuid) {
-        href = href.replace(/#.+$/, `uuid/${resource.uuid}`);
+        href = href + `/catalogue/uuid/${resource.uuid}`;
     }
-    return cleanUrl(href);
+    return href;
 };
 
 export const getCataloguePath = (path = '') => {

--- a/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
@@ -34,7 +34,8 @@ import {
     getResourceAdditionalProperties,
     getDimensions,
     canManageResourceSettings,
-    canAccessPermissions
+    canAccessPermissions,
+    formatResourceLinkUrl
 } from '../ResourceUtils';
 
 describe('Test Resource Utils', () => {
@@ -1008,5 +1009,9 @@ describe('Test Resource Utils', () => {
     it('canAccessPermissions', () => {
         expect(canAccessPermissions({ perms: ['change_resourcebase_permissions'] })).toBeTruthy();
         expect(canAccessPermissions({ perms: ['view_resourcebase'] })).toBeFalsy();
+    });
+    it('formatResourceLinkUrl', () => {
+        expect(formatResourceLinkUrl({ uuid: '123' })).toContain('/catalogue/uuid/123');
+        expect(formatResourceLinkUrl({ pk: '123' })).toNotContain('/catalogue/uuid/123');
     });
 });


### PR DESCRIPTION
### Description
This PR fixes the incorrect URL generation when copying the resource URL from the detail panel on the resource grid page.

### Issue
- #2113
