### PR TITLE
Fix #2374 Main loader shown in wrong position when application is initializing.

### DIFF
--- a/geonode_mapstore_client/client/js/apps/gn-components.js
+++ b/geonode_mapstore_client/client/js/apps/gn-components.js
@@ -87,7 +87,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             appComponent: withRoutes(routes)(ConnectedRouter),
                             pluginsConfig: getPluginsConfigOverride(getPluginsConfiguration(localConfig.plugins, pluginsConfigKey)),
                             targetId: 'ms-container',
-                            loaderComponent: MainLoader,
+                            loaderComponent: ()=> null,
                             pluginsDef: {
                                 plugins: {
                                     ...pluginsDefinition.plugins

--- a/geonode_mapstore_client/client/js/apps/gn-components.js
+++ b/geonode_mapstore_client/client/js/apps/gn-components.js
@@ -8,7 +8,6 @@
 import { connect } from 'react-redux';
 import main from '@mapstore/framework/components/app/main';
 import ComponentsRoute from '@js/routes/Components';
-import MainLoader from '@js/components/MainLoader';
 import Router, { withRoutes } from '@js/components/Router';
 import security from '@mapstore/framework/reducers/security';
 import {


### PR DESCRIPTION
This PR fix :

1.  When initializing the application , the main loader is visible in the wrong position.

More information about issue: 
https://github.com/GeoNode/geonode-mapstore-client/issues/2374#issuecomment-3847049290

After fix: 

https://github.com/user-attachments/assets/b7bafa04-b38f-416d-951b-accb838f2717


