### PR TITLE
#2398: Enable the scalebar by default for both Map and Dataset

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -132,7 +132,8 @@
                 "cfg": {
                     "shouldLoadFont": false,
                     "tools": [
-                        "popup"
+                        "popup",
+                        "scalebar"
                     ],
                     "mapOptions": {
                         "openlayers": {
@@ -145,7 +146,12 @@
                             }
                         }
                     },
-                    "containerPosition":"background"
+                    "containerPosition":"background",
+                    "toolsOptions": {
+                        "scalebar": {
+                            "container": "#footer-scalebar-container"
+                        }
+                    }
                 }
             },
             {
@@ -202,7 +208,8 @@
                 "cfg": {
                     "shouldLoadFont": false,
                     "tools": [
-                        "popup"
+                        "popup",
+                        "scalebar"
                     ],
                     "mapOptions": {
                         "openlayers": {
@@ -215,7 +222,12 @@
                             }
                         }
                     },
-                    "containerPosition":"background"
+                    "containerPosition":"background",
+                    "toolsOptions": {
+                        "scalebar": {
+                            "container": "#footer-scalebar-container"
+                        }
+                    }
                 }
             },
             {
@@ -268,7 +280,7 @@
                 "name": "Map",
                 "cfg": {
                     "shouldLoadFont": false,
-                    "tools": [],
+                    "tools": ["scalebar"],
                     "mapOptions": {
                         "openlayers": {
                             "attribution": {
@@ -280,7 +292,12 @@
                             }
                         }
                     },
-                    "containerPosition":"background"
+                    "containerPosition":"background",
+                    "toolsOptions": {
+                        "scalebar": {
+                            "container": "#footer-scalebar-container"
+                        }
+                    }
                 }
             },
             {
@@ -355,7 +372,7 @@
                 "name": "Map",
                 "cfg": {
                     "shouldLoadFont": false,
-                    "tools": [],
+                    "tools": ["scalebar"],
                     "mapOptions": {
                         "openlayers": {
                             "attribution": {
@@ -367,7 +384,12 @@
                             }
                         }
                     },
-                    "containerPosition":"background"
+                    "containerPosition":"background",
+                    "toolsOptions": {
+                        "scalebar": {
+                            "container": "#footer-scalebar-container"
+                        }
+                    }
                 }
             },
             {
@@ -719,7 +741,8 @@
                 "cfg": {
                     "tools": [
                         "draw",
-                        "box"
+                        "box",
+                        "scalebar"
                     ],
                     "mapOptions": {
                         "openlayers": {
@@ -732,7 +755,12 @@
                             }
                         }
                     },
-                    "containerPosition":"background"
+                    "containerPosition":"background",
+                    "toolsOptions": {
+                        "scalebar": {
+                            "container": "#footer-scalebar-container"
+                        }
+                    }
                 }
             },
             {
@@ -1278,7 +1306,8 @@
                 "cfg": {
                     "tools": [
                         "draw",
-                        "box"
+                        "box",
+                        "scalebar"
                     ],
                     "mapOptions": {
                         "openlayers": {
@@ -1291,7 +1320,12 @@
                             }
                         }
                     },
-                    "containerPosition":"background"
+                    "containerPosition":"background",
+                    "toolsOptions": {
+                        "scalebar": {
+                            "container": "#footer-scalebar-container"
+                        }
+                    }
                 }
             },
             {
@@ -1455,7 +1489,8 @@
                     "tools": [
                         "draw",
                         "box",
-                        "popup"
+                        "popup",
+                        "scalebar"
                     ],
                     "mapOptions": {
                         "openlayers": {
@@ -1468,7 +1503,12 @@
                             }
                         }
                     },
-                    "containerPosition":"background"
+                    "containerPosition":"background",
+                    "toolsOptions": {
+                        "scalebar": {
+                            "container": "#footer-scalebar-container"
+                        }
+                    }
                 }
             },
             {
@@ -1490,7 +1530,8 @@
                 "cfg": {
                     "tools": [
                         "draw",
-                        "box"
+                        "box",
+                        "scalebar"
                     ],
                     "mapOptions": {
                         "openlayers": {
@@ -1503,7 +1544,12 @@
                             }
                         }
                     },
-                    "containerPosition":"background"
+                    "containerPosition":"background",
+                    "toolsOptions": {
+                        "scalebar": {
+                            "container": "#footer-scalebar-container"
+                        }
+                    }
                 }
             },
             {

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -131,10 +131,6 @@
                 "name": "Map",
                 "cfg": {
                     "shouldLoadFont": false,
-                    "tools": [
-                        "popup",
-                        "scalebar"
-                    ],
                     "mapOptions": {
                         "openlayers": {
                             "attribution": {
@@ -207,10 +203,6 @@
                 "name": "Map",
                 "cfg": {
                     "shouldLoadFont": false,
-                    "tools": [
-                        "popup",
-                        "scalebar"
-                    ],
                     "mapOptions": {
                         "openlayers": {
                             "attribution": {
@@ -280,7 +272,6 @@
                 "name": "Map",
                 "cfg": {
                     "shouldLoadFont": false,
-                    "tools": ["scalebar"],
                     "mapOptions": {
                         "openlayers": {
                             "attribution": {
@@ -372,7 +363,6 @@
                 "name": "Map",
                 "cfg": {
                     "shouldLoadFont": false,
-                    "tools": ["scalebar"],
                     "mapOptions": {
                         "openlayers": {
                             "attribution": {
@@ -739,11 +729,6 @@
             {
                 "name": "Map",
                 "cfg": {
-                    "tools": [
-                        "draw",
-                        "box",
-                        "scalebar"
-                    ],
                     "mapOptions": {
                         "openlayers": {
                             "attribution": {
@@ -1304,11 +1289,6 @@
             {
                 "name": "Map",
                 "cfg": {
-                    "tools": [
-                        "draw",
-                        "box",
-                        "scalebar"
-                    ],
                     "mapOptions": {
                         "openlayers": {
                             "attribution": {
@@ -1486,12 +1466,6 @@
             {
                 "name": "Map",
                 "cfg": {
-                    "tools": [
-                        "draw",
-                        "box",
-                        "popup",
-                        "scalebar"
-                    ],
                     "mapOptions": {
                         "openlayers": {
                             "attribution": {
@@ -1528,11 +1502,6 @@
             {
                 "name": "Map",
                 "cfg": {
-                    "tools": [
-                        "draw",
-                        "box",
-                        "scalebar"
-                    ],
                     "mapOptions": {
                         "openlayers": {
                             "attribution": {


### PR DESCRIPTION
### Description
This PR updates the Map plugin configuration to include the scale bar by default, enabling it for both Map and Dataset viewers

### Issue
- #2398 

### Screenshot
#### Map
<img width="1920" height="962" alt="image" src="https://github.com/user-attachments/assets/31084b9a-4ee9-4c04-86ce-1336d570e4dd" />

#### Dataset
<img width="1920" height="962" alt="image" src="https://github.com/user-attachments/assets/8b7f21d2-ea74-4448-923d-23d03f674076" />
