### PR TITLE
Enable Public and Approved options only when ADW is activated

### DIFF
--- a/geonode_mapstore_client/context_processors.py
+++ b/geonode_mapstore_client/context_processors.py
@@ -66,5 +66,7 @@ def resource_urls(request):
         .get("OPTIONS", dict())
         .get("MOSAIC_ENABLED", False),
         "SUPPORTED_DATASET_FILE_TYPES": get_supported_datasets_file_types(),
+        "RESOURCE_PUBLISHING": getattr(settings, "RESOURCE_PUBLISHING", False),
+        "ADMIN_MODERATE_UPLOADS": getattr(settings, "ADMIN_MODERATE_UPLOADS", False),
     }
     return defaults

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -70,6 +70,8 @@
         let supportedDatasetFileTypes = geoNodeSettings.SUPPORTED_DATASET_FILE_TYPES;
         let catalogHomeRedirectsTo = geoNodeSettings.CATALOG_HOME_REDIRECTS_TO;
         let catalogPagePath = geoNodeSettings.CATALOG_PAGE_PATH;
+        let isPublishedOptionEnabled = geoNodeSettings.RESOURCE_PUBLISHING || false;
+        let isApprovedOptionEnabled = geoNodeSettings.ADMIN_MODERATE_UPLOADS || false;
         let customFilters = geoNodeSettings.CUSTOM_FILTERS || {
             "my-resources": {
                 "filter{owner.pk}": "{state('user') && state('user').pk}"
@@ -210,7 +212,9 @@
                     },
                     staticPath: "{% static '' %}",
                     catalogHomeRedirectsTo: catalogHomeRedirectsTo,
-                    catalogPagePath: catalogPagePath
+                    catalogPagePath: catalogPagePath,
+                    isPublishedOptionEnabled: isPublishedOptionEnabled,
+                    isApprovedOptionEnabled: isApprovedOptionEnabled
                 }
             },
         };


### PR DESCRIPTION
### Description
This PR adds advanced workflow options to the GeoNode settings and uses them to display the published and approved statuses in the ResourceDetail panel

### Issue
- #2219 