### PR TITLE
#2119 - Update client to show exported data from layer download

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/ActionNavbar/buttons.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ActionNavbar/buttons.jsx
@@ -8,10 +8,11 @@
 import React, { useRef } from 'react';
 import { PropTypes } from 'prop-types';
 import { connect } from 'react-redux';
-import { createSelector } from 'reselect';
+import { createSelector, createStructuredSelector } from 'reselect';
 import usePluginItems from '@mapstore/framework/hooks/usePluginItems';
 import {
-    setControlProperty
+    setControlProperty,
+    toggleControl
 } from '@mapstore/framework/actions/controls';
 import {
     toggleFullscreen
@@ -27,6 +28,10 @@ import { isDashboardEditing } from '@mapstore/framework/selectors/dashboard';
 import { createWidget } from '@mapstore/framework/actions/widgets';
 import { getResourceData, getSelectedLayerDataset } from '@js/selectors/resource';
 import { GXP_PTYPES } from '@js/utils/ResourceUtils';
+import { exportDataResultsControlEnabledSelector, checkingExportDataEntriesSelector, exportDataResultsSelector } from '@mapstore/framework/selectors/layerdownload';
+import { currentLocaleSelector } from '@mapstore/framework/selectors/locale';
+import { checkExportDataEntries, removeExportDataResult } from '@mapstore/framework/actions/layerdownload';
+import ExportDataResultsComponent from '@mapstore/framework/components/data/download/ExportDataResultsComponent';
 
 // buttons override to use in ActionNavbar for plugin imported from mapstore
 
@@ -128,6 +133,17 @@ export const LayerDownloadActionButton = connect(
     ),
     { onClick: setControlProperty.bind(null, 'layerdownload', 'enabled', true, true) }
 )(LayerDownloadActionButtonComponent);
+
+export const LayerDownloadExportDataResultsComponent = connect(createStructuredSelector({
+    active: exportDataResultsControlEnabledSelector,
+    checkingExportDataEntries: checkingExportDataEntriesSelector,
+    results: exportDataResultsSelector,
+    currentLocale: currentLocaleSelector
+}), {
+    onToggle: toggleControl.bind(null, 'exportDataResults', 'enabled'),
+    onActive: checkExportDataEntries,
+    onRemoveResult: removeExportDataResult
+})(ExportDataResultsComponent);
 
 export const FilterLayerActionButton = connect(
     (state) => ({

--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -11,7 +11,8 @@ import {
     LayerDownloadActionButton,
     FilterLayerActionButton,
     FullScreenActionButton,
-    AddWidgetActionButton
+    AddWidgetActionButton,
+    LayerDownloadExportDataResultsComponent
 } from '@js/plugins/ActionNavbar/buttons';
 import { getPluginsContext } from '@js/utils/PluginsContextUtils';
 import { toModulePlugin as msToModulePlugin } from '@mapstore/framework/utils/ModulePluginsUtils';
@@ -89,10 +90,18 @@ export const plugins = {
                         Component: LayerDownloadActionButton,
                         position: 11
                     },
-                    ActionNavbar: {
-                        name: 'LayerDownload',
-                        Component: LayerDownloadActionButton
-                    }
+                    ActionNavbar: [
+                        {
+                            name: 'LayerDownload',
+                            Component: LayerDownloadActionButton
+                        },
+                        {
+                            name: 'LayerDownload',
+                            Component: LayerDownloadExportDataResultsComponent,
+                            position: 1,
+                            target: 'right-menu'
+                        }
+                    ]
                 }
             }
         }
@@ -169,6 +178,7 @@ export const plugins = {
                         name: 'FullScreen',
                         Component: FullScreenActionButton,
                         priority: 5,
+                        position: 2,
                         target: 'right-menu'
                     }
                 }


### PR DESCRIPTION
### Description
This PR updates the client to display exported data from Layer Download in the ActionNavbar, aligning with the recent change in MapStore where this functionality was moved to the BrandNavbar. 

Since ActionNavbar serves as the GeoNode equivalent, the export component has been moved there, ensuring all supported resource types can access asynchronous layer export data consistently

### Screenshot
<img width="555" alt="image" src="https://github.com/user-attachments/assets/f65ad993-dbdb-45a0-b879-994c18d033e6" />
