### PR TITLE
Fix #2167 Update submodule to include Isochrone and Itinerary plugins

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "geonode_mapstore_client/client/MapStore2"]
 	path = geonode_mapstore_client/client/MapStore2
 	url = https://github.com/geosolutions-it/MapStore2.git
-	branch = 2025.01.xx
+	branch = master

--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -18,6 +18,10 @@ import { getPluginsContext } from '@js/utils/PluginsContextUtils';
 import { toModulePlugin as msToModulePlugin } from '@mapstore/framework/utils/ModulePluginsUtils';
 
 import TOCPlugin from '@mapstore/framework/plugins/TOC';
+import Itinerary from "@mapstore/framework/plugins/Itinerary";
+import SecurityPopup from "@mapstore/framework/plugins/SecurityPopup";
+import Isochrone from "@mapstore/framework/plugins/Isochrone";
+
 import OperationPlugin from '@js/plugins/Operation';
 import MetadataEditorPlugin from '@js/plugins/MetadataEditor';
 import MetadataViewerPlugin from '@js/plugins/MetadataEditor/MetadataViewer';
@@ -78,6 +82,9 @@ export const plugins = {
     ResourcesGridPlugin,
     FavoritesPlugin,
     ResourcesFiltersFormPlugin,
+    ItineraryPlugin: Itinerary,
+    IsochronePlugin: Isochrone,
+    SecurityPopupPlugin: SecurityPopup,
     LayerDownloadPlugin: toModulePlugin(
         'LayerDownload',
         () => import(/* webpackChunkName: 'plugins/layer-download' */ '@mapstore/framework/plugins/LayerDownload'),

--- a/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
@@ -43,6 +43,11 @@
       "hidden": true
     },
     {
+      "name": "SecurityPopup",
+      "mandatory": true,
+      "hidden": true
+    },
+    {
       "name": "TOC",
       "glyph": "1-layer",
       "symbol": "layers",
@@ -592,6 +597,20 @@
           "history": false
         }
       }
+    },
+    {
+      "name": "Itinerary",
+      "glyph": "route",
+      "title": "plugins.Itinerary.title",
+      "description": "plugins.Itinerary.description",
+      "dependencies": ["SidebarMenu"]
+    },
+    {
+      "name": "Isochrone",
+      "glyph": "1-point-dashed",
+      "title": "plugins.Isochrone.title",
+      "description": "plugins.Isochrone.description",
+      "dependencies": ["SidebarMenu"]
     }
   ]
 }


### PR DESCRIPTION
The submodule has been updated to master and Itinerary and Isochrone plugins included. Both plugins needs to be configured in a map viewer to be enabled and a valid graphhopper url endpoint must be provided:

- [Itinerary](https://dev-mapstore.geosolutionsgroup.com/mapstore/docs/api/plugins#plugins.Itinerary) doc
- [Isochrone](https://dev-mapstore.geosolutionsgroup.com/mapstore/docs/api/plugins#plugins.Isochrone) doc

<img width="1919" height="949" alt="2025-09-24 10_10_46-Window" src="https://github.com/user-attachments/assets/40761f97-92eb-4711-934e-fb789b8e850a" />

<img width="1919" height="949" alt="2025-09-24 10_11_18-Window" src="https://github.com/user-attachments/assets/a78ce2df-1543-484a-ad41-24346f55f7c1" />

<img width="1919" height="953" alt="2025-09-24 10_17_29-Window" src="https://github.com/user-attachments/assets/3957c735-9fdb-4af8-9663-d92c912462c6" />

<img width="1919" height="949" alt="2025-09-24 10_15_04-Window" src="https://github.com/user-attachments/assets/195262d4-2c07-4682-b9d9-024cd8f8adaa" />
