### PR TITLE
Add the spinner outside the create new dataset button

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/CreateDataset/containers/CreateDataset.jsx
+++ b/geonode_mapstore_client/client/js/plugins/CreateDataset/containers/CreateDataset.jsx
@@ -374,16 +374,16 @@ const CreateDataset = ({
                     </table>
                 </FlexBox>
 
-                <div>
+                <FlexBox centerChildrenVertically gap="sm">
                     <Button
                         className="gn-attribute-button"
                         variant="success"
                         disabled={!!allErrors.length || loading}
                         onClick={handleCreate}>
                         <Message msgId="gnviewer.createNewDataset" />
-                        {loading ? <Spinner /> : null}
                     </Button>
-                </div>
+                    {loading ? <Spinner /> : null}
+                </FlexBox>
             </FlexBox>
         </FlexBox>
     );


### PR DESCRIPTION
## Related tasks

Fixes https://github.com/GeoNode/geonode-mapstore-client/issues/2214

## Describe this PR

This PR changes the position of displaying the spinner and put it outside the create new dataset button.
<img width="611" height="415" alt="image" src="https://github.com/user-attachments/assets/79026732-a754-4aec-9e14-0ec2006606c5" />