### PR TITLE
Fix tile blur on initial loading in dataset pages

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -182,6 +182,7 @@ const resourceTypes = {
                             ...mapConfig,
                             map: {
                                 ...mapConfig.map,
+                                zoom: 20, // we are applying high zoom level to mitigate the initial tile blurring due to the zoom to event
                                 visualizationMode: ['3dtiles'].includes(subtype) ? VisualizationModes._3D : VisualizationModes._2D,
                                 layers: [
                                     ...mapConfig.map.layers,


### PR DESCRIPTION
This PR force the initial zoom level of dataset maps to 20, this should reduce the blurring effect due to initial zoom to dataset extent