### PR TITLE
Make the CI ESLint step actually gate (run lint without --fix)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         working-directory: ${{env.working-directory}}
 
       - name: "Run ESlint"
-        run: npm run lint
+        run: npm run lint:ci
         working-directory: ${{env.working-directory}}
 
       - name: "Run Unit Tests"

--- a/geonode_mapstore_client/client/js/plugins/CreateDataset/components/CreateDatasetAttributeRow.jsx
+++ b/geonode_mapstore_client/client/js/plugins/CreateDataset/components/CreateDatasetAttributeRow.jsx
@@ -93,103 +93,103 @@ const CreateDatasetAttributeRow = ({
 
     return (
         <>
-        <tr className="gn-dataset-attribute">
-            <td className="gn-attribute-name">
-                <FormGroup
-                    controlId={getAttributeControlId(data, 'name')}
-                    validationState={errors?.name ? 'error' : undefined}
-                >
-                    <FormControl
-                        type="text"
-                        value={data?.name || ''}
-                        disabled={!!geometryAttribute || disabled}
-                        onChange={(event) => handleOnChange({ name: event.target.value })}
-                    />
-                    {errors?.name ? <HelpBlock><Message msgId={errors.name} /></HelpBlock> : null}
-                </FormGroup>
-            </td>
-            <td className="gn-attribute-type">
-                <FormGroup controlId={getAttributeControlId(data, 'type')}>
-                    <FormControl
-                        value={data?.type || ''}
-                        componentClass="select"
-                        placeholder="select"
-                        onChange={handleTypeChange}
-                        disabled={disabled}
-                    >
-                        {typesOptions.map(({ labelId, value }) =>
-                            <option key={value} value={value}>
-                                {getMessageById(context.messages, labelId)}
-                            </option>
-                        )}
-                    </FormControl>
-                </FormGroup>
-            </td>
-            <td className="gn-attribute-nillable">
-                <FormGroup controlId={getAttributeControlId(data, 'nillable')}>
-                    <Checkbox
-                        style={{ paddingTop: 6 }}
-                        checked={!!data?.nillable}
-                        disabled={!!geometryAttribute || disabled}
-                        onChange={(event) =>
-                            handleOnChange({ nillable: event.target.checked })
-                        }
-                    />
-                </FormGroup>
-            </td>
-            <td>
-                <FlexBox column gap="sm">
+            <tr className="gn-dataset-attribute">
+                <td className="gn-attribute-name">
                     <FormGroup
-                        controlId={getAttributeControlId(data, 'restrictions')}
-                        validationState={errors?.restrictionsType ? 'error' : undefined}>
+                        controlId={getAttributeControlId(data, 'name')}
+                        validationState={errors?.name ? 'error' : undefined}
+                    >
                         <FormControl
-                            value={data?.restrictionsType}
+                            type="text"
+                            value={data?.name || ''}
+                            disabled={!!geometryAttribute || disabled}
+                            onChange={(event) => handleOnChange({ name: event.target.value })}
+                        />
+                        {errors?.name ? <HelpBlock><Message msgId={errors.name} /></HelpBlock> : null}
+                    </FormGroup>
+                </td>
+                <td className="gn-attribute-type">
+                    <FormGroup controlId={getAttributeControlId(data, 'type')}>
+                        <FormControl
+                            value={data?.type || ''}
                             componentClass="select"
                             placeholder="select"
-                            disabled={!!geometryAttribute || disabled}
-                            onChange={(event) =>
-                                handleOnChange({ restrictionsType: event.target.value })
-                            }
+                            onChange={handleTypeChange}
+                            disabled={disabled}
                         >
-                            {restrictionsOptions.map(({ labelId, value }) =>
+                            {typesOptions.map(({ labelId, value }) =>
                                 <option key={value} value={value}>
                                     {getMessageById(context.messages, labelId)}
                                 </option>
                             )}
                         </FormControl>
-                        {errors?.restrictionsType ? <HelpBlock>{errors.restrictionsType}</HelpBlock> : null}
                     </FormGroup>
-                    {data?.restrictionsType === RestrictionsTypes.Range ?
-                        <RangeRestriction
-                            errors={errors}
-                            data={data}
-                            handleOnChange={handleOnChange}
-                            disabled={disabled}
-                        /> : null}
-                    {data?.restrictionsType === RestrictionsTypes.Options
-                        ? <EnumRestriction
-                            index={index}
-                            data={data}
-                            handleOnChange={handleOnChange}
-                            getErrorByPath={getErrorByPath}
-                            disabled={disabled}
-                        /> : null}
-                </FlexBox>
-            </td>
-            <td className="gn-attribute-tools">
-                {tools}
-            </td>
-        </tr>
-        {showGeomWarning ? (
-            <tr>
-                <td
-                    className="gn-attribute-geom-warning"
-                    colSpan={5}
-                >
-                   <Message msgId="gnviewer.geometryDatasetWarning" />
+                </td>
+                <td className="gn-attribute-nillable">
+                    <FormGroup controlId={getAttributeControlId(data, 'nillable')}>
+                        <Checkbox
+                            style={{ paddingTop: 6 }}
+                            checked={!!data?.nillable}
+                            disabled={!!geometryAttribute || disabled}
+                            onChange={(event) =>
+                                handleOnChange({ nillable: event.target.checked })
+                            }
+                        />
+                    </FormGroup>
+                </td>
+                <td>
+                    <FlexBox column gap="sm">
+                        <FormGroup
+                            controlId={getAttributeControlId(data, 'restrictions')}
+                            validationState={errors?.restrictionsType ? 'error' : undefined}>
+                            <FormControl
+                                value={data?.restrictionsType}
+                                componentClass="select"
+                                placeholder="select"
+                                disabled={!!geometryAttribute || disabled}
+                                onChange={(event) =>
+                                    handleOnChange({ restrictionsType: event.target.value })
+                                }
+                            >
+                                {restrictionsOptions.map(({ labelId, value }) =>
+                                    <option key={value} value={value}>
+                                        {getMessageById(context.messages, labelId)}
+                                    </option>
+                                )}
+                            </FormControl>
+                            {errors?.restrictionsType ? <HelpBlock>{errors.restrictionsType}</HelpBlock> : null}
+                        </FormGroup>
+                        {data?.restrictionsType === RestrictionsTypes.Range ?
+                            <RangeRestriction
+                                errors={errors}
+                                data={data}
+                                handleOnChange={handleOnChange}
+                                disabled={disabled}
+                            /> : null}
+                        {data?.restrictionsType === RestrictionsTypes.Options
+                            ? <EnumRestriction
+                                index={index}
+                                data={data}
+                                handleOnChange={handleOnChange}
+                                getErrorByPath={getErrorByPath}
+                                disabled={disabled}
+                            /> : null}
+                    </FlexBox>
+                </td>
+                <td className="gn-attribute-tools">
+                    {tools}
                 </td>
             </tr>
-        ) : null}
+            {showGeomWarning ? (
+                <tr>
+                    <td
+                        className="gn-attribute-geom-warning"
+                        colSpan={5}
+                    >
+                        <Message msgId="gnviewer.geometryDatasetWarning" />
+                    </td>
+                </tr>
+            ) : null}
         </>
     );
 };

--- a/geonode_mapstore_client/client/js/plugins/ResourceDetails/ResourceDetails.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ResourceDetails/ResourceDetails.jsx
@@ -462,9 +462,9 @@ export default createPlugin('ResourceDetails', {
                 () => ({}),
                 { onClick: toggleEditMode }
             )(({ onClick, size }) => {
-                return <Button size={size} onClick={onClick}>
+                return (<Button size={size} onClick={onClick}>
                     <Message msgId="gnviewer.editData" />
-                </Button>;
+                </Button>);
             }),
             priority: 1,
             doNotHide: true

--- a/geonode_mapstore_client/client/js/utils/UploadUtils.js
+++ b/geonode_mapstore_client/client/js/utils/UploadUtils.js
@@ -124,12 +124,12 @@ export const validateFileResourceUploads = (uploads = [], { supportedFiles = [] 
             };
         }
         const allUploadsAreOptional = upload.ext.every(ext =>
-                (currentSupportedType.optional_ext || []).includes(ext) &&
+            (currentSupportedType.optional_ext || []).includes(ext) &&
                 !currentSupportedType.required_ext.includes(ext)
-            );
+        );
         const missingExtensions = allUploadsAreOptional
-                ? []
-                : currentSupportedType.required_ext.filter(ext => !upload.ext.includes(ext));
+            ? []
+            : currentSupportedType.required_ext.filter(ext => !upload.ext.includes(ext));
         const supportedTypeExtensions = getSupportedTypeExt(currentSupportedType);
         return {
             ...upload,

--- a/geonode_mapstore_client/client/package.json
+++ b/geonode_mapstore_client/client/package.json
@@ -22,6 +22,7 @@
     "test": "mapstore-project test",
     "test:watch": "mapstore-project test:watch",
     "lint": "eslint js --ext .jsx,.js --fix",
+    "lint:ci": "eslint js --ext .jsx,.js",
     "docs": "jsdoc -r js/plugins js/utils/AppUtils.js ./README.md -d ../../docs -u ../../tutorials -t ./docs-template"
   },
   "author": "GeoSolutions",


### PR DESCRIPTION
## Problem

The `test.yml` workflow runs the lint step as `npm run lint`, and the `lint` script is:

```json
"lint": "eslint js --ext .jsx,.js --fix"
```

Because `--fix` repairs every auto-fixable problem in the runner and then exits `0`, any auto-fixable violation passes CI green — the lint step never fails on them. Over time 102 such violations (indentation, plus one `react/wrap-multilines`) accumulated in committed code while CI stayed green.

Reproduce on current master:

```bash
cd geonode_mapstore_client/client && npm install
npx eslint js --ext .jsx,.js   # 102 errors, all "potentially fixable with the --fix option"
npm run lint                   # exits 0 — it silently fixes them in the runner
```

## Fix

Two commits, kept separate:

1. **Clear the 102 existing violations** with a one-time `eslint --fix`. The change is whitespace/indentation only, plus one inert `react/wrap-multilines` paren wrap — no behavior change (`git diff -w` shows only that single paren wrap).
2. **Add a `lint:ci` script without `--fix`** and point `test.yml` at it, so the lint step gates again. The local `lint` script keeps `--fix` for developer convenience.

## Verification

- `npm run lint:ci` exits `0` after the fixes.
- Full unit suite still passes — `339 tests completed`, 0 failures.
- Node 20, matching CI.

## Question for maintainers

Was running `--fix` in CI intentional? If you'd prefer flipping the convention so `lint` is the check and a new `lint:fix` does the fixing, I'm happy to adjust — just say which you'd rather have.
