### PR TITLE
Add the configuration for the Map layer settings plugin to hide close button

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -1397,7 +1397,8 @@
                 "mandatory": true,
                 "cfg": {
                     "enableIFrameModule": true,
-                    "className": "gn-dataset-layersettings"
+                    "className": "gn-dataset-layersettings",
+                    "hideCloseButton": true
                 }  
             },
             {


### PR DESCRIPTION
## Related tasks

Fixes https://github.com/GeoNode/geonode-mapstore-client/issues/2203

## Describe this PR

This PR adds the configuration for the Map layer settings to hide the close button.