### PR TITLE
Fix #2456 : Removed unpublished filter from the resources filter form.

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -3795,12 +3795,6 @@
                                     "type": "filter"
                                 },
                                 {
-                                    "id": "unpublished",
-                                    "labelId": "gnhome.unpublished",
-                                    "type": "filter",
-                                    "disableIf": "{not state('user')}"
-                                },
-                                {
                                     "id": "pending-approval",
                                     "labelId": "gnhome.pendingApproval",
                                     "type": "filter",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -139,7 +139,6 @@
             "customFiltersTitle": "Ressourcen",
             "myResources": "Meine Ressourcen",
             "pendingApproval": "Genehmigung ausstehend",
-            "unpublished": "Unveröffentlicht",
             "unApprovedunPublished": "Diese Ressource ist nicht veröffentlicht und nicht genehmigt",
             "featuredList": "Vorgestellt",
             "uploadDataset": "Datensatz hochladen",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -139,7 +139,6 @@
             "customFiltersTitle": "Resources",
             "myResources": "My resources",
             "pendingApproval": "Pending approval",
-            "unpublished": "Unpublished",
             "unApprovedunPublished": "This resource is unpublished and not approved",
             "featuredList": "Featured",
             "uploadDataset": "Upload dataset",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -139,7 +139,6 @@
             "customFiltersTitle": "Recursos",
             "myResources": "Mis recursos",
             "pendingApproval": "Este recurso no está aprobado",
-            "unpublished": "Este recurso no está publicado.",
             "unApprovedunPublished": "Este recurso no está publicado ni aprobado.",
             "featuredList": "Presentada",
             "uploadDataset": "Subir conjunto de datos",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -138,7 +138,6 @@
             "customFiltersTitle": "Resources",
             "myResources": "My resources",
             "pendingApproval": "Pending approval",
-            "unpublished": "Unpublished",
             "featuredList": "Featured",
             "uploadDataset": "Upload dataset",
             "createDataset": "Create dataset",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -139,7 +139,6 @@
             "customFiltersTitle": "Ressources",
             "myResources": "Mes ressources",
             "pendingApproval": "Cette ressource n'est pas approuvée",
-            "unpublished": "Cette ressource n'est pas publiée",
             "unApprovedunPublished": "Cette ressource n'est ni publiée ni approuvée",
             "featuredList": "Mis en exergue",
             "uploadDataset": "Télécharger l'ensemble de données",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -138,7 +138,6 @@
             "customFiltersTitle": "Resources",
             "myResources": "My resources",
             "pendingApproval": "Pending approval",
-            "unpublished": "Unpublished",
             "featuredList": "Featured",
             "uploadDataset": "Upload dataset",
             "createDataset": "Create dataset",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -141,7 +141,6 @@
             "customFiltersTitle": "Risorse",
             "myResources": "Le mie risorse",
             "pendingApproval": "Questa risorsa non è approvata",
-            "unpublished": "Questa risorsa non è pubblicata",
             "unApprovedunPublished": "Questa risorsa non è pubblicata e non è approvata",
             "featuredList": "In primo piano",
             "uploadDataset": "Carica dataset",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -138,7 +138,6 @@
             "customFiltersTitle": "Resources",
             "myResources": "My resources",
             "pendingApproval": "Pending approval",
-            "unpublished": "Unpublished",
             "featuredList": "Featured",
             "uploadDataset": "Upload dataset",
             "createDataset": "Create dataset",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-BR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-BR.json
@@ -134,7 +134,6 @@
             "customFiltersTitle": "Recursos",
             "myResources": "Meus recursos",
             "pendingApproval": "Aprovação pendente",
-            "unpublished": "Não publicado",
             "featuredList": "Em destaque",
             "uploadDataset": "Carregar conjunto de dados",
             "createDataset": "Criar conjunto de dados",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -138,7 +138,6 @@
             "customFiltersTitle": "Resources",
             "myResources": "My resources",
             "pendingApproval": "Pending approval",
-            "unpublished": "Unpublished",
             "featuredList": "Featured",
             "uploadDataset": "Upload dataset",
             "createDataset": "Create dataset",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -138,7 +138,6 @@
             "customFiltersTitle": "Resources",
             "myResources": "My resources",
             "pendingApproval": "Pending approval",
-            "unpublished": "Unpublished",
             "featuredList": "Featured",
             "uploadDataset": "Upload dataset",
             "createDataset": "Create dataset",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -139,7 +139,6 @@
             "customFiltersTitle": "Resources",
             "myResources": "My resources",
             "pendingApproval": "Pending approval",
-            "unpublished": "Unpublished",
             "featuredList": "Featured",
             "uploadDataset": "Upload dataset",
             "createDataset": "Create dataset",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -138,7 +138,6 @@
             "customFiltersTitle": "Resources",
             "myResources": "My resources",
             "pendingApproval": "Pending approval",
-            "unpublished": "Unpublished",
             "featuredList": "Featured",
             "uploadDataset": "Upload dataset",
             "createDataset": "Create dataset",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -138,7 +138,6 @@
             "customFiltersTitle": "Resources",
             "myResources": "My resources",
             "pendingApproval": "Pending approval",
-            "unpublished": "Unpublished",
             "featuredList": "Featured",
             "uploadDataset": "Upload dataset",
             "createDataset": "Create dataset",

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -83,9 +83,6 @@
             "featured": {
                 "filter{featured}": true
             },
-            "unpublished": {
-                "filter{is_published}": false
-            },
             "pending-approval": {
                 "filter{is_approved}": false
             },

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/resource_page_catalog.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/resource_page_catalog.html
@@ -28,12 +28,6 @@
                             "type": "filter"
                         },
                         {
-                            "id": "unpublished",
-                            "labelId": "gnhome.unpublished",
-                            "type": "filter",
-                            "disableIf": "{not state('user')}"
-                        },
-                        {
                             "id": "pending-approval",
                             "labelId": "gnhome.pendingApproval",
                             "type": "filter",


### PR DESCRIPTION
This PR removes `Unpublished `from the resource filter form , associated config and translations. 

<img width="1508" height="769" alt="unpublished_removed" src="https://github.com/user-attachments/assets/59cd04d4-befb-4d78-8bc8-5ed91de82337" />
