### PR TITLE
Fix: #2154 : Download metadata available for everyone

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -626,7 +626,6 @@
                         },
                         {
                             "labelId": "gnviewer.download",
-                            "disableIf": "{!state('selectedLayerPermissions').includes('download_resourcebase') || context.isDocumentExternalSource(state('gnResourceData'))}",
                             "type": "dropdown",
                             "items": [
                                 {
@@ -2465,7 +2464,6 @@
                         },
                         {
                             "labelId": "gnviewer.download",
-                            "disableIf": "{!context.resourceHasPermission(state('gnResourceData'), 'download_resourcebase')}",
                             "type": "dropdown",
                             "items": [
                                 {


### PR DESCRIPTION
Download Metadata options are now available for everyone .  

Result : When user is not logged in or when user have permission of view only. User can now also download the metadata as shown below.
<img width="1510" height="858" alt="Screenshot 2025-09-29 at 16 19 34" src="https://github.com/user-attachments/assets/f8639632-6649-4c6c-ad4b-7a5e77aa11aa" />
