### PR TITLE
show flatgeobuf in vector filter, add tabular dataset, subtype

### DIFF
--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -72,13 +72,15 @@ export const getResources = ({
         api_preset: API_PRESET.CATALOGS
     };
 
-    if (_params['filter{subtype.in}'] === 'vector') {
-        _params['filter{subtype.in}'] = ['vector', 'flatgeobuf'];
+    const subtypeMappings = {
+        vector: ['vector', 'flatgeobuf'],
+        raster: ['raster', 'cog']
+    };
+    const subtypeFilter = _params['filter{subtype.in}'];
+    if (subtypeMappings[subtypeFilter]) {
+        _params['filter{subtype.in}'] = subtypeMappings[subtypeFilter];
     }
-    if (_params['filter{subtype.in}'] === 'raster') {
-        _params['filter{subtype.in}'] = ['raster', 'cog'];
-    }
-    
+
     return axios.get(getEndpointUrl(RESOURCES), {
         params: _params,
         ...config,

--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -71,6 +71,14 @@ export const getResources = ({
         'filter{metadata_only}': false, // exclude resources such as services
         api_preset: API_PRESET.CATALOGS
     };
+
+    if (_params['filter{subtype.in}'] === 'vector') {
+        _params['filter{subtype.in}'] = ['vector', 'flatgeobuf'];
+    }
+    if (_params['filter{subtype.in}'] === 'raster') {
+        _params['filter{subtype.in}'] = ['raster', 'cog'];
+    }
+    
     return axios.get(getEndpointUrl(RESOURCES), {
         params: _params,
         ...config,
@@ -178,6 +186,7 @@ export const getDocuments = ({
         page_size: pageSize,
         'filter{resource_type.in}': 'document'
     };
+
     return axios
         .get(
             getEndpointUrl(DOCUMENTS), {

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -3829,6 +3829,11 @@
                                             "id": "3dtiles",
                                             "labelId": "gnhome.3dtiles",
                                             "type": "filter"
+                                        },
+                                        {
+                                            "id": "tabular",
+                                            "labelId": "gnhome.tabular",
+                                            "type": "filter"
                                         }
                                     ]
                                 },

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -86,6 +86,7 @@
             "raster": "Raster",
             "remote": "Remote",
             "timeSeries": "Zeitserien",
+            "tabular": "Tabellarisch",
             "filtersCount": "{count, plural, =0 { Filter } other {Filter (#)}}",
             "admin": "Admin",
             "logOut": "Ausloggen",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -86,6 +86,7 @@
             "raster": "Raster",
             "remote": "Remote",
             "timeSeries": "Time series",
+            "tabular": "Tabular",
             "filtersCount": "{count, plural, =0 { Filters } other {Filters (#)}}",
             "admin": "Admin",
             "logOut": "Log out",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -86,6 +86,7 @@
             "raster": "Raster",
             "remote": "Remota",
             "timeSeries": "Series de tiempo",
+            "tabular": "Tabular",
             "filtersCount": "{count, plural, =0 { Filtros } other {Filtros (#)}}",
             "admin": "Administración",
             "logOut": "Salir",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -85,6 +85,7 @@
             "raster": "Raster",
             "remote": "Remote",
             "timeSeries": "Time series",
+            "tabular": "Tabular",
             "filtersCount": "{count, plural, =0 { Filters } other {Filters (#)}}",
             "admin": "Admin",
             "logOut": "Log out",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -86,6 +86,7 @@
             "raster": "Raster",
             "remote": "Webservice",
             "timeSeries": "Des séries chronologiques",
+            "tabular": "Tabulaire",
             "filtersCount": "{count, plural, =0 { Filtres } other {Filtres (#)}}",
             "admin": "Administration",
             "logOut": "Se déconnecter",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -85,6 +85,7 @@
             "raster": "Raster",
             "remote": "Remote",
             "timeSeries": "Time series",
+            "tabular": "Tabular",
             "filtersCount": "{count, plural, =0 { Filters } other {Filters (#)}}",
             "admin": "Admin",
             "logOut": "Log out",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -86,6 +86,7 @@
             "raster": "Raster",
             "remote": "Remoto",
             "timeSeries": "Serie temporale vettoriale",
+            "tabular": "Tabulari",
             "filtersCount": "{count, plural, =0 { Filtri } other {Filtri (#)}}",
             "myresources": "Risorse",
             "mylink": "I miei Link",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -85,6 +85,7 @@
             "raster": "Raster",
             "remote": "Remote",
             "timeSeries": "Time series",
+            "tabular": "Tabular",
             "filtersCount": "{count, plural, =0 { Filters } other {Filters (#)}}",
             "admin": "Admin",
             "logOut": "Log out",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-BR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-BR.json
@@ -81,6 +81,7 @@
             "raster": "Raster",
             "remote": "Remoto",
             "timeSeries": "Série temporal",
+            "tabular": "Tabular",
             "filtersCount": "{count, plural, =0 { Filtros } other {Filtros (#)}}",
             "admin": "Admin",
             "logOut": "Sair",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -85,6 +85,7 @@
             "raster": "Raster",
             "remote": "Remote",
             "timeSeries": "Time series",
+            "tabular": "Tabular",
             "filtersCount": "{count, plural, =0 { Filters } other {Filters (#)}}",
             "admin": "Admin",
             "logOut": "Log out",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -85,6 +85,7 @@
             "raster": "Raster",
             "remote": "Remote",
             "timeSeries": "Time series",
+            "tabular": "Tabular",
             "filtersCount": "{count, plural, =0 { Filters } other {Filters (#)}}",
             "admin": "Admin",
             "logOut": "Log out",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -86,6 +86,7 @@
             "raster": "Raster",
             "remote": "Remote",
             "timeSeries": "Time series",
+            "tabular": "Tabular",
             "filtersCount": "{count, plural, =0 { Filters } other {Filters (#)}}",
             "admin": "Admin",
             "logOut": "Log out",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -85,6 +85,7 @@
             "raster": "Raster",
             "remote": "Remote",
             "timeSeries": "Time series",
+            "tabular": "Tabular",
             "filtersCount": "{count, plural, =0 { Filters } other {Filters (#)}}",
             "admin": "Admin",
             "logOut": "Log out",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -85,6 +85,7 @@
             "raster": "Raster",
             "remote": "Remote",
             "timeSeries": "Time series",
+            "tabular": "Tabular",
             "filtersCount": "{count, plural, =0 { Filters } other {Filters (#)}}",
             "admin": "Admin",
             "logOut": "Log out",

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -107,6 +107,9 @@
             "3dtiles": {
                 "filter{subtype.in}": "3dtiles"
             },
+            "tabular": {
+                "filter{subtype.in}": "tabular"
+            },
             "document": {
                 "filter{resource_type.in}": "document"
             },

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/pages/datasets.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/pages/datasets.html
@@ -78,6 +78,11 @@
                         "id": "3dtiles",
                         "labelId": "gnhome.3dtiles",
                         "type": "filter"
+                    },
+                    {
+                        "id": "tabular",
+                        "labelId": "gnhome.tabular",
+                        "type": "filter"
                     }
                 ])
             }


### PR DESCRIPTION
Fix issue #2471 

Show dataset Flatgeobuf .fgb for `vector` filter
and COG .tif for `raster` filter

https://github.com/user-attachments/assets/14f910fc-4465-4f25-9327-5a1b6d55a800



added new type 'tabular' and it's i18n strings, for testing this the [geonode branch tabulardata](https://github.com/GeoNode/geonode/tree/tabulardata) is required 