### PR TITLE
#2628: Fix - Display error instead of indefinite loading in resource viewer

### DIFF
--- a/geonode_mapstore_client/client/js/epics/gnresource.js
+++ b/geonode_mapstore_client/client/js/epics/gnresource.js
@@ -136,7 +136,7 @@ import {
 import { setContext, setResource as setResourceContext } from '@mapstore/framework/actions/context';
 import { REDUCERS_LOADED } from '@mapstore/framework/actions/storemanager';
 import { wrapStartStop } from '@mapstore/framework/observables/epics';
-import { parseDevHostname } from '@js/utils/APIUtils';
+import { getStatusMessage, parseDevHostname } from '@js/utils/APIUtils';
 import { ProcessTypes } from '@js/utils/ResourceServiceUtils';
 import { catalogClose, addLayerAndDescribe } from '@mapstore/framework/actions/catalog';
 import { VisualizationModes } from '@mapstore/framework/utils/MapTypeUtils';
@@ -604,7 +604,7 @@ export const gnViewerRequestNewResourceConfig = (action$, store) =>
                 .catch((error) => {
                     return Observable.of(
                         ...getResetActions(),
-                        resourceConfigError(error?.data?.detail || error?.statusText || error?.message)
+                        resourceConfigError(error?.data?.detail || getStatusMessage(error) || error?.message)
                     );
                 });
         });
@@ -660,7 +660,7 @@ export const gnViewerRequestResourceConfig = (action$, store) =>
                 .catch((error) => {
                     return Observable.of(
                         ...getResetActions(),
-                        resourceConfigError(error?.data?.detail || error?.statusText || error?.message)
+                        resourceConfigError(error?.data?.detail || getStatusMessage(error) || error?.message)
                     );
                 });
         });

--- a/geonode_mapstore_client/client/js/utils/APIUtils.js
+++ b/geonode_mapstore_client/client/js/utils/APIUtils.js
@@ -132,6 +132,22 @@ export const paramsSerializer = () => {
     };
 };
 
+/**
+ * A simple fallback for status text, which may be empty in HTTP/2 responses.
+ * This is used to avoid infinite loading (spinner) on resource viewer.
+ * @param {object} error error object
+ * @returns {string} status message
+ */
+export const getStatusMessage = (error) => {
+    const statusMessages = {
+        401: 'Unauthorized',
+        403: 'Forbidden',
+        404: 'Not Found',
+        500: 'Internal Server Error'
+    };
+    return error?.statusText || statusMessages[error?.status] || 'Unknown Error';
+};
+
 export const getResourcesSearchIndex = () => {
     return getGeoNodeLocalConfig('geoNodeSettings.resourcesSearchIndex');
 };


### PR DESCRIPTION
### Description
This PR adds fallback error text when resource fetching fails and no error message is available in the response. Since HTTP/2 responses may have an empty `statusText`, the resource viewer could otherwise remain in an indefinite loading state instead of displaying an error.

### Issue
- #2628 