### PR TITLE
Fix #2505 Add setting to configure projection defs endpoint

### DIFF
--- a/geonode_mapstore_client/client/js/epics/__tests__/gnsave-test.js
+++ b/geonode_mapstore_client/client/js/epics/__tests__/gnsave-test.js
@@ -289,7 +289,7 @@ describe('gnsave epics', () => {
         );
     });
 
-    it('should skip GeoServer style update for flatgeobuf save', (done) => {
+    it.only('should skip GeoServer style update for flatgeobuf save', (done) => {
         const NUM_ACTIONS = 4;
         const id = 1;
         const metadata = {
@@ -335,6 +335,9 @@ describe('gnsave epics', () => {
                             name: 'old_style'
                         }
                     }
+                },
+                map: {
+                    present: {}
                 },
                 layers: {
                     flat: [{

--- a/geonode_mapstore_client/client/js/epics/__tests__/gnsave-test.js
+++ b/geonode_mapstore_client/client/js/epics/__tests__/gnsave-test.js
@@ -289,7 +289,7 @@ describe('gnsave epics', () => {
         );
     });
 
-    it.only('should skip GeoServer style update for flatgeobuf save', (done) => {
+    it('should skip GeoServer style update for flatgeobuf save', (done) => {
         const NUM_ACTIONS = 4;
         const id = 1;
         const metadata = {

--- a/geonode_mapstore_client/client/js/utils/PluginsContextUtils.js
+++ b/geonode_mapstore_client/client/js/utils/PluginsContextUtils.js
@@ -155,5 +155,6 @@ export const getPluginsContext = () => ({
     },
     getDashboardCatalogueServices: (settings) => {
         return settings?.dashboardCatalogueServices || {};
-    }
+    },
+    getProjectionDefsEndpoint: (settings = {}) => settings?.projectionDefsEndpoint || ''
 });

--- a/geonode_mapstore_client/context_processors.py
+++ b/geonode_mapstore_client/context_processors.py
@@ -55,7 +55,7 @@ def resource_urls(request):
         "PROJECTION_DEFS_ENDPOINT": getattr(
             settings,
             "MAPSTORE_PROJECTION_DEFS_ENDPOINT",
-            getattr(settings, "SITEURL", "").rstrip("/") + "/geoserver",
+            (getattr(settings, "SITEURL", "") or "").rstrip("/") + "/geoserver",
         ),
         "PLUGINS_CONFIG_PATCH_RULES": getattr(
             settings, "MAPSTORE_PLUGINS_CONFIG_PATCH_RULES", []

--- a/geonode_mapstore_client/context_processors.py
+++ b/geonode_mapstore_client/context_processors.py
@@ -52,6 +52,11 @@ def resource_urls(request):
             ["/static/mapstore/ms-translations", "/static/mapstore/gn-translations"],
         ),
         "PROJECTION_DEFS": getattr(settings, "MAPSTORE_PROJECTION_DEFS", []),
+        "PROJECTION_DEFS_ENDPOINT": getattr(
+            settings,
+            "MAPSTORE_PROJECTION_DEFS_ENDPOINT",
+            getattr(settings, "SITEURL", "").rstrip("/") + "/geoserver",
+        ),
         "PLUGINS_CONFIG_PATCH_RULES": getattr(
             settings, "MAPSTORE_PLUGINS_CONFIG_PATCH_RULES", []
         ),

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -1281,6 +1281,7 @@
             {
                 "name": "CRSSelector",
                 "cfg": {
+                    "projectionDefsEndpoint": "{getProjectionDefsEndpoint(state('settings'))}",
                     "availableProjections": [
                         { "value": "EPSG:4326", "label": "EPSG:4326" },
                         { "value": "EPSG:3857", "label": "EPSG:3857" }
@@ -2626,6 +2627,7 @@
             {
                 "name": "CRSSelector",
                 "cfg": {
+                    "projectionDefsEndpoint": "{getProjectionDefsEndpoint(state('settings'))}",
                     "availableProjections": [
                         { "value": "EPSG:4326", "label": "EPSG:4326" },
                         { "value": "EPSG:3857", "label": "EPSG:3857" }

--- a/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
@@ -596,10 +596,10 @@
         "MapFooter"
       ],
       "defaultConfig": {
-        "additionalCRS": {},
-        "filterAllowedCRS": [
-          "EPSG:4326",
-          "EPSG:3857"
+        "projectionDefsEndpoint": "{getProjectionDefsEndpoint(state('settings'))}",
+        "availableProjections": [
+          { "value": "EPSG:4326", "label": "EPSG:4326" },
+          { "value": "EPSG:3857", "label": "EPSG:3857" }
         ]
       }
     },

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_geonode_config.html
@@ -64,6 +64,7 @@
         let allowedDocumentTypes = geoNodeSettings.ALLOWED_DOCUMENT_TYPES || [];
         let languages = geoNodeSettings.LANGUAGES;
         let projectionDefs = geoNodeSettings.PROJECTION_DEFS || [];
+        let projectionDefsEndpoint = geoNodeSettings.PROJECTION_DEFS_ENDPOINT || '';
         let pluginsConfigPatchRules  = geoNodeSettings.PLUGINS_CONFIG_PATCH_RULES || [];
         let translationsPath = geoNodeSettings.TRANSLATIONS_PATH;
         let extensionsFolder = geoNodeSettings.EXTENSIONS_FOLDER_PATH;
@@ -238,7 +239,8 @@
                     catalogPagePath: catalogPagePath,
                     isPublishedOptionEnabled: isPublishedOptionEnabled,
                     isApprovedOptionEnabled: isApprovedOptionEnabled,
-                    resourcesSearchIndex: resourcesSearchIndex
+                    resourcesSearchIndex: resourcesSearchIndex,
+                    projectionDefsEndpoint: projectionDefsEndpoint
                 }
             },
         };

--- a/tutorials/01-settings-variables.md
+++ b/tutorials/01-settings-variables.md
@@ -11,6 +11,7 @@ DEFAULT_MAP_CRS | crs used by the map and dataset viewers | EPSG:3857
 DEFAULT_MAP_ZOOM | initial zoom of new map | 0
 DEFAULT_TILE_SIZE | tiles size used by map and dataset viewers by default | 512
 DEFAULT_LAYER_FORMAT | tiles format used by map and dataset viewers by default | 'image/png'
+MAPSTORE_PROJECTION_DEFS_ENDPOINT | base URL of a GeoServer instance. Enables the remote projection search feature | SITEURL + '/geoserver' (embedded GeoServer)
 
 
 An example on how to update the `MAPSTORE_BASELAYERS` variable:


### PR DESCRIPTION
This PR introduces the `MAPSTORE_PROJECTION_DEFS_ENDPOINT` env variable to configure the crs endpoint, by default will access the local geoserver rest endpoint (needs geoserver 2.28.x)