### PR TITLE
Fix #2494 Error when saving style for flatgeobuff dataset

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnsave.js
+++ b/geonode_mapstore_client/client/js/epics/gnsave.js
@@ -113,15 +113,17 @@ function parseMapBody(body) {
 /**
  * Check if the selected layer can persist its default style through GeoServer REST.
  * @param {object} layer Selected layer configuration.
+ * @param {string} subtype Resource subtype.
  * @returns {boolean} True when the layer supports GeoServer default-style updates.
  */
-const isGeoServerStyleUpdateAllowed = (layer = {}) => {
-    return !STYLE_SUPPORTED_LAYER_TYPES.includes(layer?.type) && !!layer?.name;
+const isGeoServerStyleUpdateAllowed = (layer = {}, subtype) => {
+    return STYLE_SUPPORTED_LAYER_TYPES.includes(subtype) && !!layer?.name;
 };
 
 const setDefaultStyle = (state, id) => {
     const layer = getUpdatedLayer(state);
     const styleName = selectedStyleSelector(state);
+    const currentResource = getResourceData(state);
     let availableStyles = [];
     if (!isEmpty(layer.availableStyles)) {
         const defaultStyle = layer.availableStyles.filter(({ name }) => styleName === name);
@@ -137,7 +139,7 @@ const setDefaultStyle = (state, id) => {
         && !isEmpty(layers)
         && initialStyleName
         && currentStyleName !== initialStyleName
-        && isGeoServerStyleUpdateAllowed(layer)
+        && isGeoServerStyleUpdateAllowed(layer, currentResource?.subtype)
     ) {
         const { baseUrl = '' } = styleServiceSelector(state);
         return {


### PR DESCRIPTION
### Related tasks

Fixes https://github.com/GeoNode/geonode-mapstore-client/issues/2494

### Describe this PR
This PR fixes save behavior for non-GeoServer dataset formats like FlatGeoBuf, COG, and 3dtiles. This solves the issue of https://github.com/GeoNode/geonode-mapstore-client/pull/2495 PR.