### PR TITLE
Fix #2266 Multilang: use indexed fields in client queries

### DIFF
--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -12,7 +12,8 @@ import {
     paramsSerializer,
     getGeoNodeConfig,
     getGeoNodeLocalConfig,
-    API_PRESET
+    API_PRESET,
+    getResourcesSearchIndex
 } from '@js/utils/APIUtils';
 import merge from 'lodash/merge';
 import mergeWith from 'lodash/mergeWith';
@@ -62,7 +63,7 @@ export const getResources = ({
         ...getQueryParams({...params, f}, customFilters),
         ...(q && {
             search: q,
-            search_fields: ['title', 'abstract']
+            search_index: getResourcesSearchIndex()
         }),
         ...(sort && { sort: isArray(sort) ? sort : [ sort ]}),
         page,
@@ -102,7 +103,7 @@ export const getMaps = ({
                     ...params,
                     ...(q && {
                         search: q,
-                        search_fields: ['title', 'abstract']
+                        search_index: getResourcesSearchIndex()
                     }),
                     ...(sort && { sort: isArray(sort) ? sort : [ sort ]}),
                     page,
@@ -138,7 +139,7 @@ export const getDatasets = ({
                     'filter{metadata_only}': false,
                     ...(q && {
                         search: q,
-                        search_fields: ['title', 'abstract']
+                        search_index: getResourcesSearchIndex()
                     }),
                     ...(sort && { sort: isArray(sort) ? sort : [ sort ]}),
                     page,
@@ -171,7 +172,7 @@ export const getDocumentsByDocType = (docType = 'image', {
                     ...params,
                     ...(q && {
                         search: q,
-                        search_fields: ['title', 'abstract']
+                        search_index: getResourcesSearchIndex()
                     }),
                     ...(sort && { sort: isArray(sort) ? sort : [ sort ]}),
                     'filter{subtype}': [docType],
@@ -335,7 +336,7 @@ export const getGeoApps = ({
                     ...params,
                     ...(q && {
                         search: q,
-                        search_fields: ['title', 'abstract']
+                        search_index: getResourcesSearchIndex()
                     }),
                     ...(sort && { sort: isArray(sort) ? sort : [ sort ]}),
                     page,

--- a/geonode_mapstore_client/client/js/utils/APIUtils.js
+++ b/geonode_mapstore_client/client/js/utils/APIUtils.js
@@ -132,6 +132,10 @@ export const paramsSerializer = () => {
     };
 };
 
+export const getResourcesSearchIndex = () => {
+    return getGeoNodeLocalConfig('geoNodeSettings.resourcesSearchIndex');
+};
+
 export const API_PRESET = {
     CATALOGS: 'catalog_list',
     DATASETS: 'dataset_list',

--- a/geonode_mapstore_client/context_processors.py
+++ b/geonode_mapstore_client/context_processors.py
@@ -68,5 +68,6 @@ def resource_urls(request):
         "SUPPORTED_DATASET_FILE_TYPES": get_supported_datasets_file_types(),
         "RESOURCE_PUBLISHING": getattr(settings, "RESOURCE_PUBLISHING", False),
         "ADMIN_MODERATE_UPLOADS": getattr(settings, "ADMIN_MODERATE_UPLOADS", False),
+        "RESOURCES_SEARCH_INDEX": getattr(settings, "RESOURCES_SEARCH_INDEX", "title_abstract"),
     }
     return defaults

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -72,6 +72,7 @@
         let catalogPagePath = geoNodeSettings.CATALOG_PAGE_PATH;
         let isPublishedOptionEnabled = geoNodeSettings.RESOURCE_PUBLISHING || false;
         let isApprovedOptionEnabled = geoNodeSettings.ADMIN_MODERATE_UPLOADS || false;
+        let resourcesSearchIndex = geoNodeSettings.RESOURCES_SEARCH_INDEX || 'title_abstract';
         let customFilters = geoNodeSettings.CUSTOM_FILTERS || {
             "my-resources": {
                 "filter{owner.pk}": "{state('user') && state('user').pk}"
@@ -214,7 +215,8 @@
                     catalogHomeRedirectsTo: catalogHomeRedirectsTo,
                     catalogPagePath: catalogPagePath,
                     isPublishedOptionEnabled: isPublishedOptionEnabled,
-                    isApprovedOptionEnabled: isApprovedOptionEnabled
+                    isApprovedOptionEnabled: isApprovedOptionEnabled,
+                    resourcesSearchIndex: resourcesSearchIndex
                 }
             },
         };

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/search_bar.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/snippets/search_bar.html
@@ -158,8 +158,7 @@
                     const url = '/api/v2/resources' +
                     '?page=' + options.page +
                     '&search=' + options.value +
-                    '&search_fields=title' +
-                    '&search_fields=abstract' +
+                    '&search_index=' + window.__GEONODE_CONFIG__?.localConfig?.geoNodeSettings?.resourcesSearchIndex +
                     '&filter{metadata_only}=false';
                     {% endblock %}
                     request = $.ajax({


### PR DESCRIPTION
This PR introduces usage of `search_index` instead of `search_fields` for search on resources related api.
The value for `search_index` is controlled by the `RESOURCES_SEARCH_INDEX` setting, `title_abstract` by default