### PR TITLE
Guard getResourceStatuses against a null resource

### DIFF
--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -307,7 +307,7 @@ export const getResourceStatuses = (resource, userInfo) => {
         isDeleting,
         isCopying,
         items: [
-            ...(resource.advertised === false ? [{
+            ...(resource?.advertised === false ? [{
                 type: 'icon',
                 tooltipId: 'resourcesCatalog.unadvertised',
                 glyph: 'eye-slash'

--- a/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
@@ -37,10 +37,18 @@ import {
     canManageResourceSettings,
     canAccessPermissions,
     formatResourceLinkUrl,
-    canEditMap
+    canEditMap,
+    getResourceStatuses
 } from '../ResourceUtils';
 
 describe('Test Resource Utils', () => {
+    it('getResourceStatuses does not throw for a null resource', () => {
+        const status = getResourceStatuses(null);
+        expect(status.isProcessing).toBe(false);
+        expect(status.isDeleting).toBe(false);
+        expect(status.isCopying).toBe(false);
+        expect(status.items).toEqual([]);
+    });
     it('should getViewedResourcePermissions', () => {
         const data = [{
             name: "testType",


### PR DESCRIPTION
## Problem

`getResourceStatuses(resource, userInfo)` in `utils/ResourceUtils.js` is written to tolerate a missing resource — it guards three reads:

```js
const { executions = [] } = resource || {};
const isApproved = resource?.is_approved;
const isPublished = isApproved && resource?.is_published;
```

…but then dereferences `resource` without a guard:

```js
...(resource.advertised === false ? [{ ... }] : []),
```

So `getResourceStatuses(null)` (or `undefined`) throws `TypeError: Cannot read properties of null (reading 'advertised')`, defeating the null-handling the rest of the function already implements.

## Fix

```js
...(resource?.advertised === false ? [{ ... }] : []),
```

## Test

Added to `utils/__tests__/ResourceUtils-test.js`: `getResourceStatuses(null)` throws on `master` and returns the expected status object (`isProcessing/isDeleting/isCopying: false`, `items: []`) with the fix. Full suite green.
