### PR TITLE
Support flatgeobuf in metadata explorer

### DIFF
--- a/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
+++ b/geonode_mapstore_client/client/js/routes/UploadDataset.jsx
@@ -105,7 +105,8 @@ function UploadDataset({
             })}
             remoteTypes={[
                 { value: '3dtiles', label: '3D Tiles' },
-                { value: 'cog', label: 'COG' }
+                { value: 'cog', label: 'COG' },
+                { value: 'flatgeobuf', label: 'FlatGeobuf' }
             ]}
             remoteTypeErrorMessageId="gnviewer.unsupportedUrlServiceType"
         >

--- a/geonode_mapstore_client/client/js/utils/UploadUtils.js
+++ b/geonode_mapstore_client/client/js/utils/UploadUtils.js
@@ -17,9 +17,16 @@ export const hasExtensionInUrl = (remoteResource) => {
     return !isEmpty(ext);
 };
 
-export const isCOGFileUrl = (url = '') => {
+export const remoteTypeByUrl = (url, defaultType) => {
     const urlLowerCase = url.toLowerCase();
-    return urlLowerCase.endsWith('.tif') || urlLowerCase.endsWith('.tiff');
+    const fileTypeMaps = {
+        '.tif': 'cog',
+        '.tiff': 'cog',
+        '.fgb': 'flatgeobuf',
+        '.flatgeobuf': 'flatgeobuf'
+    };
+    const matchedType = Object.keys(fileTypeMaps).find(extension => urlLowerCase.endsWith(extension));
+    return matchedType ? fileTypeMaps[matchedType] : defaultType;
 };
 
 export const isNotSupported = (remoteResource) => !isNil(remoteResource?.supported) && !remoteResource?.supported;
@@ -140,9 +147,10 @@ export const validateRemoteResourceUploads = (uploads = [], { remoteTypes } = {}
         const isValidRemoteUrl = !!upload.url
             && !(upload.url.indexOf('/') === 0) // is not relative
             && isValidURL(upload.url);
-        // Automatically change remoteType to 'cog' if URL ends with .tif or .tiff
-        const isTifFile = isCOGFileUrl(upload.url);
-        const remoteType = isTifFile ? 'cog' : upload.remoteType;
+
+        // Automatically change remoteType by file extension
+        const remoteType = remoteTypeByUrl(upload.url, upload.remoteType);
+
         const isRemoteTypeSupported = remoteTypes ? !!remoteTypes.find(({ value }) => value === remoteType) : true;
         const supported = !!(!isRemoteUrlDuplicated && isValidRemoteUrl && isRemoteTypeSupported);
         return {

--- a/geonode_mapstore_client/client/js/utils/__tests__/UploadUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/UploadUtils-test.js
@@ -21,7 +21,7 @@ import {
     getUploadProperty,
     getSize,
     getExceedingFileSize,
-    isCOGFileUrl
+    remoteTypeByUrl
 } from '../UploadUtils';
 
 const supportedFiles = [
@@ -51,12 +51,13 @@ const supportedFiles = [
 ];
 
 describe('Test Upload Utils', () => {
-    it('isCOGFileUrl', () => {
-        expect(isCOGFileUrl()).toBe(false);
-        expect(isCOGFileUrl('http://example.com/data.tif')).toBe(true);
-        expect(isCOGFileUrl('http://example.com/data.tiff')).toBe(true);
-        expect(isCOGFileUrl('http://example.com/DATA.TIF')).toBe(true);
-        expect(isCOGFileUrl('http://example.com/data.png')).toBe(false);
+    it('remoteTypeByUrl', () => {
+        expect(remoteTypeByUrl('http://example.com/data.tif', '')).toBe('cog');
+        expect(remoteTypeByUrl('http://example.com/data.tiff', '')).toBe('cog');
+        expect(remoteTypeByUrl('http://example.com/data.fgb', '')).toBe('flatgeobuf');
+        expect(remoteTypeByUrl('http://example.com/data.flatgeobuf', '')).toBe('flatgeobuf');
+        expect(remoteTypeByUrl('http://example.com/data.csv', 'csv')).toBe('csv');
+        expect(remoteTypeByUrl('http://example.com/data.png', 'png')).toBe('png');
     });
     it('hasExtensionInUrl', () => {
         expect(hasExtensionInUrl()).toBe(false);
@@ -231,7 +232,7 @@ describe('Test Upload Utils', () => {
             }
         ]);
     });
-    it('validateRemoteResourceUploads sets COG type for tif/tiff URLs', () => {
+    it('validateRemoteResourceUploads sets COG type for .tif/.tiff URLs', () => {
         const uploads = [
             { url: 'http://example.com/data.tif', remoteType: '', type: 'remote' },
             { url: 'http://example.com/data.TIFF', remoteType: 'wms', type: 'remote' }
@@ -244,6 +245,22 @@ describe('Test Upload Utils', () => {
         expect(first.ready).toBe(true);
 
         expect(second.remoteType).toBe('cog');
+        expect(second.supported).toBe(true);
+        expect(second.ready).toBe(true);
+    });
+    it('validateRemoteResourceUploads sets FlatGeobuf type for .fgb/.flatgeobuf URLs', () => {
+        const uploads = [
+            { url: 'http://example.com/data.fgb', remoteType: '', type: 'remote' },
+            { url: 'http://example.com/data.flatgeobuf', remoteType: 'wms', type: 'remote' }
+        ];
+        const remoteTypes = [{ value: 'flatgeobuf' }];
+        const [first, second] = validateRemoteResourceUploads(uploads, { remoteTypes });
+
+        expect(first.remoteType).toBe('flatgeobuf');
+        expect(first.supported).toBe(true);
+        expect(first.ready).toBe(true);
+
+        expect(second.remoteType).toBe('flatgeobuf');
         expect(second.supported).toBe(true);
         expect(second.ready).toBe(true);
     });

--- a/geonode_mapstore_client/client/themes/geonode/less/_upload.less
+++ b/geonode_mapstore_client/client/themes/geonode/less/_upload.less
@@ -195,14 +195,14 @@
                     }
                 }
                 .Select-control {
-                    width: 85px;
+                    width: 116px;
                     border-left: none;
                     border-top: none;
                     border-right: none;
                 }
                 .Select-menu-outer {
                     width: auto;
-                    font-size: 0.7rem;
+                    font-size: 0.8rem;
                     font-weight: normal;
                     line-height: 0.8rem;
                 }
@@ -217,9 +217,9 @@
                     padding-left: 0.25rem;
                 }
                 .Select-value-label {
-                    padding: 3px 7px;
+                    padding: 3px 10px;
                     border-radius: 10px;
-                    font-size: 0.7rem;
+                    font-size: 0.8rem;
                     font-weight: normal;
                     line-height: 0.8rem;
                 }

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -2110,7 +2110,8 @@
                         { "name": "3dtiles", "label": "3D Tiles" }, 
                         { "name": "model", "label": "IFC Model" }, 
                         { "name": "arcgis", "label": "ArcGIS" }, 
-                        { "name": "cog", "label": "COG" }
+                        { "name": "cog", "label": "COG" },
+                        { "name": "flatgeobuf", "label": "FlatGeobuf" }
                     ]
                 }
             },


### PR DESCRIPTION
fix issues #2264

- adapt resource FlatGeobuf as Geonode datasets
- upgrade UploadPanel components for loading remote resource FlatGeobuf

flatgeobuf apply default geometryType for stiling

NOTE: this PR is in Draft because we waiting backend pass new attribute_set geometryType to apply correct Style.
Now the default style applied is for a `GeometryCollection`

A remote Flatgeobuf remote for testing:
https://flatgeobuf.org/test/data/countries.fgb

Open FlatGeobuf layer from Catalog:

https://github.com/user-attachments/assets/1486116f-1357-4897-afe8-fdb8e6f59e6e



Create new dataset use remote FlatGeobuf resource:


https://github.com/user-attachments/assets/03ba60a4-9f7e-4bc8-960b-3a22fba47f5f


