### PR TITLE
#2616: Implement document replacement

### DIFF
--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -697,7 +697,7 @@ export const copyResource = (resource) => {
         title: resource.title,
         ...(resource.data && { data: resource.data })
     };
-    const action = resource.resource_type === "document" ? "document_clone" : "";
+    const action = resource.resource_type === "document" ? "document_copy" : "";
     const cloneData = {'defaults': defaults, ...(action && {action})};
     return axios.put(getEndpointUrl(RESOURCES, `/${resource.pk}/copy`), cloneData)
         .then(({ data }) => data);

--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -697,7 +697,9 @@ export const copyResource = (resource) => {
         title: resource.title,
         ...(resource.data && { data: resource.data })
     };
-    return axios.put(getEndpointUrl(RESOURCES, `/${resource.pk}/copy`), 'defaults=' + JSON.stringify(defaults))
+    const action = resource.resource_type === "document" ? "document_clone" : "";
+    const cloneData = 'defaults=' + JSON.stringify(defaults) + (action ? '&action=' + action : '');
+    return axios.put(getEndpointUrl(RESOURCES, `/${resource.pk}/copy`), cloneData)
         .then(({ data }) => data);
 };
 

--- a/geonode_mapstore_client/client/js/api/geonode/v2/index.js
+++ b/geonode_mapstore_client/client/js/api/geonode/v2/index.js
@@ -698,7 +698,7 @@ export const copyResource = (resource) => {
         ...(resource.data && { data: resource.data })
     };
     const action = resource.resource_type === "document" ? "document_clone" : "";
-    const cloneData = 'defaults=' + JSON.stringify(defaults) + (action ? '&action=' + action : '');
+    const cloneData = {'defaults': defaults, ...(action && {action})};
     return axios.put(getEndpointUrl(RESOURCES, `/${resource.pk}/copy`), cloneData)
         .then(({ data }) => data);
 };

--- a/geonode_mapstore_client/client/js/routes/UploadDocument.jsx
+++ b/geonode_mapstore_client/client/js/routes/UploadDocument.jsx
@@ -121,7 +121,8 @@ function UploadDocument({
 }
 
 UploadDocument.propTypes = {
-    location: PropTypes.object
+    location: PropTypes.object,
+    refreshTime: PropTypes.number
 };
 
 UploadDocument.defaultProps = {

--- a/geonode_mapstore_client/client/js/routes/UploadDocument.jsx
+++ b/geonode_mapstore_client/client/js/routes/UploadDocument.jsx
@@ -13,37 +13,64 @@ import { createSelector } from 'reselect';
 import UploadPanel from '@js/plugins/Operation/components/UploadPanel';
 import ExecutionRequestTable from '@js/plugins/Operation/components/ExecutionRequestTable';
 import useUpload from '@js/plugins/Operation/hooks/useUpload';
+import useExecutionRequest from '@js/plugins/Operation/hooks/useExecutionRequest';
 import {
     getUploadMainFile,
     getUploadProperty,
     getSupportedFilesByResourceType,
     getMaxParallelUploads,
     getMaxAllowedSizeByResourceType,
-    hasExtensionInUrl,
-    getUploadFileName
+    hasExtensionInUrl
 } from '@js/utils/UploadUtils';
+import {
+    getEndpointUrl,
+    UPLOADS,
+    EXECUTION_REQUEST
+} from '@js/api/geonode/v2/constants';
 import { canAddRemoteResource } from '@js/selectors/resource';
 
-function UploadDocument({uploadConfig, enableRemoteUploads = false}) {
-
-    const [requests, setRequests] = useState([]);
+function UploadDocument({
+    refreshTime,
+    uploadConfig,
+    enableRemoteUploads = false
+}) {
 
     const api = {
         upload: {
-            url: '/documents/upload?no__redirect=true',
+            url: getEndpointUrl(UPLOADS, '/upload'),
             body: {
                 file: {
-                    'title': getUploadFileName,
-                    'doc_file': getUploadMainFile
+                    'base_file': getUploadMainFile,
+                    'action': "document_upload"
                 },
                 remote: {
-                    'title': getUploadFileName,
-                    'doc_url': getUploadProperty('url'),
-                    'extension': getUploadProperty('remoteType')
+                    'url': getUploadProperty('url'),
+                    'extension': getUploadProperty('remoteType'),
+                    'action': "document_upload"
                 }
+            }
+        },
+        executionRequest: {
+            url: getEndpointUrl(EXECUTION_REQUEST),
+            params: {
+                'filter{action}': 'document_upload',
+                'sort[]': '-created'
             }
         }
     };
+
+    const [forceRequests, setForceRequests] = useState(0);
+
+    const {
+        requests,
+        uploadsToRequest,
+        deleteRequest
+    } = useExecutionRequest({
+        api: api.executionRequest,
+        forceRequests,
+        refreshTime,
+        onRefresh: () => {}
+    });
 
     const {
         progress,
@@ -54,25 +81,9 @@ function UploadDocument({uploadConfig, enableRemoteUploads = false}) {
         uploadRequest
     } = useUpload({
         api: api.upload,
-        onComplete: (responses, successfulUploads) => {
-            setRequests(prevRequests =>[
-                ...successfulUploads.map(({ data, upload }) => {
-                    return {
-                        exec_id: upload.id,
-                        name: getUploadFileName({ upload }),
-                        created: Date.now(),
-                        status: 'finished',
-                        output_params: {
-                            resources: [
-                                {
-                                    detail_url: data.url
-                                }
-                            ]
-                        }
-                    };
-                }),
-                ...prevRequests
-            ]);
+        onComplete: (_, successfulUploads) => {
+            uploadsToRequest(successfulUploads);
+            setForceRequests(prevForceRequests => prevForceRequests + 1);
         }
     });
 
@@ -102,9 +113,7 @@ function UploadDocument({uploadConfig, enableRemoteUploads = false}) {
                 titleMsgId="gnviewer.uploadDocument"
                 descriptionMsgId="gnviewer.dragAndDropFile"
                 requests={requests}
-                onDelete={(deleteId) => {
-                    setRequests(prevRequests => prevRequests.filter(request => request.exec_id !== deleteId));
-                }}
+                onDelete={deleteRequest}
                 {...uploadConfig}
             />
         </UploadPanel>
@@ -116,7 +125,7 @@ UploadDocument.propTypes = {
 };
 
 UploadDocument.defaultProps = {
-
+    refreshTime: 3000
 };
 
 const ConnectedUploadDocument = connect(

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -2976,7 +2976,7 @@
                     "iconName": "refresh",
                     "titleMsgId": "gnviewer.updateDocumentTitle",
                     "blocking": true,
-                    "action": "replace",
+                    "action": "document_replace",
                     "pageReload": true,
                     "api": {
                         "uploadActions": [

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -2896,6 +2896,10 @@
                                     "type": "link",
                                     "href": "{getMetadataUrl(state('gnResourceData'))}",
                                     "labelId": "gnviewer.editMetadata"
+                                },
+                                {
+                                    "type": "plugin",
+                                    "name": "OperationReplaceDocument"
                                 }
                             ]
                         },
@@ -2956,6 +2960,54 @@
             },
             {
                 "name": "MetadataViewer"
+            },
+            {
+                "name": "Operation",
+                "cfg": {
+                    "id": "replace-document",
+                    "labelId": "gnviewer.updateDocument",
+                    "containerPosition": "header",
+                    "iconName": "refresh",
+                    "titleMsgId": "gnviewer.updateDocumentTitle",
+                    "blocking": true,
+                    "action": "replace",
+                    "pageReload": true,
+                    "api": {
+                        "uploadActions": [
+                            {
+                                "labelId": "gnviewer.replace",
+                                "action": "document_replace",
+                                "variant": "danger",
+                                "showConfirm": true
+                            }
+                        ],
+                        "upload": {
+                            "url": "{getEndpointUrl('uploads', '/upload')}",
+                            "maxParallelUploads": 1,
+                            "body": {
+                                "file": {
+                                    "resource_pk": "{get(state('gnResourceData'), 'pk')}",
+                                    "base_file": "{getUploadMainFile}",
+                                    "action": "document_replace"
+                                }
+                            },
+                            "supportedFiles": "{getSupportedFilesByResourceType('document')}"
+                        },
+                        "executionRequest": {
+                            "url": "{getEndpointUrl('executionrequest')}",
+                            "params": {
+                                "filter{action.in}": ["document_replace"],
+                                "sort[]": "-created",
+                                "filter{geonode_resource}": "{get(state('gnResourceData'), 'pk')}"
+                            }
+                        }
+                    }
+                },
+                "override": {
+                    "ActionNavbar": {
+                        "name": "OperationReplaceDocument"
+                    }
+                }
             }
         ],
         "dashboard_viewer": [

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -2645,6 +2645,12 @@
                         { "value": "EPSG:3857", "label": "EPSG:3857" }
                     ]
                 }
+            },
+            {
+                "name": "ExecutionTracker",
+                "cfg": {
+                    "containerPosition": "header"
+                }
             }
         ],
         "geostory_viewer": [
@@ -3007,6 +3013,12 @@
                     "ActionNavbar": {
                         "name": "OperationReplaceDocument"
                     }
+                }
+            },
+            {
+                "name": "ExecutionTracker",
+                "cfg": {
+                    "containerPosition": "header"
                 }
             }
         ],

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.de-DE.json
@@ -476,6 +476,8 @@
             "replaceDatasetTitle": "Datensatz ersetzen",
             "updateDataset": "Datensatz aktualisieren",
             "updateDatasetTitle": "Datensatz aktualisieren",
+            "updateDocument": "Dokument aktualisieren",
+            "updateDocumentTitle": "Dokument aktualisieren",
             "metadataFor": "Metadaten:",
             "metadataUpdateError": "Die Metadaten konnten nicht aktualisiert werden",
             "metadataNotFound": "Für die ausgewählte Ressource wurden keine Metadaten gefunden",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -477,6 +477,8 @@
             "replaceDatasetTitle": "Replace dataset",
             "updateDataset": "Update Dataset",
             "updateDatasetTitle": "Update dataset",
+            "updateDocument": "Update Document",
+            "updateDocumentTitle": "Update document",
             "metadataFor": "Metadata:",
             "metadataUpdateError": "It was not possible to update the metadata",
             "metadataNotFound": "Metadata not found for the selected resource",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.es-ES.json
@@ -474,6 +474,8 @@
             "replaceDatasetTitle": "Reemplazar conjunto de datos",
             "updateDataset": "Actualizar Conjunto De Datos",
             "updateDatasetTitle": "Actualizar conjunto de datos",
+            "updateDocument": "Actualizar Documento",
+            "updateDocumentTitle": "Actualizar documento",
             "metadataFor": "Metadatos:",
             "metadataUpdateError": "No fue posible actualizar los metadatos",
             "metadataNotFound": "No se encontraron metadatos para el recurso seleccionado",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fi-FI.json
@@ -434,6 +434,8 @@
             "replaceDatasetTitle": "Replace dataset",
             "updateDataset": "Update Dataset",
             "updateDatasetTitle": "Update dataset",
+            "updateDocument": "Update Document",
+            "updateDocumentTitle": "Update document",
             "metadataFor": "Metadata:",
             "metadataUpdateError": "It was not possible to update the metadata",
             "metadataNotFound": "Metadata not found for the selected resource",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.fr-FR.json
@@ -475,6 +475,8 @@
             "replaceDatasetTitle": "Remplacer l'ensemble de données",
             "updateDataset": "Mettre à jour l'ensemble de données",
             "updateDatasetTitle": "Mettre à jour l'ensemble de données",
+            "updateDocument": "Mettre à jour le document",
+            "updateDocumentTitle": "Mettre à jour le document",
             "metadataFor": "Métadonnées:",
             "metadataUpdateError": "Il n'a pas été possible de mettre à jour les métadonnées",
             "metadataNotFound": "Les métadonnées ne sont pas trouvées pour la ressource sélectionnée",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.hr-HR.json
@@ -434,6 +434,8 @@
             "replaceDatasetTitle": "Replace dataset",
             "updateDataset": "Update Dataset",
             "updateDatasetTitle": "Update dataset",
+            "updateDocument": "Update Document",
+            "updateDocumentTitle": "Update document",
             "metadataFor": "Metadata:",
             "metadataUpdateError": "It was not possible to update the metadata",
             "metadataNotFound": "Metadata not found for the selected resource",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.it-IT.json
@@ -477,6 +477,8 @@
             "replaceDatasetTitle": "Sostituisci dataset",
             "updateDataset": "Aggiorna dataset",
             "updateDatasetTitle": "Aggiorna dataset",
+            "updateDocument": "Aggiorna documento",
+            "updateDocumentTitle": "Aggiorna documento",
             "metadataFor": "Metadati:",
             "metadataUpdateError": "Non è stato possibile aggiornare i metadati",
             "metadataNotFound": "Metadati non disponibili per la risorsa selezionata",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.nl-NL.json
@@ -434,6 +434,8 @@
             "replaceDatasetTitle": "Replace dataset",
             "updateDataset": "Update Dataset",
             "updateDatasetTitle": "Update dataset",
+            "updateDocument": "Update Document",
+            "updateDocumentTitle": "Update document",
             "metadataFor": "Metadata:",
             "metadataUpdateError": "It was not possible to update the metadata",
             "metadataNotFound": "Metadata not found for the selected resource",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.pt-PT.json
@@ -434,6 +434,8 @@
             "replaceDatasetTitle": "Replace dataset",
             "updateDataset": "Update Dataset",
             "updateDatasetTitle": "Update dataset",
+            "updateDocument": "Update Document",
+            "updateDocumentTitle": "Update document",
             "metadataFor": "Metadata:",
             "metadataUpdateError": "It was not possible to update the metadata",
             "metadataNotFound": "Metadata not found for the selected resource",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sk-SK.json
@@ -434,6 +434,8 @@
             "replaceDatasetTitle": "Replace dataset",
             "updateDataset": "Update Dataset",
             "updateDatasetTitle": "Update dataset",
+            "updateDocument": "Update Document",
+            "updateDocumentTitle": "Update document",
             "metadataFor": "Metadata:",
             "metadataUpdateError": "It was not possible to update the metadata",
             "metadataNotFound": "Metadata not found for the selected resource",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.sv-SE.json
@@ -435,6 +435,8 @@
             "replaceDatasetTitle": "Replace dataset",
             "updateDataset": "Update Dataset",
             "updateDatasetTitle": "Update dataset",
+            "updateDocument": "Update Document",
+            "updateDocumentTitle": "Update document",
             "metadataFor": "Metadata:",
             "metadataUpdateError": "It was not possible to update the metadata",
             "metadataNotFound": "Metadata not found for the selected resource",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.vi-VN.json
@@ -434,6 +434,8 @@
             "replaceDatasetTitle": "Replace dataset",
             "updateDataset": "Update Dataset",
             "updateDatasetTitle": "Update dataset",
+            "updateDocument": "Update Document",
+            "updateDocumentTitle": "Update document",
             "metadataFor": "Metadata:",
             "metadataUpdateError": "It was not possible to update the metadata",
             "metadataNotFound": "Metadata not found for the selected resource",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.zh-ZH.json
@@ -434,6 +434,8 @@
             "replaceDatasetTitle": "Replace dataset",
             "updateDataset": "Update Dataset",
             "updateDatasetTitle": "Update dataset",
+            "updateDocument": "Update Document",
+            "updateDocumentTitle": "Update document",
             "metadataFor": "Metadata:",
             "metadataUpdateError": "It was not possible to update the metadata",
             "metadataNotFound": "Metadata not found for the selected resource",


### PR DESCRIPTION
### Description
This PR implements document replacement and updates document upload and cloning to use the updated endpoints, along with the corresponding payloads and configurations.

It also fixes missing visual feedback for the map/document cloning operation.

### Issue
- #2616 

> [!WARNING]
Backend dependent. [Branch](https://github.com/GeoNode/geonode/tree/document_upload) for testing 