### PR TITLE
Fix #2515 Only WMS maplayers are persisted correctly in the resource payload

### DIFF
--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -234,7 +234,10 @@ export const resourceToLayerConfig = (resource) => {
         }
     };
 
-    const extendedParams = { pk };
+    const extendedParams = {
+        pk,
+        alternate
+    };
 
     if (subtype === '3dtiles') {
         const { url: tilesetUrl } = links.find(({ extension }) => (extension === '3dtiles')) || {};
@@ -712,7 +715,7 @@ export function getGeoNodeMapLayers(data) {
                 ...(layer.type === 'wms' && {
                     current_style: layer.style || ''
                 }),
-                name: layer.name || '',
+                name: layer?.extendedParams?.alternate || layer.name || '',
                 order: index,
                 opacity: layer.opacity ?? 1,
                 visibility: layer.visibility
@@ -738,6 +741,7 @@ export function toGeoNodeMapConfig(data) {
                         ...(layer?.extendedParams?.pk && {
                             extendedParams: {
                                 pk: layer.extendedParams.pk,
+                                alternate: layer.extendedParams.alternate,
                                 ...(layer.extendedParams.mapLayer?.pk && {
                                     mapLayer: { pk: layer.extendedParams.mapLayer.pk }
                                 })
@@ -765,6 +769,7 @@ export function toMapStoreMapConfig(resource, baseConfig) {
                     }),
                     extendedParams: {
                         pk: mapLayer.dataset?.pk ?? layer.extendedParams?.pk,
+                        alternate: mapLayer.dataset?.alternate ?? layer.extendedParams?.alternate ?? layer.name,
                         ...(mapLayer.pk !== undefined && {
                             mapLayer: { pk: mapLayer.pk }
                         })

--- a/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
@@ -251,7 +251,8 @@ describe('Test Resource Utils', () => {
                         msId: '03'
                     },
                     dataset: {
-                        pk: 1
+                        pk: 1,
+                        alternate: 'geonode:layer'
                     }
                 }
             ],
@@ -297,7 +298,7 @@ describe('Test Resource Utils', () => {
                             name: 'geonode:layer',
                             url: 'geoserver/wms',
                             style: 'geonode:style01',
-                            extendedParams: { pk: 1, mapLayer: { pk: 10 } }
+                            extendedParams: { pk: 1, alternate: 'geonode:layer', mapLayer: { pk: 10 } }
                         }
                     ]
                 }
@@ -314,7 +315,8 @@ describe('Test Resource Utils', () => {
                         msId: '03'
                     },
                     dataset: {
-                        pk: 1
+                        pk: 1,
+                        alternate: 'geonode:layer'
                     }
                 }
             ],
@@ -364,7 +366,7 @@ describe('Test Resource Utils', () => {
                             name: 'geonode:layer',
                             url: 'geoserver/wms',
                             style: 'geonode:style01',
-                            extendedParams: { pk: 1, mapLayer: { pk: 10 } },
+                            extendedParams: { pk: 1, alternate: 'geonode:layer', mapLayer: { pk: 10 } },
                             featureInfo: { template: "<div>test</div>", format: FEATURE_INFO_FORMAT }
                         }
                     ]
@@ -382,7 +384,8 @@ describe('Test Resource Utils', () => {
                         msId: '03'
                     },
                     dataset: {
-                        pk: 1
+                        pk: 1,
+                        alternate: 'geonode:layer'
                     }
                 }
             ],
@@ -441,7 +444,7 @@ describe('Test Resource Utils', () => {
                             name: 'geonode:layer',
                             url: 'geoserver/wms',
                             style: 'geonode:style01',
-                            extendedParams: { pk: 1, mapLayer: { pk: 10 } }
+                            extendedParams: { pk: 1, alternate: 'geonode:layer', mapLayer: { pk: 10 } }
                         }
                     ]
                 }
@@ -532,7 +535,7 @@ describe('Test Resource Utils', () => {
         expect(getGeoNodeMapLayers(data)).toEqual([]);
     });
 
-    it('toGeoNodeMapConfig cleans up extendedParams to { pk, mapLayer: { pk } } and drops other keys', () => {
+    it('toGeoNodeMapConfig cleans up extendedParams to { pk, alternate, mapLayer: { pk } } and drops other keys', () => {
         const data = {
             map: {
                 layers: [{
@@ -541,6 +544,7 @@ describe('Test Resource Utils', () => {
                     name: 'geonode:layer',
                     extendedParams: {
                         pk: 1,
+                        alternate: 'geonode:layer',
                         mapLayer: { pk: 10 },
                         defaultStyle: { name: 'foo', title: 'bar' },
                         unrelated: 'should be dropped'
@@ -551,6 +555,7 @@ describe('Test Resource Utils', () => {
         const result = toGeoNodeMapConfig(data);
         expect(result.data.map.layers[0].extendedParams).toEqual({
             pk: 1,
+            alternate: 'geonode:layer',
             mapLayer: { pk: 10 }
         });
     });
@@ -562,12 +567,12 @@ describe('Test Resource Utils', () => {
                     id: '03',
                     type: 'wms',
                     name: 'geonode:layer',
-                    extendedParams: { pk: 1 }
+                    extendedParams: { pk: 1, alternate: 'geonode:layer' }
                 }]
             }
         };
         const result = toGeoNodeMapConfig(data);
-        expect(result.data.map.layers[0].extendedParams).toEqual({ pk: 1 });
+        expect(result.data.map.layers[0].extendedParams).toEqual({ pk: 1, alternate: 'geonode:layer' });
     });
 
     it('toMapStoreMapConfig removes geonode layers without a matching maplayer (orphans)', () => {
@@ -605,7 +610,7 @@ describe('Test Resource Utils', () => {
                         id: '03',
                         type: 'wms',
                         name: 'geonode:layer',
-                        extendedParams: { pk: 1, mapLayer: { pk: 10 } }
+                        extendedParams: { pk: 1, alternate: 'geonode:layer', mapLayer: { pk: 10 } }
                     }]
                 }
             }
@@ -613,6 +618,7 @@ describe('Test Resource Utils', () => {
         const result = toMapStoreMapConfig(resource, { map: { layers: [] } });
         expect(result.map.layers[0].extendedParams).toEqual({
             pk: 1,
+            alternate: 'geonode:layer',
             mapLayer: { pk: 10 }
         });
     });
@@ -625,18 +631,19 @@ describe('Test Resource Utils', () => {
                     type: 'wms',
                     name: 'geonode:layer',
                     style: 'geonode:style',
-                    extendedParams: { pk: 1, mapLayer: { pk: 10 } }
+                    extendedParams: { pk: 1, alternate: 'geonode:layer', mapLayer: { pk: 10 } }
                 }]
             }
         };
         const saved = toGeoNodeMapConfig(data);
         const resource = {
             ...saved,
-            maplayers: saved.maplayers.map(ml => ({ ...ml, dataset: { pk: 1 } }))
+            maplayers: saved.maplayers.map(ml => ({ ...ml, dataset: { pk: 1, alternate: 'geonode:layer' } }))
         };
         const reloaded = toMapStoreMapConfig(resource, { map: { layers: [] } });
         expect(reloaded.map.layers[0].extendedParams).toEqual({
             pk: 1,
+            alternate: 'geonode:layer',
             mapLayer: { pk: 10 }
         });
     });
@@ -1365,6 +1372,211 @@ describe('Test Resource Utils', () => {
                 'fr-FR': 'Titre de la couche',
                 'default': 'Default title'
             });
+        });
+    });
+    describe('alternate is propagated through extendedParams', () => {
+        // parseDevHostname references __DEVTOOLS__ (a webpack DefinePlugin global
+        // not declared in the karma test config); the 3dtiles/cog/flatgeobuf
+        // branches call it, so define it here to avoid ReferenceError
+        let prevDevtools;
+        before(() => {
+            prevDevtools = window.__DEVTOOLS__;
+            window.__DEVTOOLS__ = false;
+        });
+        after(() => {
+            window.__DEVTOOLS__ = prevDevtools;
+        });
+
+        it('resourceToLayerConfig (default WMS) includes alternate in extendedParams', () => {
+            const newLayer = resourceToLayerConfig({
+                alternate: 'geonode:layer_name',
+                links: [{
+                    extension: 'html',
+                    link_type: 'OGC:WMS',
+                    name: 'OGC WMS Service',
+                    mime: 'text/html',
+                    url: '/geoserver/wms'
+                }],
+                title: 'Layer title',
+                perms: [],
+                pk: 1
+            });
+            expect(newLayer.extendedParams).toEqual({ pk: 1, alternate: 'geonode:layer_name' });
+        });
+
+        it('resourceToLayerConfig (3dtiles) includes alternate in extendedParams', () => {
+            const newLayer = resourceToLayerConfig({
+                alternate: 'geonode:tileset',
+                subtype: '3dtiles',
+                links: [{ extension: '3dtiles', url: '/tileset.json' }],
+                title: 'Tileset',
+                perms: [],
+                pk: 2
+            });
+            expect(newLayer.extendedParams).toEqual({ pk: 2, alternate: 'geonode:tileset' });
+        });
+
+        it('resourceToLayerConfig (cog) includes alternate in extendedParams', () => {
+            const newLayer = resourceToLayerConfig({
+                alternate: 'geonode:cog_layer',
+                subtype: 'cog',
+                links: [{ extension: 'cog', url: '/raster.tif' }],
+                title: 'COG',
+                perms: [],
+                pk: 3
+            });
+            expect(newLayer.extendedParams).toEqual({ pk: 3, alternate: 'geonode:cog_layer' });
+        });
+
+        it('resourceToLayerConfig (flatgeobuf) includes alternate in extendedParams', () => {
+            const newLayer = resourceToLayerConfig({
+                alternate: 'geonode:fgb_layer',
+                subtype: 'flatgeobuf',
+                attribute_set: [],
+                links: [{ extension: 'flatgeobuf', url: '/data.fgb' }],
+                title: 'FGB',
+                perms: [],
+                pk: 4
+            });
+            expect(newLayer.extendedParams).toEqual({ pk: 4, alternate: 'geonode:fgb_layer' });
+        });
+
+        it('resourceToLayerConfig (arcgis) includes alternate in extendedParams', () => {
+            const newLayer = resourceToLayerConfig({
+                alternate: 'remoteWorkspace:1',
+                title: 'Layer title',
+                perms: [],
+                links: [{
+                    extension: 'html',
+                    link_type: 'image',
+                    mime: 'text/html',
+                    name: 'ArcGIS REST ImageServer',
+                    url: '/MapServer'
+                }],
+                pk: 5,
+                ptype: 'gxp_arcrestsource'
+            });
+            expect(newLayer.extendedParams).toEqual({ pk: 5, alternate: 'remoteWorkspace:1' });
+        });
+
+        it('getGeoNodeMapLayers prefers extendedParams.alternate over layer.name', () => {
+            const data = {
+                map: {
+                    layers: [{
+                        id: '03',
+                        type: 'wms',
+                        name: 'fallback:name',
+                        extendedParams: { pk: 1, alternate: 'geonode:from_alternate', mapLayer: { pk: 10 } }
+                    }]
+                }
+            };
+            const mapLayers = getGeoNodeMapLayers(data);
+            expect(mapLayers.length).toBe(1);
+            expect(mapLayers[0].name).toBe('geonode:from_alternate');
+        });
+
+        it('getGeoNodeMapLayers falls back to layer.name when extendedParams.alternate is missing', () => {
+            const data = {
+                map: {
+                    layers: [{
+                        id: '03',
+                        type: 'wms',
+                        name: 'fallback:name',
+                        extendedParams: { pk: 1 }
+                    }]
+                }
+            };
+            const mapLayers = getGeoNodeMapLayers(data);
+            expect(mapLayers[0].name).toBe('fallback:name');
+        });
+
+        it('toMapStoreMapConfig sets alternate from mapLayer.dataset.alternate (preferred)', () => {
+            const resource = {
+                maplayers: [{
+                    pk: 10,
+                    extra_params: { msId: '03' },
+                    dataset: { pk: 1, alternate: 'dataset:alternate' }
+                }],
+                data: {
+                    map: {
+                        layers: [{
+                            id: '03',
+                            type: 'wms',
+                            name: 'layer:name',
+                            extendedParams: { pk: 1, alternate: 'stale:alternate', mapLayer: { pk: 10 } }
+                        }]
+                    }
+                }
+            };
+            const result = toMapStoreMapConfig(resource, { map: { layers: [] } });
+            expect(result.map.layers[0].extendedParams.alternate).toBe('dataset:alternate');
+        });
+
+        it('toMapStoreMapConfig falls back to layer.extendedParams.alternate when dataset.alternate is missing', () => {
+            const resource = {
+                maplayers: [{
+                    pk: 10,
+                    extra_params: { msId: '03' },
+                    dataset: { pk: 1 }
+                }],
+                data: {
+                    map: {
+                        layers: [{
+                            id: '03',
+                            type: 'wms',
+                            name: 'layer:name',
+                            extendedParams: { pk: 1, alternate: 'stored:alternate', mapLayer: { pk: 10 } }
+                        }]
+                    }
+                }
+            };
+            const result = toMapStoreMapConfig(resource, { map: { layers: [] } });
+            expect(result.map.layers[0].extendedParams.alternate).toBe('stored:alternate');
+        });
+
+        it('toMapStoreMapConfig falls back to layer.name when neither alternate is available', () => {
+            const resource = {
+                maplayers: [{
+                    pk: 10,
+                    extra_params: { msId: '03' },
+                    dataset: { pk: 1 }
+                }],
+                data: {
+                    map: {
+                        layers: [{
+                            id: '03',
+                            type: 'wms',
+                            name: 'layer:name',
+                            extendedParams: { pk: 1, mapLayer: { pk: 10 } }
+                        }]
+                    }
+                }
+            };
+            const result = toMapStoreMapConfig(resource, { map: { layers: [] } });
+            expect(result.map.layers[0].extendedParams.alternate).toBe('layer:name');
+        });
+
+        it('round-trip via toGeoNodeMapConfig → toMapStoreMapConfig preserves alternate', () => {
+            const data = {
+                map: {
+                    layers: [{
+                        id: '03',
+                        type: 'wms',
+                        name: 'layer:name',
+                        style: 'geonode:style',
+                        extendedParams: { pk: 1, alternate: 'geonode:roundtrip', mapLayer: { pk: 10 } }
+                    }]
+                }
+            };
+            const saved = toGeoNodeMapConfig(data);
+            // maplayer.name should come from extendedParams.alternate
+            expect(saved.maplayers[0].name).toBe('geonode:roundtrip');
+            const resource = {
+                ...saved,
+                maplayers: saved.maplayers.map(ml => ({ ...ml, dataset: { pk: 1, alternate: 'geonode:roundtrip' } }))
+            };
+            const reloaded = toMapStoreMapConfig(resource, { map: { layers: [] } });
+            expect(reloaded.map.layers[0].extendedParams.alternate).toBe('geonode:roundtrip');
         });
     });
 });


### PR DESCRIPTION
This PR includes the alternate value inside the extendedParams of a layer to properly connect a maplayer to a dataset