### PR TITLE
Fix gnDownload reducer mutating previous state on DOWNLOAD_METADATA_COMPLETE

### DIFF
--- a/geonode_mapstore_client/client/js/reducers/__tests__/gndownload-test.js
+++ b/geonode_mapstore_client/client/js/reducers/__tests__/gndownload-test.js
@@ -34,4 +34,11 @@ describe('gndownload reducer', () => {
             }
         });
     });
+    it('downloadMetaDataComplete does not mutate the previous state', () => {
+        const previousLinkState = { 1: true };
+        const state = { downloads: { ISO: previousLinkState, DublinCore: {} } };
+        gndownload(state, downloadMetaDataComplete('ISO', 1));
+        // a reducer must be pure: the previous state object must remain untouched
+        expect(previousLinkState).toEqual({ 1: true });
+    });
 });

--- a/geonode_mapstore_client/client/js/reducers/gndownload.js
+++ b/geonode_mapstore_client/client/js/reducers/gndownload.js
@@ -32,9 +32,8 @@ function gnDownload(state = defaultState, action) {
     }
     case DOWNLOAD_METADATA_COMPLETE: {
         const linkType = action?.link?.split(' ').join('');
-        // copy the link bucket before deleting so the previous state is not mutated
-        const remaining = { ...(state.downloads[linkType] || {}) };
-        delete remaining[action.pk];
+        // omit the completed pk immutably so the previous state is not mutated
+        const { [action.pk]: removed, ...remaining } = state.downloads[linkType] || {};
         return {
             ...state,
             downloads: {

--- a/geonode_mapstore_client/client/js/reducers/gndownload.js
+++ b/geonode_mapstore_client/client/js/reducers/gndownload.js
@@ -31,17 +31,15 @@ function gnDownload(state = defaultState, action) {
         };
     }
     case DOWNLOAD_METADATA_COMPLETE: {
-        const newState = { ...state };
         const linkType = action?.link?.split(' ').join('');
-        const downloads = newState.downloads[linkType];
-        delete downloads[action.pk];
+        // copy the link bucket before deleting so the previous state is not mutated
+        const remaining = { ...(state.downloads[linkType] || {}) };
+        delete remaining[action.pk];
         return {
-            ...newState,
+            ...state,
             downloads: {
-                ...newState.downloads,
-                [linkType]: {
-                    ...downloads
-                }
+                ...state.downloads,
+                [linkType]: remaining
             }
         };
     }


### PR DESCRIPTION
## Problem

In `reducers/gnDownload`, the `DOWNLOAD_METADATA_COMPLETE` case mutates the previous state:

```js
const newState = { ...state };                 // shallow copy
const downloads = newState.downloads[linkType]; // same reference as state.downloads[linkType]
delete downloads[action.pk];                    // mutates the incoming state!
```

`{ ...state }` is shallow, so `newState.downloads[linkType]` is the *same object* as the incoming `state.downloads[linkType]`. The `delete` removes the key from the previous state before the immutable spread runs. Reducers must be pure — mutating prior state can break referential-equality checks, memoized selectors, and time-travel debugging.

## Fix

Copy the link bucket before deleting, so the previous state is untouched:

```js
const linkType = action?.link?.split(' ').join('');
const remaining = { ...(state.downloads[linkType] || {}) };
delete remaining[action.pk];
return { ...state, downloads: { ...state.downloads, [linkType]: remaining } };
```

## Test

Added to `reducers/__tests__/gndownload-test.js`: captures the previous link bucket and asserts it is unchanged after dispatch. Fails on `master` (`Expected {} to equal { 1: true }`), passes with the fix. Output value is unchanged. Full suite green.
