### PR TITLE
fix Metadata page breaks the app when deleting title

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/MetadataEditor/containers/MetadataEditor.jsx
+++ b/geonode_mapstore_client/client/js/plugins/MetadataEditor/containers/MetadataEditor.jsx
@@ -231,7 +231,7 @@ function MetadataEditor({
                     readonly={readOnly}
                     ref={initialize.current}
                     formContext={{
-                        title: metadata.title || metadataMultiLang.title.en || getMessageById(messages, 'gnviewer.metadataEditorTitle'),
+                        title: metadata.title || metadataMultiLang.title?.en || getMessageById(messages, 'gnviewer.metadataEditorTitle'),
                         metadata: metadataMultiLang,
                         capitalizeTitle: capitalizeFieldTitle,
                         messages

--- a/geonode_mapstore_client/client/js/plugins/MetadataEditor/containers/MetadataEditor.jsx
+++ b/geonode_mapstore_client/client/js/plugins/MetadataEditor/containers/MetadataEditor.jsx
@@ -216,6 +216,7 @@ function MetadataEditor({
 
     const {schemaMultiLang, uiSchemaMultiLang} = schemaToMultiLang(schema, uiSchema);
     const metadataMultiLang = metadataToMultiLang(metadata, schema);
+    const defaultTitle = getMessageById(messages, 'gnviewer.metadataEditorTitle');
 
     return (
         <div className="gn-metadata">
@@ -231,7 +232,7 @@ function MetadataEditor({
                     readonly={readOnly}
                     ref={initialize.current}
                     formContext={{
-                        title: metadata.title || metadataMultiLang.title?.en || getMessageById(messages, 'gnviewer.metadataEditorTitle'),
+                        title: metadata.title || metadataMultiLang.title?.en || Object.values(metadataMultiLang.title || {})[0] || defaultTitle,
                         metadata: metadataMultiLang,
                         capitalizeTitle: capitalizeFieldTitle,
                         messages


### PR DESCRIPTION
This PR fix the bug #2375 

In case where the title field is not multilingual.
One possible improvement would be to add the default language to the jsonschema. Currently, the client can't make this choice, so it chooses EN, assuming it's always present in all conditions.