### PR TITLE
Fix the view for non-spatial datasets has broken raster viewers

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -100,7 +100,6 @@ import {
     getCataloguePath,
     isDefaultDatasetSubtype,
     resourceHasPermission,
-    checkIfGeometryAttributeIsNull,
     canEditMap
 } from '@js/utils/ResourceUtils';
 import {
@@ -183,7 +182,7 @@ const resourceTypes = {
                     const [mapConfig, gnLayer, newLayer] = response;
                     const {minx, miny, maxx, maxy } = newLayer?.bbox?.bounds || {};
                     const extent = newLayer?.bbox?.bounds && [minx, miny, maxx, maxy ];
-                    const hasNoGeometry = checkIfGeometryAttributeIsNull(gnLayer.attribute_set);
+                    const hasNoGeometry = gnLayer?.subtype === 'tabular';
                     const hasDownloadPermission = gnLayer?.perms?.includes('download_resourcebase');
                     return Observable.of(
                         configureMap({

--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -17,9 +17,9 @@ import { excludeGoogleBackground, extractTileMatrixFromSources, ServerTypes } fr
 import { getGeoNodeLocalConfig, parseDevHostname } from '@js/utils/APIUtils';
 import { ProcessTypes, ProcessStatus } from '@js/utils/ResourceServiceUtils';
 import { determineResourceType } from '@js/utils/FileUtils';
-import { isGeometryType } from '@mapstore/framework/utils/ogc/WFS/base';
 
 import { createDefaultStyle } from '@mapstore/framework/utils/StyleUtils';
+
 /**
 * @module utils/ResourceUtils
 */
@@ -994,10 +994,6 @@ export const canManageResourceSettings = (resource) => {
 export const canAccessPermissions = (resource) => {
     const { perms } = resource || {};
     return perms?.includes('change_resourcebase_permissions');
-};
-
-export const checkIfGeometryAttributeIsNull = (attributeSet) => {
-    return isEmpty(attributeSet?.find(attribute => isGeometryType({ type: attribute.attribute_type })));
 };
 
 /**


### PR DESCRIPTION
### Related tasks

Fixes https://github.com/GeoNode/geonode-mapstore-client/issues/2463

### Describe this PR

This PR updates the condition to display the tabular dataset / non-spatial dataset. It only applies the non-spatial view when the dataset has tabular sub type.