### PR TITLE
Fix DOWNLOAD_COMPLETE reducer clearing all downloads instead of the completed one

### DIFF
--- a/geonode_mapstore_client/client/js/reducers/__tests__/resourceservice-test.js
+++ b/geonode_mapstore_client/client/js/reducers/__tests__/resourceservice-test.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import expect from 'expect';
+import resourceservice from '@js/reducers/resourceservice';
+import { downloadResource, downloadComplete } from '@js/actions/gnresource';
+
+describe('resourceservice reducer', () => {
+    it('DOWNLOAD_RESOURCE adds the resource to downloads', () => {
+        const state = resourceservice({ processes: [], downloads: [] }, downloadResource({ pk: 1 }));
+        expect(state.downloads).toEqual([{ pk: 1 }]);
+    });
+    it('DOWNLOAD_COMPLETE removes only the completed download, keeping the others', () => {
+        const state = { processes: [], downloads: [{ pk: 1 }, { pk: 2 }] };
+        expect(resourceservice(state, downloadComplete({ pk: 1 }))).toEqual({
+            processes: [],
+            downloads: [{ pk: 2 }]
+        });
+    });
+});

--- a/geonode_mapstore_client/client/js/reducers/resourceservice.js
+++ b/geonode_mapstore_client/client/js/reducers/resourceservice.js
@@ -77,7 +77,7 @@ function resourceservice(state = defaultState, action) {
             ...state,
             downloads: [
                 ...state.downloads.filter((download) =>
-                    (download?.resource?.pk === action?.resource?.pk))
+                    download?.pk !== action?.resource?.pk)
             ]
         };
     }

--- a/geonode_mapstore_client/client/js/reducers/resourceservice.js
+++ b/geonode_mapstore_client/client/js/reducers/resourceservice.js
@@ -75,10 +75,8 @@ function resourceservice(state = defaultState, action) {
     case DOWNLOAD_COMPLETE: {
         return {
             ...state,
-            downloads: [
-                ...state.downloads.filter((download) =>
-                    download?.pk !== action?.resource?.pk)
-            ]
+            downloads: state.downloads.filter((download) =>
+                download?.pk !== action?.resource?.pk)
         };
     }
     default:


### PR DESCRIPTION
## Problem

In `reducers/resourceservice.js`, the `DOWNLOAD_COMPLETE` case filters:

```js
downloads: [
    ...state.downloads.filter((download) =>
        (download?.resource?.pk === action?.resource?.pk))
]
```

But `downloads` stores **bare resource objects** (`{ pk, ... }`), not `{ resource }` wrappers:
- `DOWNLOAD_RESOURCE` pushes `action.resource` directly;
- the epic dispatches `downloadComplete({ ...downloaded.resource })` (`epics/resourceservice.js`);
- the `processingDownload` selector matches `download?.pk`;
- the selector test fixture is `downloads: [{ pk: 1 }]`.

So `download?.resource?.pk` is always `undefined`, the predicate becomes `undefined === action.resource.pk` (false for every element), and **the entire downloads array is emptied** — completing one download clears the "in progress" state of all the others. The operator is also inverted: to drop the completed one, the filter must *keep* the entries that do **not** match.

## Fix

```js
...state.downloads.filter((download) =>
    download?.pk !== action?.resource?.pk)
```

## Test

New `reducers/__tests__/resourceservice-test.js`. The `DOWNLOAD_COMPLETE` case fails on `master` (returns `downloads: []`) and passes with the fix (returns `downloads: [{ pk: 2 }]`). Full unit suite stays green (Node 20).
