### PR TITLE
Fix #2367 Pending indicator CSS fixes for Filter and Update Metadata button

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/ActionNavbar/buttons.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ActionNavbar/buttons.jsx
@@ -172,7 +172,7 @@ export const FilterLayerActionButton = connect(
     return (
         <Button
             variant={variant}
-            className={active ? 'gn-success-changes-icon' : ''}
+            className={active ? 'ms-notification-circle warning' : ''}
             size={size}
             onClick={() => onClick()}
         >

--- a/geonode_mapstore_client/client/js/plugins/MetadataEditor/containers/MetadataUpdateButton.jsx
+++ b/geonode_mapstore_client/client/js/plugins/MetadataEditor/containers/MetadataUpdateButton.jsx
@@ -71,7 +71,7 @@ function MetadataUpdateButton({
             size={size}
             variant={variant}
             disabled={!pendingChanges || updating}
-            className={pendingChanges ? 'gn-pending-changes-icon' : ''}
+            className={pendingChanges ? 'ms-notification-circle warning' : ''}
             onClick={() => handleUpdate()}
         >
             <Message msgId="gnhome.update" />

--- a/geonode_mapstore_client/client/themes/geonode/less/_base.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_base.less
@@ -66,13 +66,6 @@
     .page-header {
         .border-color-var(@theme-vars[main-border-color]);
     }
-
-    .gn-pending-changes-icon, 
-    .gn-success-changes-icon {
-        &::after {
-            .background-color-var(@theme-vars[warning]);
-        }
-    }
 }
 
 // **************
@@ -185,23 +178,6 @@ body {
         overflow-y: auto;
         overflow-x: hidden;
         z-index: 1;
-    }
-}
-
-.gn-pending-changes-icon,
-.gn-success-changes-icon {
-    position: relative;
-    &::after {
-        content: '';
-        display: block;
-        width: 0.5rem;
-        height: 0.5rem;
-        position: absolute;
-        right: 2px;
-        top: 2px;
-        border-radius: 50%;
-        .shadow-soft();
-        z-index: 10;
     }
 }
 


### PR DESCRIPTION
This PR fix the following issue:

Pending changes indicator is not displayed when using the Filter button or the Update Metadata button.

Issue: #2367 

Screen shots after fix :
<img width="1504" height="708" alt="Screenshot 2026-02-02 at 18 36 50" src="https://github.com/user-attachments/assets/29616ac0-29df-4ac3-adfd-3305358484a9" />
<img width="782" height="379" alt="Screenshot 2026-02-02 at 18 40 48" src="https://github.com/user-attachments/assets/dcc9e73a-17fb-4af2-8cd2-02db8e908b94" />



