### PR TITLE
#2358: Dataset - Fallback to WPS async downloads in case missing default download URLs

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/ActionNavbar/buttons.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ActionNavbar/buttons.jsx
@@ -26,7 +26,7 @@ import { getSelectedLayer } from '@mapstore/framework/selectors/layers';
 import { isDashboardEditing } from '@mapstore/framework/selectors/dashboard';
 import { createWidget } from '@mapstore/framework/actions/widgets';
 import { getResourceData, getSelectedLayerDataset } from '@js/selectors/resource';
-import { GXP_PTYPES } from '@js/utils/ResourceUtils';
+import { GXP_PTYPES, hasDefaultDownload, ResourceTypes } from '@js/utils/ResourceUtils';
 import { exportDataResultsControlEnabledSelector, checkingExportDataEntriesSelector, exportDataResultsSelector } from '@mapstore/framework/selectors/layerdownload';
 import { currentLocaleSelector } from '@mapstore/framework/selectors/locale';
 import { checkExportDataEntries, removeExportDataResult } from '@mapstore/framework/actions/layerdownload';
@@ -71,7 +71,9 @@ const LayerDownloadActionButtonComponent = ({
     nodeTypes,
     items,
     status,
-    statusTypes
+    statusTypes,
+    showIcon,
+    tooltipId = "gnviewer.exportData"
 }, context) => {
     const node = useRef();
     const { loadedPlugins } = context;
@@ -109,14 +111,22 @@ const LayerDownloadActionButtonComponent = ({
             </>
         ) : null;
     }
+
+    // Hide export data icon button for datasets with default download
+    if (data?.resource_type === ResourceTypes.DATASET && hasDefaultDownload(data) && showIcon) {
+        return null;
+    }
+
+    const Component = tooltip(Button);
     return (
-        <Button
+        <Component
             variant={variant}
             size={size}
             onClick={() => onClick()}
+            {...showIcon && { tooltipId }}
         >
-            <Message msgId="gnviewer.exportData" />
-        </Button>
+            {showIcon ? <Glyphicon glyph="download" /> : <Message msgId="gnviewer.exportData" />}
+        </Component>
     );
 };
 

--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -118,7 +118,13 @@ export const plugins = {
                             position: 1,
                             target: 'right-menu'
                         }
-                    ]
+                    ],
+                    ResourceDetails: {
+                        name: 'LayerDownload',
+                        Component: LayerDownloadActionButton,
+                        target: 'toolbar',
+                        position: 1
+                    }
                 }
             }
         }

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -830,12 +830,26 @@ export const getResourceImageSource = (image) => {
     return image ? image : 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPAAAADICAIAAABZHvsFAAAACXBIWXMAAC4jAAAuIwF4pT92AAABiklEQVR42u3SAQ0AAAjDMMC/5+MAAaSVsKyTFHwxEmBoMDQYGgyNocHQYGgwNBgaQ4OhwdBgaDA0hgZDg6HB0GBoDA2GBkODocHQGBoMDYYGQ4OhMTQYGgwNhgZDY2gwNBgaDI2hwdBgaDA0GBpDg6HB0GBoMDSGBkODocHQYGgMDYYGQ4OhwdAYGgwNhgZDg6ExNBgaDA2GBkNjaDA0GBoMDYbG0GBoMDQYGkODocHQYGgwNIYGQ4OhwdBgaAwNhgZDg6HB0BgaDA2GBkODoTE0GBoMDYYGQ2NoMDQYGgwNhsbQYGgwNBgaQ4OhwdBgaDA0hgZDg6HB0GBoDA2GBkODocHQGBoMDYYGQ4OhMTQYGgwNhgZDY2gwNBgaDA2GxtBgaDA0GBoMjaHB0GBoMDSGBkODocHQYGgMDYYGQ4OhwdAYGgwNhgZDg6ExNBgaDA2GBkNjaDA0GBoMDYbG0GBoMDQYGgyNocHQYGgwNIYGQ4OhwdBgaAwNhgZDg6HB0BgaDA2GBkPDbQH4OQSN0W8qegAAAABJRU5ErkJggg==';
 };
 
+export const hasDefaultDownload = (resource) => {
+    return !isEmpty(resource?.download_urls) && resource.download_urls.some((d) => d.default);
+};
+
 export const getDownloadUrlInfo = (resource) => {
     const hrefUrl = { url: resource?.href, ajaxSafe: false };
     if (isDocumentExternalSource(resource)) {
         return hrefUrl;
     }
-    if (!isEmpty(resource?.download_urls)) {
+    const downloadUrls = resource?.download_urls ?? [];
+    if (!isEmpty(downloadUrls)) {
+
+        // For datasets, use only default download url
+        if (resource?.resource_type === ResourceTypes.DATASET) {
+            const downloadData = downloadUrls.find((d) => d.default);
+            const _url = !isEmpty(downloadData) ? downloadData.url : null;
+            const ajaxSafe = !isEmpty(downloadData) ? downloadData.ajax_safe : false;
+            return { url: _url, ajaxSafe };
+        }
+
         const downloadData = resource.download_urls.length === 1
             ? resource.download_urls[0]
             : resource.download_urls.find((d) => d.default);


### PR DESCRIPTION
### Description
This PR adds a fallback to WPS async download when the default download is not configured for a dataset resource. For assets, the existing downloader behavior remains unchanged.

### Issue
- #2358

### Screenshot
**Dataset Resource with no default in download urls**
<img width="655" height="148" alt="image" src="https://github.com/user-attachments/assets/4db327da-b696-4966-9d2b-e6bdd62619bf" />
<img width="648" height="290" alt="image" src="https://github.com/user-attachments/assets/4158b7eb-5a2a-4fad-b198-8d5f5ac7dbd8" />
