### PR TITLE
Fix position of the timeline plugins

### DIFF
--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -192,7 +192,11 @@
                 "name": "Notifications"
             },
             {
-                "name": "Timeline"
+                "name": "Timeline",
+                "cfg": {
+                  "expandLimit": 20,
+                  "containerPosition": "bottom"
+                }
             },
             {
                 "name": "Playback"
@@ -261,7 +265,11 @@
                 }
             },
             {
-                "name": "Timeline"
+                "name": "Timeline",
+                "cfg": {
+                  "expandLimit": 20,
+                  "containerPosition": "bottom"
+                }
             },
             {
                 "name": "Playback"
@@ -352,7 +360,11 @@
                 "name": "Notifications"
             },
             {
-                "name": "Timeline"
+                "name": "Timeline",
+                "cfg": {
+                  "expandLimit": 20,
+                  "containerPosition": "bottom"
+                }
             },
             {
                 "name": "Playback"
@@ -460,7 +472,11 @@
                 }
             },
             {
-                "name": "Timeline"
+                "name": "Timeline",
+                "cfg": {
+                  "expandLimit": 20,
+                  "containerPosition": "bottom"
+                }
             },
             {
                 "name": "Playback"
@@ -905,7 +921,11 @@
                 }
             },
             {
-                "name": "Timeline"
+                "name": "Timeline",
+                "cfg": {
+                  "expandLimit": 20,
+                  "containerPosition": "bottom"
+                }
             },
             {
                 "name": "Playback"
@@ -2169,7 +2189,11 @@
                 }
             },
             {
-                "name": "Timeline"
+                "name": "Timeline",
+                "cfg": {
+                  "expandLimit": 20,
+                  "containerPosition": "bottom"
+                }
             },
             {
                 "name": "Playback"

--- a/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
@@ -474,7 +474,10 @@
       "description": "plugins.Timeline.description",
       "dependencies": [
         "Playback"
-      ]
+      ],
+      "defaultConfig": {
+        "containerPosition": "bottom"
+      }
     },
     {
       "name": "Playback",


### PR DESCRIPTION
### Related tasks

Fixes https://github.com/GeoNode/geonode-mapstore-client/issues/2545

### Describe this PR

This PR fixes the position of the timeline plugin.
Currently, it is displayed at the top of the page as defined in the issue. With the new changes, the timeline is displayed correctly at the bottom of the map.
<img width="957" height="496" alt="image" src="https://github.com/user-attachments/assets/367b6cad-38f3-4888-9208-79a58b9fa883" />