### PR TITLE
Fix: Maplayer adds background geonode layer to TOC

### DIFF
--- a/geonode_mapstore_client/client/js/utils/ResourceUtils.js
+++ b/geonode_mapstore_client/client/js/utils/ResourceUtils.js
@@ -426,7 +426,7 @@ export function cleanStyles(styles = [], excluded = []) {
 
 export function getGeoNodeMapLayers(data) {
     return (data?.map?.layers || [])
-        .filter(layer => layer?.extendedParams?.pk)
+        .filter(layer => layer?.extendedParams?.pk && layer?.group !== "background")
         .map((layer, index) => {
             return {
                 ...(layer.extendedParams.mapLayer?.pk && {

--- a/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
+++ b/geonode_mapstore_client/client/js/utils/__tests__/ResourceUtils-test.js
@@ -137,6 +137,16 @@ describe('Test Resource Utils', () => {
                         extendedParams: { pk: 1, mapLayer: { pk: 10 } },
                         opacity: 0.5,
                         visibility: false
+                    },
+                    {
+                        id: '04',
+                        type: 'wms',
+                        name: 'geonode:layer_bg',
+                        url: 'geoserver/wms',
+                        group: "background",
+                        extendedParams: { pk: 1, mapLayer: { pk: 10 } },
+                        opacity: 0.5,
+                        visibility: false
                     }
                 ]
             }


### PR DESCRIPTION
### Description
This PR fixes an issue where adding a layer from the GeoNode catalog service also adds the background layer to the map layers when the background layer originates from GeoNode. This issue does not affect the stable v5.1
