### PR TITLE
Fix #2632 Settings plugin hidden in the list of available plugins

### DIFF
--- a/geonode_mapstore_client/client/js/components/Router/Router.jsx
+++ b/geonode_mapstore_client/client/js/components/Router/Router.jsx
@@ -82,38 +82,38 @@ const Router = forwardRef(({
                     >
                         <ConnectedRouter history={history}>
                             <>
-                            <MonitoringDialog />
-                            <ErrorBoundary
-                                FallbackComponent={ErrorFallback}
-                                onError={e => {
-                                    console.error(e); // eslint-disable-line no-console
-                                }}>
-                                {routes.map((route, i) => {
-                                    const routeConfig = route.pageConfig || {};
-                                    const Component = route.component;
-                                    if (route.protectedRoute && !user && urlHash === route.hash) {
-                                        window.location.href = `${LOGIN_URL}?next=${encodeURIComponent(window.location.pathname + urlHash)}`;
-                                        return null;
-                                    }
-                                    return (
-                                        <Route
-                                            key={(route.name || route.path) + i}
-                                            exact
-                                            path={route.path}
-                                            component={(props) =>
-                                                <Component
-                                                    {...props}
-                                                    name={route.name}
-                                                    plugins={plugins}
-                                                    pluginsConfig={pluginsConfig}
-                                                    loaderComponent={loaderComponent}
-                                                    geoNodeConfiguration={geoNodeConfiguration}
-                                                    {...routeConfig}
-                                                />}
-                                        />
-                                    );
-                                })}
-                            </ErrorBoundary>
+                                <MonitoringDialog />
+                                <ErrorBoundary
+                                    FallbackComponent={ErrorFallback}
+                                    onError={e => {
+                                        console.error(e); // eslint-disable-line no-console
+                                    }}>
+                                    {routes.map((route, i) => {
+                                        const routeConfig = route.pageConfig || {};
+                                        const Component = route.component;
+                                        if (route.protectedRoute && !user && urlHash === route.hash) {
+                                            window.location.href = `${LOGIN_URL}?next=${encodeURIComponent(window.location.pathname + urlHash)}`;
+                                            return null;
+                                        }
+                                        return (
+                                            <Route
+                                                key={(route.name || route.path) + i}
+                                                exact
+                                                path={route.path}
+                                                component={(props) =>
+                                                    <Component
+                                                        {...props}
+                                                        name={route.name}
+                                                        plugins={plugins}
+                                                        pluginsConfig={pluginsConfig}
+                                                        loaderComponent={loaderComponent}
+                                                        geoNodeConfiguration={geoNodeConfiguration}
+                                                        {...routeConfig}
+                                                    />}
+                                            />
+                                        );
+                                    })}
+                                </ErrorBoundary>
                             </>
                         </ConnectedRouter>
                     </Localized>

--- a/geonode_mapstore_client/client/js/plugins/CreateDataset/components/CreateDatasetAttributeRow.jsx
+++ b/geonode_mapstore_client/client/js/plugins/CreateDataset/components/CreateDatasetAttributeRow.jsx
@@ -93,103 +93,103 @@ const CreateDatasetAttributeRow = ({
 
     return (
         <>
-        <tr className="gn-dataset-attribute">
-            <td className="gn-attribute-name">
-                <FormGroup
-                    controlId={getAttributeControlId(data, 'name')}
-                    validationState={errors?.name ? 'error' : undefined}
-                >
-                    <FormControl
-                        type="text"
-                        value={data?.name || ''}
-                        disabled={!!geometryAttribute || disabled}
-                        onChange={(event) => handleOnChange({ name: event.target.value })}
-                    />
-                    {errors?.name ? <HelpBlock><Message msgId={errors.name} /></HelpBlock> : null}
-                </FormGroup>
-            </td>
-            <td className="gn-attribute-type">
-                <FormGroup controlId={getAttributeControlId(data, 'type')}>
-                    <FormControl
-                        value={data?.type || ''}
-                        componentClass="select"
-                        placeholder="select"
-                        onChange={handleTypeChange}
-                        disabled={disabled}
-                    >
-                        {typesOptions.map(({ labelId, value }) =>
-                            <option key={value} value={value}>
-                                {getMessageById(context.messages, labelId)}
-                            </option>
-                        )}
-                    </FormControl>
-                </FormGroup>
-            </td>
-            <td className="gn-attribute-nillable">
-                <FormGroup controlId={getAttributeControlId(data, 'nillable')}>
-                    <Checkbox
-                        style={{ paddingTop: 6 }}
-                        checked={!!data?.nillable}
-                        disabled={!!geometryAttribute || disabled}
-                        onChange={(event) =>
-                            handleOnChange({ nillable: event.target.checked })
-                        }
-                    />
-                </FormGroup>
-            </td>
-            <td>
-                <FlexBox column gap="sm">
+            <tr className="gn-dataset-attribute">
+                <td className="gn-attribute-name">
                     <FormGroup
-                        controlId={getAttributeControlId(data, 'restrictions')}
-                        validationState={errors?.restrictionsType ? 'error' : undefined}>
+                        controlId={getAttributeControlId(data, 'name')}
+                        validationState={errors?.name ? 'error' : undefined}
+                    >
                         <FormControl
-                            value={data?.restrictionsType}
+                            type="text"
+                            value={data?.name || ''}
+                            disabled={!!geometryAttribute || disabled}
+                            onChange={(event) => handleOnChange({ name: event.target.value })}
+                        />
+                        {errors?.name ? <HelpBlock><Message msgId={errors.name} /></HelpBlock> : null}
+                    </FormGroup>
+                </td>
+                <td className="gn-attribute-type">
+                    <FormGroup controlId={getAttributeControlId(data, 'type')}>
+                        <FormControl
+                            value={data?.type || ''}
                             componentClass="select"
                             placeholder="select"
-                            disabled={!!geometryAttribute || disabled}
-                            onChange={(event) =>
-                                handleOnChange({ restrictionsType: event.target.value })
-                            }
+                            onChange={handleTypeChange}
+                            disabled={disabled}
                         >
-                            {restrictionsOptions.map(({ labelId, value }) =>
+                            {typesOptions.map(({ labelId, value }) =>
                                 <option key={value} value={value}>
                                     {getMessageById(context.messages, labelId)}
                                 </option>
                             )}
                         </FormControl>
-                        {errors?.restrictionsType ? <HelpBlock>{errors.restrictionsType}</HelpBlock> : null}
                     </FormGroup>
-                    {data?.restrictionsType === RestrictionsTypes.Range ?
-                        <RangeRestriction
-                            errors={errors}
-                            data={data}
-                            handleOnChange={handleOnChange}
-                            disabled={disabled}
-                        /> : null}
-                    {data?.restrictionsType === RestrictionsTypes.Options
-                        ? <EnumRestriction
-                            index={index}
-                            data={data}
-                            handleOnChange={handleOnChange}
-                            getErrorByPath={getErrorByPath}
-                            disabled={disabled}
-                        /> : null}
-                </FlexBox>
-            </td>
-            <td className="gn-attribute-tools">
-                {tools}
-            </td>
-        </tr>
-        {showGeomWarning ? (
-            <tr>
-                <td
-                    className="gn-attribute-geom-warning"
-                    colSpan={5}
-                >
-                   <Message msgId="gnviewer.geometryDatasetWarning" />
+                </td>
+                <td className="gn-attribute-nillable">
+                    <FormGroup controlId={getAttributeControlId(data, 'nillable')}>
+                        <Checkbox
+                            style={{ paddingTop: 6 }}
+                            checked={!!data?.nillable}
+                            disabled={!!geometryAttribute || disabled}
+                            onChange={(event) =>
+                                handleOnChange({ nillable: event.target.checked })
+                            }
+                        />
+                    </FormGroup>
+                </td>
+                <td>
+                    <FlexBox column gap="sm">
+                        <FormGroup
+                            controlId={getAttributeControlId(data, 'restrictions')}
+                            validationState={errors?.restrictionsType ? 'error' : undefined}>
+                            <FormControl
+                                value={data?.restrictionsType}
+                                componentClass="select"
+                                placeholder="select"
+                                disabled={!!geometryAttribute || disabled}
+                                onChange={(event) =>
+                                    handleOnChange({ restrictionsType: event.target.value })
+                                }
+                            >
+                                {restrictionsOptions.map(({ labelId, value }) =>
+                                    <option key={value} value={value}>
+                                        {getMessageById(context.messages, labelId)}
+                                    </option>
+                                )}
+                            </FormControl>
+                            {errors?.restrictionsType ? <HelpBlock>{errors.restrictionsType}</HelpBlock> : null}
+                        </FormGroup>
+                        {data?.restrictionsType === RestrictionsTypes.Range ?
+                            <RangeRestriction
+                                errors={errors}
+                                data={data}
+                                handleOnChange={handleOnChange}
+                                disabled={disabled}
+                            /> : null}
+                        {data?.restrictionsType === RestrictionsTypes.Options
+                            ? <EnumRestriction
+                                index={index}
+                                data={data}
+                                handleOnChange={handleOnChange}
+                                getErrorByPath={getErrorByPath}
+                                disabled={disabled}
+                            /> : null}
+                    </FlexBox>
+                </td>
+                <td className="gn-attribute-tools">
+                    {tools}
                 </td>
             </tr>
-        ) : null}
+            {showGeomWarning ? (
+                <tr>
+                    <td
+                        className="gn-attribute-geom-warning"
+                        colSpan={5}
+                    >
+                        <Message msgId="gnviewer.geometryDatasetWarning" />
+                    </td>
+                </tr>
+            ) : null}
         </>
     );
 };

--- a/geonode_mapstore_client/client/js/plugins/ResourceDetails/ResourceDetails.jsx
+++ b/geonode_mapstore_client/client/js/plugins/ResourceDetails/ResourceDetails.jsx
@@ -462,9 +462,9 @@ export default createPlugin('ResourceDetails', {
                 () => ({}),
                 { onClick: toggleEditMode }
             )(({ onClick, size }) => {
-                return <Button size={size} onClick={onClick}>
+                return (<Button size={size} onClick={onClick}>
                     <Message msgId="gnviewer.editData" />
-                </Button>;
+                </Button>);
             }),
             priority: 1,
             doNotHide: true

--- a/geonode_mapstore_client/client/js/utils/UploadUtils.js
+++ b/geonode_mapstore_client/client/js/utils/UploadUtils.js
@@ -124,12 +124,12 @@ export const validateFileResourceUploads = (uploads = [], { supportedFiles = [] 
             };
         }
         const allUploadsAreOptional = upload.ext.every(ext =>
-                (currentSupportedType.optional_ext || []).includes(ext) &&
+            (currentSupportedType.optional_ext || []).includes(ext) &&
                 !currentSupportedType.required_ext.includes(ext)
-            );
+        );
         const missingExtensions = allUploadsAreOptional
-                ? []
-                : currentSupportedType.required_ext.filter(ext => !upload.ext.includes(ext));
+            ? []
+            : currentSupportedType.required_ext.filter(ext => !upload.ext.includes(ext));
         const supportedTypeExtensions = getSupportedTypeExt(currentSupportedType);
         return {
             ...upload,

--- a/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json
@@ -167,10 +167,7 @@
         "viewerOptions": {
           "container": "{ReactSwipe}"
         }
-      },
-      "children": [
-        "Settings"
-      ]
+      }
     },
     {
       "name": "Locate",
@@ -611,6 +608,7 @@
     {
       "name": "Settings",
       "glyph": "cog",
+      "mandatory": true,
       "title": "plugins.Settings.title",
       "description": "plugins.Settings.description",
       "dependencies": [


### PR DESCRIPTION
Fix issue #2632  allows you to always have the Settings plugin available which is now required for the Coalesce WMS settings and the basic Cesium 3D options
<img width="570" height="412" alt="image" src="https://github.com/user-attachments/assets/6b889569-69a6-4f8e-86c1-4643861faa89" />


Two changes in default `geonode_mapstore_client/static/mapstore/configs/pluginsConfig.json`:
1. "Settings" has been removed as a child in the Identify plugin. This was the cause of it not appearing in the root plugin list.
2. The Settings plugin is now "mandatory": true for both new and existing map viewers.

NOTE: other changes is indentation of automatic eslint but needed for lint the master