### PR TITLE
Guard required_ext access in validateFileResourceUploads (fixes TypeError for optional-only types)

### DIFF
--- a/geonode_mapstore_client/client/js/utils/UploadUtils.js
+++ b/geonode_mapstore_client/client/js/utils/UploadUtils.js
@@ -125,17 +125,17 @@ export const validateFileResourceUploads = (uploads = [], { supportedFiles = [] 
         }
         const allUploadsAreOptional = upload.ext.every(ext =>
                 (currentSupportedType.optional_ext || []).includes(ext) &&
-                !currentSupportedType.required_ext.includes(ext)
+                !(currentSupportedType.required_ext || []).includes(ext)
             );
         const missingExtensions = allUploadsAreOptional
                 ? []
-                : currentSupportedType.required_ext.filter(ext => !upload.ext.includes(ext));
+                : (currentSupportedType.required_ext || []).filter(ext => !upload.ext.includes(ext));
         const supportedTypeExtensions = getSupportedTypeExt(currentSupportedType);
         return {
             ...upload,
             ext: [...upload.ext].sort((a, b) => supportedTypeExtensions.indexOf(a) - supportedTypeExtensions.indexOf(b)),
             ready: missingExtensions.length === 0,
-            missingExtensions: missingExtensions.length > 0 && missingExtensions.length === currentSupportedType.required_ext.length
+            missingExtensions: missingExtensions.length > 0 && missingExtensions.length === (currentSupportedType.required_ext || []).length
                 ? ['*']
                 : missingExtensions
         };

--- a/geonode_mapstore_client/client/js/utils/UploadUtils.js
+++ b/geonode_mapstore_client/client/js/utils/UploadUtils.js
@@ -123,19 +123,21 @@ export const validateFileResourceUploads = (uploads = [], { supportedFiles = [] 
                 supported: false
             };
         }
+        const requiredExtensions = currentSupportedType.required_ext || [];
+        const optionalExtensions = currentSupportedType.optional_ext || [];
         const allUploadsAreOptional = upload.ext.every(ext =>
-                (currentSupportedType.optional_ext || []).includes(ext) &&
-                !(currentSupportedType.required_ext || []).includes(ext)
+                optionalExtensions.includes(ext) &&
+                !requiredExtensions.includes(ext)
             );
         const missingExtensions = allUploadsAreOptional
                 ? []
-                : (currentSupportedType.required_ext || []).filter(ext => !upload.ext.includes(ext));
+                : requiredExtensions.filter(ext => !upload.ext.includes(ext));
         const supportedTypeExtensions = getSupportedTypeExt(currentSupportedType);
         return {
             ...upload,
             ext: [...upload.ext].sort((a, b) => supportedTypeExtensions.indexOf(a) - supportedTypeExtensions.indexOf(b)),
             ready: missingExtensions.length === 0,
-            missingExtensions: missingExtensions.length > 0 && missingExtensions.length === (currentSupportedType.required_ext || []).length
+            missingExtensions: missingExtensions.length > 0 && missingExtensions.length === requiredExtensions.length
                 ? ['*']
                 : missingExtensions
         };

--- a/geonode_mapstore_client/client/js/utils/__tests__/UploadUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/UploadUtils-test.js
@@ -232,6 +232,33 @@ describe('Test Upload Utils', () => {
             }
         ]);
     });
+    it('validateFileResourceUploads does not throw for a supported type without required_ext', () => {
+        // Regression: getSupportedTypeExt() guards required_ext with `|| []`, but
+        // validateFileResourceUploads dereferenced it directly. A supported type
+        // declaring only optional_ext (no required_ext) matched the upload and then
+        // threw `TypeError: Cannot read properties of undefined (reading 'includes')`.
+        const optionalOnlySupportedFiles = [
+            {
+                id: 'style',
+                label: 'Style',
+                optional_ext: ['sld'],
+                source: ['upload'],
+                format: 'vector'
+            }
+        ];
+        expect(validateFileResourceUploads([
+            { type: 'file', ext: ['sld'], files: { sld: {} }, supported: true }
+        ], { supportedFiles: optionalOnlySupportedFiles })).toEqual([
+            {
+                type: 'file',
+                ext: ['sld'],
+                files: { sld: {} },
+                supported: true,
+                ready: true,
+                missingExtensions: []
+            }
+        ]);
+    });
     it('validateRemoteResourceUploads sets COG type for .tif/.tiff URLs', () => {
         const uploads = [
             { url: 'http://example.com/data.tif', remoteType: '', type: 'remote' },


### PR DESCRIPTION
## Problem

`validateFileResourceUploads` dereferences `currentSupportedType.required_ext` directly:

```js
const allUploadsAreOptional = upload.ext.every(ext =>
    (currentSupportedType.optional_ext || []).includes(ext) &&
    !currentSupportedType.required_ext.includes(ext)          // <-- no guard
);
const missingExtensions = allUploadsAreOptional
    ? []
    : currentSupportedType.required_ext.filter(...);           // <-- no guard
// ...
missingExtensions.length === currentSupportedType.required_ext.length  // <-- no guard
```

But `required_ext` is optional in the data model — `getSupportedTypeExt` already guards it:

```js
export const getSupportedTypeExt = (supportedType = {}) => {
    return [...(supportedType.required_ext || []), ...(supportedType.optional_ext || [])];
};
```

A `supportedType` declaring only `optional_ext` (no `required_ext`) still matches an upload via `getSupportedTypeExt`, then `validateFileResourceUploads` throws `TypeError: Cannot read properties of undefined (reading 'includes')`.

(Originally raised by `gemini-code-assist` on #2560; that PR only reindented these lines, so the fix belongs in its own change.)

## Fix

Guard the three `required_ext` reads with `|| []`, matching `getSupportedTypeExt`. No behavior change for types that declare `required_ext`.

## Test

Added a regression test in `UploadUtils-test.js` for a supported type with only `optional_ext`. It throws on `master` and passes with the fix:

```
✗ validateFileResourceUploads does not throw for a supported type without required_ext
  TypeError: Cannot read properties of undefined (reading 'includes')   # before
✔ validateFileResourceUploads does not throw for a supported type without required_ext  # after
```

Full suite: 340 tests pass (was 339), Node 20.

## Note

Touches the same `validateFileResourceUploads` lines as #2560 (a CI lint-gate PR that reindented this file). The two are independent; whichever merges second needs a trivial whitespace rebase.
