### PR TITLE
Fix #2325 map viewer spining indefinitely when loading non-existent map issue

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -237,7 +237,6 @@ const resourceTypes = {
                             ? axios.all([{...resource}, getGeoAppByPk(mapViewers?.pk, {api_preset: 'catalog_list', include: ['data', 'linked_resources']})])
                             : Promise.resolve([{...resource}]);
                     })
-                    .catch(() => null)
             ]))
                 .switchMap(([baseConfig, resource]) => {
                     const [mapResource, mapViewerResource] = resource ?? [];


### PR DESCRIPTION
## Related task

Fixes https://github.com/GeoNode/geonode-mapstore-client/issues/2325

## Describe this PR

This PR fixes the issue of indefinite spinning when loading a non-existent map in the Map viewer.
<img width="1472" height="973" alt="image" src="https://github.com/user-attachments/assets/8b15d085-a9e4-482a-a600-596d31ac9764" />