### PR TITLE
Feat #2331 Implement support for COG Remote Layers

### DIFF
--- a/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
+++ b/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
@@ -104,7 +104,8 @@ function UploadDataset({
                 remoteType: '3dtiles'
             })}
             remoteTypes={[
-                { value: '3dtiles', label: '3D Tiles' }
+                { value: '3dtiles', label: '3D Tiles' },
+                { value: 'cog', label: 'COG' }
             ]}
             remoteTypeErrorMessageId="gnviewer.unsupportedUrlServiceType"
         >

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -204,6 +204,21 @@ export const resourceToLayerConfig = (resource) => {
             extendedParams
         };
     }
+    if (subtype === 'cog') {
+        const { url: cogUrl } = links.find(({ extension }) => (extension === 'cog')) || {};
+        return {
+            perms,
+            id: uuid(),
+            type: 'cog',
+            title,
+            sources: [{
+                url: parseDevHostname(cogUrl || ''),
+            }],
+            ...(bbox && { bbox }),
+            visibility: true,
+            extendedParams
+        };
+    }
 
     switch (ptype) {
     case GXP_PTYPES.REST_MAP:

--- a/geonode_mapstore_client/client/js/utils/UploadUtils.js
+++ b/geonode_mapstore_client/client/js/utils/UploadUtils.js
@@ -141,8 +141,7 @@ export const validateRemoteResourceUploads = (uploads = [], { remoteTypes } = {}
             && !(upload.url.indexOf('/') === 0) // is not relative
             && isValidURL(upload.url);
         // Automatically change remoteType to 'cog' if URL ends with .tif or .tiff
-        const urlLowerCase = upload.url?.toLowerCase() || '';
-        const isTifFile = urlLowerCase.endsWith('.tif') || urlLowerCase.endsWith('.tiff');
+        const isTifFile = isCOGFileUrl(upload.url);
         const remoteType = isTifFile ? 'cog' : upload.remoteType;
         const isRemoteTypeSupported = remoteTypes ? !!remoteTypes.find(({ value }) => value === remoteType) : true;
         const supported = !!(!isRemoteUrlDuplicated && isValidRemoteUrl && isRemoteTypeSupported);

--- a/geonode_mapstore_client/client/js/utils/UploadUtils.js
+++ b/geonode_mapstore_client/client/js/utils/UploadUtils.js
@@ -17,6 +17,11 @@ export const hasExtensionInUrl = (remoteResource) => {
     return !isEmpty(ext);
 };
 
+export const isCOGFileUrl = (url = '') => {
+    const urlLowerCase = url.toLowerCase();
+    return urlLowerCase.endsWith('.tif') || urlLowerCase.endsWith('.tiff');
+};
+
 export const isNotSupported = (remoteResource) => !isNil(remoteResource?.supported) && !remoteResource?.supported;
 
 export const getErrorMessageId = (remoteResource, { remoteTypeErrorMessageId } = {}) => {
@@ -135,10 +140,15 @@ export const validateRemoteResourceUploads = (uploads = [], { remoteTypes } = {}
         const isValidRemoteUrl = !!upload.url
             && !(upload.url.indexOf('/') === 0) // is not relative
             && isValidURL(upload.url);
-        const isRemoteTypeSupported = remoteTypes ? !!remoteTypes.find(({ value }) => value === upload.remoteType) : true;
+        // Automatically change remoteType to 'cog' if URL ends with .tif or .tiff
+        const urlLowerCase = upload.url?.toLowerCase() || '';
+        const isTifFile = urlLowerCase.endsWith('.tif') || urlLowerCase.endsWith('.tiff');
+        const remoteType = isTifFile ? 'cog' : upload.remoteType;
+        const isRemoteTypeSupported = remoteTypes ? !!remoteTypes.find(({ value }) => value === remoteType) : true;
         const supported = !!(!isRemoteUrlDuplicated && isValidRemoteUrl && isRemoteTypeSupported);
         return {
             ...upload,
+            remoteType,
             supported,
             ready: supported,
             validation: {

--- a/geonode_mapstore_client/client/js/utils/__tests__/UploadUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/UploadUtils-test.js
@@ -20,7 +20,8 @@ import {
     getUploadFileName,
     getUploadProperty,
     getSize,
-    getExceedingFileSize
+    getExceedingFileSize,
+    isCOGFileUrl
 } from '../UploadUtils';
 
 const supportedFiles = [
@@ -50,6 +51,13 @@ const supportedFiles = [
 ];
 
 describe('Test Upload Utils', () => {
+    it('isCOGFileUrl', () => {
+        expect(isCOGFileUrl()).toBe(false);
+        expect(isCOGFileUrl('http://example.com/data.tif')).toBe(true);
+        expect(isCOGFileUrl('http://example.com/data.tiff')).toBe(true);
+        expect(isCOGFileUrl('http://example.com/DATA.TIF')).toBe(true);
+        expect(isCOGFileUrl('http://example.com/data.png')).toBe(false);
+    });
     it('hasExtensionInUrl', () => {
         expect(hasExtensionInUrl()).toBe(false);
         expect(hasExtensionInUrl({ url: 'http://path/filename.png' })).toBe(true);
@@ -222,6 +230,22 @@ describe('Test Upload Utils', () => {
                 missingExtensions: []
             }
         ]);
+    });
+    it('validateRemoteResourceUploads sets COG type for tif/tiff URLs', () => {
+        const uploads = [
+            { url: 'http://example.com/data.tif', remoteType: '', type: 'remote' },
+            { url: 'http://example.com/data.TIFF', remoteType: 'wms', type: 'remote' }
+        ];
+        const remoteTypes = [{ value: 'cog' }];
+        const [first, second] = validateRemoteResourceUploads(uploads, { remoteTypes });
+
+        expect(first.remoteType).toBe('cog');
+        expect(first.supported).toBe(true);
+        expect(first.ready).toBe(true);
+
+        expect(second.remoteType).toBe('cog');
+        expect(second.supported).toBe(true);
+        expect(second.ready).toBe(true);
     });
     it('validateRemoteResourceUploads', () => {
         expect(validateRemoteResourceUploads()).toEqual([]);


### PR DESCRIPTION
## Related tasks

Fixes https://github.com/GeoNode/geonode-mapstore-client/issues/2331

## Describe this PR

This PR allow the creation of a new remote layer for COG files. It also automatically selects COG if the remote URLs ends with *.tif/.tiff* extension. It also displays the added COG layer in the dataset viewer.

## Other useful information

- There is a known issue with the projection.
<img width="1914" height="1034" alt="image" src="https://github.com/user-attachments/assets/a9c0dab1-d163-4c35-a5b3-7106cb410f56" />